### PR TITLE
feat(control): add remote router administration

### DIFF
--- a/apps/bitrouter/src/actions/administration.rs
+++ b/apps/bitrouter/src/actions/administration.rs
@@ -1,0 +1,414 @@
+//! Typed, content-limited host inspection shared by the CLI and control API.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use bitrouter_sdk::config::{Config, ConfigRoutingTable, PolicyModelTarget};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::daemon::ObserveStatusProvider;
+use crate::paths::ConfigSource;
+use crate::policy_lock::{LoadedPolicyLock, PolicyRuntime};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyView {
+    #[default]
+    Active,
+    Disk,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyInput {
+    #[serde(default)]
+    pub view: PolicyView,
+    pub name: Option<String>,
+}
+
+impl PolicyInput {
+    pub fn validate(&self) -> Result<()> {
+        if let Some(name) = &self.name {
+            validate_identifier(name)?;
+        }
+        Ok(())
+    }
+}
+
+pub fn validate_identifier(value: &str) -> Result<()> {
+    anyhow::ensure!(
+        !value.is_empty() && value.len() <= 256 && !value.chars().any(char::is_control),
+        "identifier must contain 1–256 bytes and no control characters"
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ProviderEntry {
+    pub id: String,
+    pub models: usize,
+    pub active: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ProvidersReport {
+    pub resolved_via: String,
+    pub providers: Vec<ProviderEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AgentEntry {
+    pub id: String,
+    pub configured: bool,
+    pub in_catalog: bool,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AgentsReport {
+    pub resolved_via: String,
+    pub readiness_checked: bool,
+    pub agents: Vec<AgentEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ObserveReport {
+    pub daemon_reachable: bool,
+    pub compiled_in: bool,
+    pub exporter_wired: bool,
+    pub sampler: Option<String>,
+    pub sampler_arg: Option<f64>,
+    pub metrics_enabled: bool,
+    pub header_count: usize,
+    pub resource_attribute_count: usize,
+    pub api_key_count: usize,
+    pub api_key_cap: usize,
+    pub user_id_count: usize,
+    pub user_id_cap: usize,
+    pub active_spans: usize,
+}
+
+impl ObserveReport {
+    pub fn from_snapshot(snapshot: crate::daemon::ObserveStatusPayload, reachable: bool) -> Self {
+        Self {
+            daemon_reachable: reachable,
+            compiled_in: snapshot.compiled_in,
+            exporter_wired: snapshot.exporter_wired,
+            sampler: snapshot.sampler,
+            sampler_arg: snapshot.sampler_arg,
+            metrics_enabled: snapshot.metrics_enabled,
+            header_count: snapshot.header_count,
+            resource_attribute_count: snapshot.resource_attribute_count,
+            api_key_count: snapshot.api_key_count,
+            api_key_cap: snapshot.api_key_cap,
+            user_id_count: snapshot.user_id_count,
+            user_id_cap: snapshot.user_id_cap,
+            active_spans: snapshot.active_spans,
+        }
+    }
+}
+
+/// Explicitly selected policy fields; never serialize the source document.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PolicyDetail {
+    pub tiers: BTreeMap<String, PolicyModelTarget>,
+    pub routes: BTreeMap<String, String>,
+    pub default_tier: Option<String>,
+    pub tool_use_tier: Option<String>,
+    pub tool_safe_tiers: Vec<String>,
+    pub certificates: BTreeMap<String, CertificateIdentity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct CertificateIdentity {
+    pub selected_tier: String,
+    pub evidence_digest: String,
+    pub compiler_config_digest: String,
+    pub evaluator_config_digest: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PolicyReport {
+    pub view: PolicyView,
+    pub availability: String,
+    pub digest: Option<String>,
+    pub mode: String,
+    pub policies: Vec<String>,
+    pub bindings: BTreeMap<String, String>,
+    pub evidence_root: Option<String>,
+    pub eval_snapshot_root: Option<String>,
+    pub definitions: BTreeMap<String, PolicyDetail>,
+}
+
+impl PolicyReport {
+    pub fn from_loaded(
+        config: &Config,
+        loaded: Option<&LoadedPolicyLock>,
+        view: PolicyView,
+    ) -> Self {
+        let definitions = loaded
+            .map(|loaded| {
+                loaded
+                    .document
+                    .policies
+                    .iter()
+                    .map(|(name, definition)| {
+                        let certificates = loaded
+                            .document
+                            .certificates
+                            .get(name)
+                            .into_iter()
+                            .flat_map(|entries| entries.iter())
+                            .map(|(key, certificate)| {
+                                (
+                                    key.clone(),
+                                    CertificateIdentity {
+                                        selected_tier: certificate.selected_tier.clone(),
+                                        evidence_digest: certificate.evidence_digest.clone(),
+                                        compiler_config_digest: certificate
+                                            .compiler_config_digest
+                                            .clone(),
+                                        evaluator_config_digest: certificate
+                                            .evaluator_config_digest
+                                            .clone(),
+                                    },
+                                )
+                            })
+                            .collect();
+                        (
+                            name.clone(),
+                            PolicyDetail {
+                                tiers: definition.tiers.clone(),
+                                routes: definition.routes.clone(),
+                                default_tier: definition.default_tier.clone(),
+                                tool_use_tier: definition.tool_use_tier.clone(),
+                                tool_safe_tiers: definition.tool_safe_tiers.clone(),
+                                certificates,
+                            },
+                        )
+                    })
+                    .collect::<BTreeMap<_, _>>()
+            })
+            .unwrap_or_default();
+        let artifact = loaded.and_then(|loaded| loaded.document.artifact.as_ref());
+        Self {
+            view,
+            availability: if loaded.is_some() {
+                "available"
+            } else {
+                "not_configured"
+            }
+            .into(),
+            digest: loaded.map(|loaded| loaded.digest.clone()),
+            mode: match config.policy.mode {
+                bitrouter_sdk::config::PolicyRuntimeMode::Frozen => "frozen",
+                bitrouter_sdk::config::PolicyRuntimeMode::Adaptive => "adaptive",
+            }
+            .into(),
+            policies: definitions.keys().cloned().collect(),
+            bindings: config
+                .presets
+                .iter()
+                .filter_map(|(name, preset)| {
+                    preset
+                        .policy
+                        .as_ref()
+                        .map(|policy| (name.clone(), policy.clone()))
+                })
+                .collect(),
+            evidence_root: artifact.map(|artifact| artifact.evidence_root.clone()),
+            eval_snapshot_root: artifact.and_then(|artifact| artifact.eval_snapshot_root.clone()),
+            definitions,
+        }
+    }
+
+    pub fn selected(mut self, name: Option<&str>) -> Result<Self> {
+        match name {
+            Some(name) => {
+                validate_identifier(name)?;
+                anyhow::ensure!(self.definitions.contains_key(name), "policy_not_found");
+                self.definitions.retain(|key, _| key == name);
+            }
+            None => self.definitions.clear(),
+        }
+        Ok(self)
+    }
+}
+
+/// Live host ports; construction does not consult a remote client's files.
+#[derive(Clone)]
+pub struct Administration {
+    pub source: ConfigSource,
+    pub routing: Arc<ConfigRoutingTable>,
+    pub policy: Arc<PolicyRuntime>,
+    pub observe: Arc<dyn ObserveStatusProvider>,
+}
+
+impl Administration {
+    pub fn providers(&self) -> ProvidersReport {
+        providers(&self.routing.snapshot_config(), "live")
+    }
+
+    pub fn agents(&self) -> AgentsReport {
+        agents(&self.routing.snapshot_config(), "live")
+    }
+
+    pub fn observe(&self) -> ObserveReport {
+        ObserveReport::from_snapshot(self.observe.status(), true)
+    }
+
+    pub async fn policy(&self, input: PolicyInput) -> Result<PolicyReport> {
+        input.validate()?;
+        let report = match input.view {
+            PolicyView::Active => self.policy.administration_snapshot(),
+            PolicyView::Disk => disk_policy(&self.source).await?,
+        };
+        report.selected(input.name.as_deref())
+    }
+}
+
+pub async fn disk_policy(source: &ConfigSource) -> Result<PolicyReport> {
+    let config = crate::paths::load_config(source)
+        .await
+        .map_err(|_| anyhow::anyhow!("invalid_configuration"))?;
+    let path = match source {
+        ConfigSource::File(path) => Some(path.as_path()),
+        _ => None,
+    };
+    let loaded = crate::policy_lock::load_for_config(&config, path)
+        .await
+        .map_err(|_| anyhow::anyhow!("invalid_policy"))?;
+    Ok(PolicyReport::from_loaded(
+        &config,
+        loaded.as_ref(),
+        PolicyView::Disk,
+    ))
+}
+
+pub fn providers(config: &Config, source: &str) -> ProvidersReport {
+    ProvidersReport {
+        resolved_via: source.into(),
+        providers: crate::commands::list_providers(config)
+            .into_iter()
+            .map(|row| ProviderEntry {
+                id: row.id,
+                models: row.model_count,
+                active: row.active,
+            })
+            .collect(),
+    }
+}
+
+pub fn agents(config: &Config, source: &str) -> AgentsReport {
+    AgentsReport {
+        resolved_via: source.into(),
+        readiness_checked: false,
+        agents: crate::agents::list(config)
+            .into_iter()
+            .map(|row| AgentEntry {
+                id: row.id,
+                configured: row.configured,
+                in_catalog: row.in_catalog,
+                description: if row.in_catalog {
+                    row.description
+                } else {
+                    "Custom configured agent".into()
+                },
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_agent_commands_are_never_reported() -> Result<()> {
+        let config = bitrouter_sdk::config::parse(
+            "agents:\n  custom:\n    name: custom\n    transport:\n      type: stdio\n      command: secret-command\n      args: [secret-token]\n",
+        )?;
+        let report = serde_json::to_string(&agents(&config, "live"))?;
+        assert!(!report.contains("secret-command"));
+        assert!(!report.contains("secret-token"));
+        assert!(report.contains("Custom configured agent"));
+        Ok(())
+    }
+
+    #[test]
+    fn telemetry_omits_endpoint_and_service_strings() -> Result<()> {
+        let mut snapshot = crate::daemon::ObserveStatusPayload::unwired(true);
+        snapshot.endpoint = Some("https://secret:token@example.test/path?key=private".into());
+        snapshot.service_name = Some("secret-service".into());
+        let report = serde_json::to_string(&ObserveReport::from_snapshot(snapshot, true))?;
+        assert!(!report.contains("secret"));
+        assert!(!report.contains("endpoint"));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod snapshot_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn active_mode_and_bindings_change_only_with_the_policy_snapshot() -> anyhow::Result<()> {
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("bitrouter.yaml");
+        let lock = directory.path().join("policy-lock.yaml");
+        let initial_yaml = "inherit_defaults: false\npolicy:\n  mode: frozen\npresets:\n  coding:\n    model: fixture:old\n    policy: coding\n";
+        let candidate_yaml = "inherit_defaults: false\npolicy:\n  mode: adaptive\npresets:\n  chat:\n    model: fixture:new\n    policy: coding\n";
+        let policy_yaml = |model: &str| {
+            format!(
+                "lockfileVersion: 1\npolicies:\n  coding:\n    key_strategy: agent_trace\n    tiers: {{ strong: fixture:{model} }}\n    routes: {{}}\n    default_tier: strong\n    tool_use_tier: strong\n    tool_safe_tiers: [strong]\n"
+            )
+        };
+        std::fs::write(&path, initial_yaml)?;
+        std::fs::write(&lock, policy_yaml("old"))?;
+        let initial = bitrouter_sdk::config::load(&path).await?;
+        let db = crate::db::connect("sqlite::memory:").await?;
+        crate::db::run_migrations(&db).await?;
+        let runtime = PolicyRuntime::new(
+            &initial,
+            Some(&path),
+            db,
+            None,
+            crate::eval::settlement::PendingEvalDecisionStore::default(),
+            None,
+        )
+        .await?;
+        let active_before = runtime.administration_snapshot();
+        assert_eq!(active_before.mode, "frozen");
+        assert_eq!(
+            active_before.bindings.get("coding").map(String::as_str),
+            Some("coding")
+        );
+
+        std::fs::write(&path, candidate_yaml)?;
+        std::fs::write(&lock, policy_yaml("new"))?;
+        let disk = disk_policy(&ConfigSource::File(path.clone())).await?;
+        assert_eq!(disk.mode, "adaptive");
+        assert!(disk.bindings.contains_key("chat"));
+        assert_ne!(disk.digest, active_before.digest);
+        let still_active = runtime.administration_snapshot();
+        assert_eq!(still_active.mode, active_before.mode);
+        assert_eq!(still_active.bindings, active_before.bindings);
+        assert_eq!(still_active.digest, active_before.digest);
+
+        let candidate = bitrouter_sdk::config::load(&path).await?;
+        let prepared = runtime.prepare_for_config(&candidate, Some(&path)).await?;
+        assert_eq!(
+            runtime.administration_snapshot().digest,
+            active_before.digest
+        );
+        runtime.commit(prepared);
+        let active_after = runtime.administration_snapshot();
+        assert_eq!(active_after.view, PolicyView::Active);
+        assert_eq!(active_after.mode, disk.mode);
+        assert_eq!(active_after.bindings, disk.bindings);
+        assert_eq!(active_after.digest, disk.digest);
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/actions/mod.rs
+++ b/apps/bitrouter/src/actions/mod.rs
@@ -8,6 +8,7 @@
 //! Only actions with more than one surface belong here; every other CLI command
 //! keeps its own report under [`crate::output::reports`].
 
+pub mod administration;
 pub mod commands;
 pub mod models;
 pub mod requests;

--- a/apps/bitrouter/src/actions/requests.rs
+++ b/apps/bitrouter/src/actions/requests.rs
@@ -4,16 +4,160 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::daemon::{self, DaemonCommand, DaemonResponse};
 use crate::metering::store::TimeWindow;
-use crate::output::reports::requests::{DaemonView, RequestsReport};
+use crate::output::reports::requests::{
+    DaemonView, MeteringAvailability, MeteringComponentAvailability, RequestFilterView,
+    RequestReportData, RequestsReport,
+};
 use crate::paths::ConfigSource;
 
 /// Maximum number of rows any interactive/read API returns.
 pub const MAX_REQUEST_ROWS: u64 = 500;
 
+/// Maximum duration of a caller-supplied request interval.
+pub const MAX_REQUEST_WINDOW_DAYS: i64 = 7;
+
 const DAEMON_PROBE_TIMEOUT: Duration = Duration::from_millis(750);
+
+/// Input accepted by local and remote request-inspection surfaces.
+///
+/// Leaving both time fields unset selects today from the server's UTC clock.
+/// Supplying either one requires the other, so the database always receives an
+/// explicit half-open interval rather than a client-local relative time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RequestFilters {
+    /// Maximum rows to return. The action validates `1..=500`.
+    #[serde(default = "default_request_limit")]
+    pub limit: u64,
+    /// Inclusive RFC3339 time bound, paired with `until`.
+    pub since: Option<String>,
+    /// Exclusive RFC3339 time bound, paired with `since`.
+    pub until: Option<String>,
+    /// Resolved model identifier to inspect.
+    pub model: Option<String>,
+    /// Serving provider identifier to inspect.
+    pub provider: Option<String>,
+}
+
+impl Default for RequestFilters {
+    fn default() -> Self {
+        Self {
+            limit: default_request_limit(),
+            since: None,
+            until: None,
+            model: None,
+            provider: None,
+        }
+    }
+}
+
+impl RequestFilters {
+    /// Start from the default server-relative filter with an explicit page size.
+    pub fn with_limit(limit: u64) -> Self {
+        Self {
+            limit,
+            ..Self::default()
+        }
+    }
+
+    fn resolve(&self) -> Result<ResolvedRequestFilters> {
+        self.resolve_at(Utc::now())
+    }
+
+    fn resolve_at(&self, now: DateTime<Utc>) -> Result<ResolvedRequestFilters> {
+        if !(1..=MAX_REQUEST_ROWS).contains(&self.limit) {
+            anyhow::bail!("request limit must be between 1 and {MAX_REQUEST_ROWS}");
+        }
+        validate_optional_filter(self.model.as_deref(), "model")?;
+        validate_optional_filter(self.provider.as_deref(), "provider")?;
+
+        let (since, until, window) = match (&self.since, &self.until) {
+            (None, None) => (utc_midnight(now), now, "today"),
+            (Some(since), Some(until)) => {
+                let since = parse_timestamp(since, "since")?;
+                let until = parse_timestamp(until, "until")?;
+                if since >= until {
+                    anyhow::bail!("request since must precede until");
+                }
+                if until.signed_duration_since(since)
+                    > chrono::Duration::days(MAX_REQUEST_WINDOW_DAYS)
+                {
+                    anyhow::bail!("request time range must not exceed seven days");
+                }
+                (since, until, "custom")
+            }
+            _ => anyhow::bail!("request since and until must be supplied together"),
+        };
+
+        Ok(ResolvedRequestFilters {
+            window: TimeWindow::Custom {
+                start: since,
+                end: until,
+            },
+            window_label: window,
+            since,
+            until,
+            model: self.model.clone(),
+            provider: self.provider.clone(),
+            limit: self.limit,
+        })
+    }
+}
+
+fn default_request_limit() -> u64 {
+    MAX_REQUEST_ROWS
+}
+
+fn utc_midnight(now: DateTime<Utc>) -> DateTime<Utc> {
+    now.date_naive().and_time(chrono::NaiveTime::MIN).and_utc()
+}
+
+fn parse_timestamp(value: &str, field: &str) -> Result<DateTime<Utc>> {
+    if value.len() > 256 {
+        anyhow::bail!("request {field} must be an RFC3339 timestamp");
+    }
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(|_| anyhow::anyhow!("request {field} must be an RFC3339 timestamp"))
+}
+
+fn validate_optional_filter(value: Option<&str>, field: &str) -> Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if value.trim().is_empty() || value.len() > 256 || value.chars().any(char::is_control) {
+        anyhow::bail!("request {field} filter must contain 1–256 bytes and no control characters");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedRequestFilters {
+    window: TimeWindow,
+    window_label: &'static str,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
+    model: Option<String>,
+    provider: Option<String>,
+    limit: u64,
+}
+
+impl ResolvedRequestFilters {
+    fn report_filters(&self) -> RequestFilterView {
+        RequestFilterView::new(
+            self.since.to_rfc3339(),
+            self.until.to_rfc3339(),
+            self.model.clone(),
+            self.provider.clone(),
+        )
+    }
+}
 
 pub struct RequestsAction {
     source: ConfigSource,
@@ -28,47 +172,99 @@ impl RequestsAction {
     /// Build one host-wide request snapshot.
     ///
     /// Metering reads remain best-effort as on the original local CLI: an
-    /// unavailable store produces an empty report rather than hiding daemon
-    /// health. Transport/auth/version failures are handled outside this action
-    /// and remain hard errors for remote clients.
+    /// unavailable store retains daemon state and labels every metering
+    /// component unavailable rather than presenting placeholders as observed
+    /// zero usage. Transport/auth/version failures are handled outside this
+    /// action and remain hard errors for remote clients.
     pub async fn report(&self, limit: u64) -> Result<RequestsReport> {
-        if !(1..=MAX_REQUEST_ROWS).contains(&limit) {
-            anyhow::bail!("request limit must be between 1 and {MAX_REQUEST_ROWS}");
-        }
+        self.report_filtered(RequestFilters::with_limit(limit))
+            .await
+    }
 
-        let window = TimeWindow::Today;
+    /// Build one host-wide filtered request snapshot.
+    pub async fn report_filtered(&self, filters: RequestFilters) -> Result<RequestsReport> {
+        let filters = filters.resolve()?;
         let daemon = daemon_view(&self.socket).await;
         let Some(store) = crate::metering::reader::open_readonly(&self.source).await else {
-            return Ok(RequestsReport::new(
+            return Ok(RequestsReport::new_filtered(
                 daemon,
-                window,
-                Default::default(),
-                Default::default(),
-                Vec::new(),
+                RequestReportData {
+                    window: filters.window_label.to_string(),
+                    filters: filters.report_filters(),
+                    summary: Default::default(),
+                    rate: Default::default(),
+                    rows: Vec::new(),
+                    metering: MeteringAvailability::unavailable(),
+                    truncated: false,
+                },
             ));
         };
-        let summary = match store.spend_summary(window).await {
-            Ok(summary) => summary,
+        let (summary, summary_availability) = match store
+            .spend_summary_filtered(
+                filters.window,
+                filters.model.as_deref(),
+                filters.provider.as_deref(),
+            )
+            .await
+        {
+            Ok(summary) => (summary, MeteringComponentAvailability::Available),
             Err(error) => {
                 tracing::debug!(%error, "request-summary read failed");
-                Default::default()
+                (
+                    Default::default(),
+                    MeteringComponentAvailability::Unavailable,
+                )
             }
         };
-        let rate = match store.get_total_rate().await {
-            Ok(rate) => rate,
+        let (rate, rate_availability) = match store.get_total_rate().await {
+            Ok(rate) => (rate, MeteringComponentAvailability::Available),
             Err(error) => {
                 tracing::debug!(%error, "request-rate read failed");
-                Default::default()
+                (
+                    Default::default(),
+                    MeteringComponentAvailability::Unavailable,
+                )
             }
         };
-        let rows = match store.recent_requests(window, limit, None).await {
-            Ok(rows) => rows,
+        let (rows, truncated, rows_availability) = match store
+            .recent_requests_filtered(
+                filters.window,
+                filters.model.as_deref(),
+                filters.provider.as_deref(),
+                filters.limit,
+            )
+            .await
+        {
+            Ok(page) => (
+                page.rows,
+                page.truncated,
+                MeteringComponentAvailability::Available,
+            ),
             Err(error) => {
                 tracing::debug!(%error, "recent-request read failed");
-                Vec::new()
+                (
+                    Vec::new(),
+                    false,
+                    MeteringComponentAvailability::Unavailable,
+                )
             }
         };
-        Ok(RequestsReport::new(daemon, window, summary, rate, rows))
+        Ok(RequestsReport::new_filtered(
+            daemon,
+            RequestReportData {
+                window: filters.window_label.to_string(),
+                filters: filters.report_filters(),
+                summary,
+                rate,
+                rows,
+                metering: MeteringAvailability {
+                    summary: summary_availability,
+                    rate: rate_availability,
+                    rows: rows_availability,
+                },
+                truncated,
+            },
+        ))
     }
 }
 
@@ -108,6 +304,7 @@ mod tests {
         let report = action.report(10).await?;
         assert!(report.rows.is_empty());
         assert!(report.daemon.is_none());
+        assert_eq!(report.metering, MeteringAvailability::unavailable());
         Ok(())
     }
 
@@ -122,6 +319,60 @@ mod tests {
         );
         assert!(action.report(0).await.is_err());
         assert!(action.report(MAX_REQUEST_ROWS + 1).await.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn filters_require_paired_bounded_rfc3339_times() -> anyhow::Result<()> {
+        let now = DateTime::parse_from_rfc3339("2026-09-08T10:30:00Z")?.with_timezone(&Utc);
+        let valid = RequestFilters {
+            limit: 12,
+            since: Some("2026-09-01T10:30:00+00:00".to_string()),
+            until: Some("2026-09-08T10:30:00Z".to_string()),
+            model: Some("gpt-5".to_string()),
+            provider: Some("openai".to_string()),
+        }
+        .resolve_at(now)?;
+        assert_eq!(valid.window_label, "custom");
+        assert_eq!(valid.since.to_rfc3339(), "2026-09-01T10:30:00+00:00");
+        assert_eq!(valid.until.to_rfc3339(), "2026-09-08T10:30:00+00:00");
+
+        let unpaired = RequestFilters {
+            since: Some("2026-09-01T10:30:00Z".to_string()),
+            ..RequestFilters::default()
+        };
+        assert!(unpaired.resolve_at(now).is_err());
+
+        let too_wide = RequestFilters {
+            since: Some("2026-09-01T10:30:00Z".to_string()),
+            until: Some("2026-09-08T10:30:01Z".to_string()),
+            ..RequestFilters::default()
+        };
+        assert!(too_wide.resolve_at(now).is_err());
+
+        let malformed = RequestFilters {
+            since: Some("not-a-time".to_string()),
+            until: Some("2026-09-08T10:30:00Z".to_string()),
+            ..RequestFilters::default()
+        };
+        assert!(malformed.resolve_at(now).is_err());
+
+        let unsafe_identifier = RequestFilters {
+            model: Some("gpt-5\nignored".to_string()),
+            ..RequestFilters::default()
+        };
+        assert!(unsafe_identifier.resolve_at(now).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn default_filters_resolve_to_server_today() -> anyhow::Result<()> {
+        let now = DateTime::parse_from_rfc3339("2026-09-08T10:30:00Z")?.with_timezone(&Utc);
+        let resolved = RequestFilters::with_limit(4).resolve_at(now)?;
+        assert_eq!(resolved.window_label, "today");
+        assert_eq!(resolved.since.to_rfc3339(), "2026-09-08T00:00:00+00:00");
+        assert_eq!(resolved.until, now);
+        assert_eq!(resolved.limit, 4);
         Ok(())
     }
 }

--- a/apps/bitrouter/src/administration_target.rs
+++ b/apps/bitrouter/src/administration_target.rs
@@ -1,0 +1,351 @@
+//! Typed local-or-remote inspection ports.
+//!
+//! A remote context names the complete target.  This module resolves that
+//! choice before a caller can load a local config, socket, database, or
+//! provider environment, then exposes the same read operations to the CLI and
+//! operations dashboard.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use bitrouter_mcp::actions::models::ModelsReport;
+use bitrouter_mcp::actions::route::{RouteInput, RouteReport};
+use bitrouter_mcp::actions::status::StatusReport;
+
+use crate::actions::administration::{
+    AgentsReport, ObserveReport, PolicyInput, PolicyReport, PolicyView, ProvidersReport,
+};
+use crate::actions::models::RoutableModels;
+use crate::actions::requests::{RequestFilters, RequestsAction};
+use crate::actions::route::RouteAction;
+use crate::actions::status::DaemonStatus;
+use crate::contexts::RemoteContext;
+use crate::daemon::{
+    self, DaemonCommand, DaemonInspection, DaemonInspectionReport, DaemonResponse,
+};
+use crate::output::reports::requests::RequestsReport;
+use crate::paths::ConfigSource;
+use crate::reload::ReloadState;
+use crate::remote_control::operations::{OperationReport, ReloadInput};
+
+/// Result of an explicit reload submitted through a selected target.
+///
+/// A local control socket completes synchronously and can only return the
+/// coordinator's current state. Remote control retains an exact operation
+/// receipt by request id, including a still-running operation after bounded
+/// client polling.
+pub enum ReloadSubmission {
+    Local(ReloadState),
+    Remote(OperationReport),
+}
+
+/// The currently advertised control grants relevant to the dashboard.
+///
+/// Server-side authorization remains authoritative when an action is sent. The
+/// UI uses this snapshot only to avoid presenting a reload trigger to a
+/// credential that discovery says cannot submit one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ControlAuthority {
+    pub read: bool,
+    pub reload: bool,
+}
+
+/// One selected target for a passive administration action.
+#[derive(Clone)]
+pub enum InspectionTarget {
+    Local {
+        source: ConfigSource,
+        socket: PathBuf,
+    },
+    Remote {
+        name: String,
+        client: Arc<crate::remote_control::HttpControlClient>,
+    },
+}
+
+impl InspectionTarget {
+    /// Resolve the target once.  A remote context is complete by itself, so
+    /// reject local flags before constructing a client or reading any local
+    /// configuration.
+    pub async fn resolve(
+        remote: Option<(String, RemoteContext)>,
+        config: Option<&Path>,
+        socket: Option<&Path>,
+    ) -> Result<Self> {
+        match remote {
+            Some((name, context)) => {
+                reject_remote_local_flags(config, socket)?;
+                Ok(Self::Remote {
+                    name,
+                    client: Arc::new(context.client()?),
+                })
+            }
+            None => {
+                let source = crate::paths::resolve_config(config)?;
+                let socket = match socket {
+                    Some(socket) => socket.to_path_buf(),
+                    None => {
+                        let config = crate::paths::load_config(&source).await?;
+                        daemon::socket_path_for(&source, &config)
+                    }
+                };
+                Ok(Self::Local { source, socket })
+            }
+        }
+    }
+
+    pub fn label(&self) -> String {
+        match self {
+            Self::Local { .. } => "local".to_string(),
+            Self::Remote { name, .. } => format!("remote:{name}"),
+        }
+    }
+
+    /// Local ACP sessions are deliberately absent from a remote inspection
+    /// target.  The catalog itself remains readable through [`Self::agents`].
+    pub fn allows_agent_launch(&self) -> bool {
+        matches!(self, Self::Local { .. })
+    }
+
+    /// The dashboard uses this only to choose the explicitly initiated reload
+    /// protocol. It does not widen the local socket protocol.
+    pub fn is_remote(&self) -> bool {
+        matches!(self, Self::Remote { .. })
+    }
+
+    pub fn local_source(&self) -> Option<&ConfigSource> {
+        match self {
+            Self::Local { source, .. } => Some(source),
+            Self::Remote { .. } => None,
+        }
+    }
+
+    /// The local-only adapter for legacy CLI output may retain the socket in
+    /// its established JSON shape. Remote targets never expose a socket.
+    pub fn local_socket(&self) -> Option<&Path> {
+        match self {
+            Self::Local { socket, .. } => Some(socket),
+            Self::Remote { .. } => None,
+        }
+    }
+
+    pub async fn status(&self) -> Result<StatusReport> {
+        match self {
+            Self::Local { source, socket } => {
+                DaemonStatus::new(socket, Some(source.clone()))
+                    .report()
+                    .await
+            }
+            Self::Remote { client, .. } => client.status().await,
+        }
+    }
+
+    pub async fn models(&self, provider: Option<&str>) -> Result<ModelsReport> {
+        match self {
+            Self::Local { source, socket } => {
+                Ok(RoutableModels::new(source.clone(), Some(socket.clone()))
+                    .report()
+                    .await?
+                    .filtered(provider))
+            }
+            Self::Remote { client, .. } => client.models(provider).await,
+        }
+    }
+
+    pub async fn requests(&self, filters: RequestFilters) -> Result<RequestsReport> {
+        match self {
+            Self::Local { source, socket } => {
+                RequestsAction::new(source.clone(), socket.clone())
+                    .report_filtered(filters)
+                    .await
+            }
+            Self::Remote { client, .. } => client.requests_filtered(&filters).await,
+        }
+    }
+
+    pub async fn route(&self, input: RouteInput) -> Result<RouteReport> {
+        match self {
+            Self::Local { source, socket } => {
+                RouteAction::new(source.clone(), Some(socket.clone()))
+                    .report(input)
+                    .await
+            }
+            Self::Remote { client, .. } => client.route(&input).await,
+        }
+    }
+
+    pub async fn providers(&self) -> Result<ProvidersReport> {
+        match self {
+            Self::Local { .. } => match self.inspect(DaemonInspection::Providers).await? {
+                DaemonInspectionReport::Providers(report) => Ok(report),
+                other => unexpected_inspection("providers", other),
+            },
+            Self::Remote { client, .. } => client.providers().await,
+        }
+    }
+
+    pub async fn agents(&self) -> Result<AgentsReport> {
+        match self {
+            Self::Local { .. } => match self.inspect(DaemonInspection::Agents).await? {
+                DaemonInspectionReport::Agents(report) => Ok(report),
+                other => unexpected_inspection("agents", other),
+            },
+            Self::Remote { client, .. } => client.agents().await,
+        }
+    }
+
+    pub async fn observe(&self) -> Result<ObserveReport> {
+        match self {
+            Self::Local { .. } => match self.inspect(DaemonInspection::Observe).await {
+                Ok(DaemonInspectionReport::Observe(report)) => Ok(report),
+                Ok(other) => unexpected_inspection("observe", other),
+                Err(error) if daemon::is_not_reachable(&error) => Ok(ObserveReport::from_snapshot(
+                    daemon::ObserveStatusPayload::unwired(bitrouter_telemetry::OTEL_ENABLED),
+                    false,
+                )),
+                Err(error) => Err(error),
+            },
+            Self::Remote { client, .. } => client.observe().await,
+        }
+    }
+
+    pub async fn policy(&self, input: PolicyInput) -> Result<PolicyReport> {
+        input.validate()?;
+        match self {
+            Self::Local { source, .. } if input.view == PolicyView::Disk => {
+                crate::actions::administration::disk_policy(source)
+                    .await?
+                    .selected(input.name.as_deref())
+            }
+            Self::Local { .. } => match self.inspect(DaemonInspection::Policy { input }).await? {
+                DaemonInspectionReport::Policy(report) => Ok(report),
+                other => unexpected_inspection("policy", other),
+            },
+            Self::Remote { client, .. } => client.policy(&input).await,
+        }
+    }
+
+    pub async fn reload_state(&self) -> Result<ReloadState> {
+        match self {
+            Self::Local { socket, .. } => {
+                match daemon::send_command(socket, &DaemonCommand::ReloadState).await? {
+                    DaemonResponse::ReloadState { state } => Ok(state),
+                    DaemonResponse::Error { message } => Err(anyhow::anyhow!(message)),
+                    other => Err(anyhow::anyhow!(
+                        "unexpected daemon reload-state response: {other:?}"
+                    )),
+                }
+            }
+            Self::Remote { client, .. } => client.state().await,
+        }
+    }
+
+    /// Read the control discovery grants cached by the remote client. Local
+    /// IPC is operator-local, so it has both capabilities when its daemon
+    /// supports the corresponding command.
+    pub async fn control_authority(&self) -> Result<ControlAuthority> {
+        match self {
+            Self::Local { .. } => Ok(ControlAuthority {
+                read: true,
+                reload: true,
+            }),
+            Self::Remote { client, .. } => Ok(ControlAuthority {
+                read: client.can_action("status").await?,
+                reload: client.can_action("reload").await?,
+            }),
+        }
+    }
+
+    pub async fn reload(&self) -> Result<ReloadSubmission> {
+        match self {
+            Self::Local { socket, .. } => {
+                match daemon::send_command(socket, &DaemonCommand::Reload { env: Vec::new() })
+                    .await?
+                {
+                    DaemonResponse::Ok => Ok(ReloadSubmission::Local(self.reload_state().await?)),
+                    DaemonResponse::Error { message } => Err(anyhow::anyhow!(message)),
+                    other => Err(anyhow::anyhow!(
+                        "unexpected daemon reload response: {other:?}"
+                    )),
+                }
+            }
+            Self::Remote { client, .. } => Ok(ReloadSubmission::Remote(client.reload().await?)),
+        }
+    }
+
+    /// Submit an already fenced remote reload request. Keeping this separate
+    /// from [`Self::reload`] lets the dashboard retain the generated request
+    /// and instance identifiers if the HTTP response is interrupted.
+    pub async fn submit_remote_reload(&self, input: &ReloadInput) -> Result<OperationReport> {
+        match self {
+            Self::Local { .. } => anyhow::bail!(
+                "local reloads use the control socket and do not accept remote reload inputs"
+            ),
+            Self::Remote { client, .. } => client.submit_reload(input).await,
+        }
+    }
+
+    pub async fn operation(&self, request_id: &str, instance: &str) -> Result<OperationReport> {
+        match self {
+            Self::Local { .. } => anyhow::bail!(
+                "local reloads do not retain operation receipts; inspect the current reload state instead"
+            ),
+            Self::Remote { client, .. } => client.operation(request_id, instance).await,
+        }
+    }
+
+    async fn inspect(&self, inspection: DaemonInspection) -> Result<DaemonInspectionReport> {
+        let Self::Local { socket, .. } = self else {
+            anyhow::bail!("local inspection is unavailable for a remote target");
+        };
+        match daemon::send_command(socket, &DaemonCommand::Inspect { inspection }).await? {
+            DaemonResponse::Inspection { report } => Ok(report),
+            DaemonResponse::Error { message } => Err(anyhow::anyhow!(message)),
+            other => Err(anyhow::anyhow!(
+                "unexpected daemon inspection response: {other:?}"
+            )),
+        }
+    }
+}
+
+fn unexpected_inspection<T>(action: &str, report: DaemonInspectionReport) -> Result<T> {
+    anyhow::bail!("daemon returned the wrong inspection report for {action}: {report:?}")
+}
+
+pub fn reject_remote_local_flags(config: Option<&Path>, socket: Option<&Path>) -> Result<()> {
+    if config.is_some() || socket.is_some() {
+        return Err(bitrouter_sdk::BitrouterError::bad_request(
+            "a remote context does not accept --config or --socket; the named context is the \
+             complete target",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn remote_local_flags_are_rejected_before_the_token_is_read() -> anyhow::Result<()> {
+        let config = tempfile::tempdir()?.path().join("bitrouter.yaml");
+        let error = InspectionTarget::resolve(
+            Some((
+                "workstation".to_string(),
+                RemoteContext {
+                    endpoint: "https://router.example/control/v1/".to_string(),
+                    token_env: "UNSET_TEST_CONTROL_TOKEN".to_string(),
+                },
+            )),
+            Some(&config),
+            None,
+        )
+        .await
+        .err()
+        .ok_or_else(|| anyhow::anyhow!("remote config flag unexpectedly succeeded"))?;
+        assert!(error.to_string().contains("does not accept --config"));
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/daemon.rs
+++ b/apps/bitrouter/src/daemon.rs
@@ -25,7 +25,11 @@ use bitrouter_sdk::language_model::RoutingPrefs;
 use chrono::{DateTime, Utc};
 
 use crate::acp_runtime::AcpRuntime;
+use crate::actions::administration::{
+    Administration, AgentsReport, ObserveReport, PolicyInput, PolicyReport, ProvidersReport,
+};
 use crate::metering::{MeteringStore, TimeWindow};
+use crate::reload::{ReloadAdmissionError, ReloadReport, ReloadReservation, ReloadState};
 
 /// Anything the daemon's `Reload` command (and SIGHUP) should re-read. The
 /// runtime reloader fans out to every reloadable subsystem — routing table,
@@ -36,6 +40,44 @@ use crate::metering::{MeteringStore, TimeWindow};
 pub trait DaemonReloader: Send + Sync {
     /// Reload every reloadable subsystem.
     async fn reload(&self) -> anyhow::Result<()>;
+
+    /// Reload with owner-trusted local environment overrides. Implementations
+    /// that own a coordinator install overrides after reserving exclusive
+    /// reload ownership; a generic reloader cannot truthfully promise that.
+    async fn reload_with_env(&self, env: Vec<(String, String)>) -> anyhow::Result<()> {
+        if env.is_empty() {
+            self.reload().await
+        } else {
+            Err(anyhow::anyhow!(
+                "this daemon reloader does not support coordinated environment overrides"
+            ))
+        }
+    }
+
+    /// Return boot-local reload state when this implementation supports guarded
+    /// reload admission. `None` deliberately means unsupported, rather than a
+    /// fabricated instance identity or generation.
+    fn reload_state(&self) -> Option<ReloadState> {
+        None
+    }
+
+    /// Atomically fence a remote operation against the current boot and
+    /// generation. The reservation must be passed to [`Self::reload_reserved`]
+    /// exactly once or dropped so its coordinator can clear the admission.
+    fn reserve_remote(
+        &self,
+        _expected_instance: &str,
+        _expected_generation: u64,
+    ) -> Result<ReloadReservation, ReloadAdmissionError> {
+        Err(ReloadAdmissionError::Unsupported)
+    }
+
+    /// Execute a previously admitted remote reload. The default is reachable
+    /// only through an invalid implementation because [`Self::reserve_remote`]
+    /// rejects every request, and still returns a truthful unsupported report.
+    async fn reload_reserved(&self, _reservation: ReloadReservation) -> ReloadReport {
+        ReloadReport::unsupported()
+    }
 }
 
 /// A reloader that does nothing — useful for tests / minimal embeddings of the
@@ -68,6 +110,8 @@ pub enum DaemonCommand {
         #[serde(default)]
         env: Vec<(String, String)>,
     },
+    /// Read the reload coordinator's boot-local state without mutating it.
+    ReloadState,
     /// Report daemon status.
     Status,
     /// List every model the live routing table can route, each with the
@@ -89,6 +133,12 @@ pub enum DaemonCommand {
     /// snapshot. The wire format is the same `ObserveStatusPayload` the
     /// CLI pretty-prints for `bitrouter observe status`.
     ObserveStatus,
+    /// Run one safe, typed administration read against the live daemon.
+    ///
+    /// This is intentionally a closed enum rather than a JSON method name or
+    /// a serialized HTTP request.  The local control socket remains a
+    /// host-local transport with its own contract.
+    Inspect { inspection: DaemonInspection },
     /// Remove every route lease in one principal/controller namespace.
     AcpControllerCleanup {
         /// Opaque principal derived from the normal API credential, or local.
@@ -134,6 +184,26 @@ pub enum DaemonCommand {
         /// Harness-native ACP session identity.
         session_id: String,
     },
+}
+
+/// Passive live inspection operations accepted over the local control socket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "inspection", rename_all = "snake_case")]
+pub enum DaemonInspection {
+    Providers,
+    Agents,
+    Observe,
+    Policy { input: PolicyInput },
+}
+
+/// Typed result of a [`DaemonInspection`] request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "report", rename_all = "snake_case")]
+pub enum DaemonInspectionReport {
+    Providers(ProvidersReport),
+    Agents(AgentsReport),
+    Observe(ObserveReport),
+    Policy(PolicyReport),
 }
 
 /// One resolved hop of a route chain.
@@ -184,6 +254,10 @@ pub enum DaemonResponse {
         /// The serialized exporter state.
         payload: ObserveStatusPayload,
     },
+    /// Reload coordinator state for the current daemon boot.
+    ReloadState { state: ReloadState },
+    /// A typed administration inspection result.
+    Inspection { report: DaemonInspectionReport },
     /// Daemon-confirmed route state for one native ACP session.
     AcpRouteState {
         /// Live model selectors accepted as logical routes.
@@ -474,8 +548,43 @@ pub async fn run_control_socket_with_acp_runtime(
     observe: Arc<dyn ObserveStatusProvider>,
     acp: AcpControlPlane,
 ) -> Result<()> {
+    run_control_socket_with_acp_runtime_and_administration(
+        socket_path,
+        app,
+        listen,
+        reloader,
+        observe,
+        acp,
+        None,
+    )
+    .await
+}
+
+/// Run the local control socket with optional live administration ports.
+///
+/// Existing embeddings retain the historical control-socket surface through
+/// [`run_control_socket_with_acp_runtime`].  The app assembly injects these
+/// ports only after it has constructed the running routing and policy state.
+pub async fn run_control_socket_with_acp_runtime_and_administration(
+    socket_path: PathBuf,
+    app: Arc<App>,
+    listen: String,
+    reloader: Arc<dyn DaemonReloader>,
+    observe: Arc<dyn ObserveStatusProvider>,
+    acp: AcpControlPlane,
+    administration: Option<Administration>,
+) -> Result<()> {
     let mut listener = transport::bind(&socket_path).await?;
-    let result = accept_loop(&mut listener, &app, &listen, &reloader, &observe, &acp).await;
+    let result = accept_loop(
+        &mut listener,
+        &app,
+        &listen,
+        &reloader,
+        &observe,
+        &acp,
+        &administration,
+    )
+    .await;
     listener.cleanup().await;
     result
 }
@@ -487,12 +596,13 @@ async fn accept_loop(
     reloader: &Arc<dyn DaemonReloader>,
     observe: &Arc<dyn ObserveStatusProvider>,
     acp: &AcpControlPlane,
+    administration: &Option<Administration>,
 ) -> Result<()> {
     loop {
         let stream = listener.accept().await?;
         // Handle one command per connection. A `Stop` ends the loop (and thus
         // the whole `serve`); any other command loops for the next client.
-        if handle_connection(stream, app, listen, reloader, observe, acp).await? {
+        if handle_connection(stream, app, listen, reloader, observe, acp, administration).await? {
             tracing::info!("stop command received — shutting down");
             return Ok(());
         }
@@ -511,6 +621,7 @@ async fn handle_connection<S>(
     reloader: &Arc<dyn DaemonReloader>,
     observe: &Arc<dyn ObserveStatusProvider>,
     acp: &AcpControlPlane,
+    administration: &Option<Administration>,
 ) -> Result<bool>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -535,7 +646,7 @@ where
     };
 
     let is_stop = matches!(command, DaemonCommand::Stop);
-    let response = dispatch(command, app, listen, reloader, observe, acp).await;
+    let response = dispatch(command, app, listen, reloader, observe, acp, administration).await;
     write_response(reader.get_mut(), &response).await?;
     Ok(is_stop)
 }
@@ -547,30 +658,25 @@ async fn dispatch(
     reloader: &Arc<dyn DaemonReloader>,
     observe: &Arc<dyn ObserveStatusProvider>,
     acp: &AcpControlPlane,
+    administration: &Option<Administration>,
 ) -> DaemonResponse {
     match command {
         DaemonCommand::Stop => DaemonResponse::Ok,
-        DaemonCommand::Reload { env } => {
-            // Apply the CLI's env snapshot first so file-mode YAML
-            // `${VAR}` substitution and zero-config's "is this
-            // provider's key set" check see the freshly-exported
-            // values. Empty list = caller didn't ask us to update env;
-            // we keep whatever was already in the override map.
-            if !env.is_empty() {
-                let map: std::collections::HashMap<String, String> = env.into_iter().collect();
-                bitrouter_sdk::config::set_env_overrides(map);
-                tracing::info!("env override map updated by reload");
+        DaemonCommand::Reload { env } => match reloader.reload_with_env(env).await {
+            Ok(()) => {
+                tracing::info!("reload succeeded");
+                DaemonResponse::Ok
             }
-            match reloader.reload().await {
-                Ok(()) => {
-                    tracing::info!("reload succeeded");
-                    DaemonResponse::Ok
-                }
-                Err(e) => DaemonResponse::Error {
-                    message: format!("reload failed: {e}"),
-                },
-            }
-        }
+            Err(e) => DaemonResponse::Error {
+                message: format!("reload failed: {e}"),
+            },
+        },
+        DaemonCommand::ReloadState => match reloader.reload_state() {
+            Some(state) => DaemonResponse::ReloadState { state },
+            None => DaemonResponse::Error {
+                message: "reload state is unavailable on this daemon".to_string(),
+            },
+        },
         DaemonCommand::Status => {
             let routable = app
                 .language_model()
@@ -778,6 +884,39 @@ async fn dispatch(
         }
         DaemonCommand::ObserveStatus => DaemonResponse::ObserveStatus {
             payload: observe.status(),
+        },
+        DaemonCommand::Inspect { inspection } => {
+            inspection_response(inspection, administration).await
+        }
+    }
+}
+
+async fn inspection_response(
+    inspection: DaemonInspection,
+    administration: &Option<Administration>,
+) -> DaemonResponse {
+    let Some(administration) = administration else {
+        return DaemonResponse::Error {
+            message: "live administration reads are unavailable on this daemon".to_string(),
+        };
+    };
+    match inspection {
+        DaemonInspection::Providers => DaemonResponse::Inspection {
+            report: DaemonInspectionReport::Providers(administration.providers()),
+        },
+        DaemonInspection::Agents => DaemonResponse::Inspection {
+            report: DaemonInspectionReport::Agents(administration.agents()),
+        },
+        DaemonInspection::Observe => DaemonResponse::Inspection {
+            report: DaemonInspectionReport::Observe(administration.observe()),
+        },
+        DaemonInspection::Policy { input } => match administration.policy(input).await {
+            Ok(report) => DaemonResponse::Inspection {
+                report: DaemonInspectionReport::Policy(report),
+            },
+            Err(error) => DaemonResponse::Error {
+                message: format!("policy inspection failed: {error}"),
+            },
         },
     }
 }
@@ -1282,17 +1421,42 @@ mod tests {
         for cmd in [
             DaemonCommand::Stop,
             DaemonCommand::Reload { env: Vec::new() },
+            DaemonCommand::ReloadState,
             DaemonCommand::Status,
             DaemonCommand::Route {
                 model: "gpt-5".to_string(),
             },
             DaemonCommand::ObserveStatus,
+            DaemonCommand::Inspect {
+                inspection: DaemonInspection::Policy {
+                    input: PolicyInput::default(),
+                },
+            },
         ] {
             let json = serde_json::to_string(&cmd).unwrap();
             let back: DaemonCommand = serde_json::from_str(&json).unwrap();
             // tag-based round trip
             assert_eq!(std::mem::discriminant(&cmd), std::mem::discriminant(&back));
         }
+    }
+
+    #[test]
+    fn inspection_response_round_trips_as_json() -> anyhow::Result<()> {
+        let response = DaemonResponse::Inspection {
+            report: DaemonInspectionReport::Providers(ProvidersReport {
+                resolved_via: "live".to_string(),
+                providers: Vec::new(),
+            }),
+        };
+        let json = serde_json::to_string(&response)?;
+        let decoded: DaemonResponse = serde_json::from_str(&json)?;
+        match decoded {
+            DaemonResponse::Inspection {
+                report: DaemonInspectionReport::Providers(report),
+            } => assert_eq!(report.resolved_via, "live"),
+            other => anyhow::bail!("expected provider inspection, got {other:?}"),
+        }
+        Ok(())
     }
 
     #[test]

--- a/apps/bitrouter/src/dashboard.rs
+++ b/apps/bitrouter/src/dashboard.rs
@@ -1,6 +1,7 @@
 //! Application driver for the local/remote operations dashboard.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::time::Duration;
 
 use agent_client_protocol::schema::v1::{
     ContentBlock, ContentChunk, PromptResponse, RequestPermissionOutcome,
@@ -13,13 +14,18 @@ use bitrouter_mcp::actions::status::StatusReport;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use futures::StreamExt;
 
-use crate::actions::models::RoutableModels;
-use crate::actions::requests::RequestsAction;
-use crate::actions::route::RouteAction;
-use crate::actions::status::DaemonStatus;
+use crate::actions::administration::{
+    AgentsReport, ObserveReport, PolicyDetail, PolicyInput, PolicyReport, PolicyView,
+    ProvidersReport,
+};
+use crate::actions::requests::RequestFilters;
+use crate::administration_target::{ControlAuthority, InspectionTarget, ReloadSubmission};
 use crate::contexts::RemoteContext;
 use crate::output::reports::requests::RequestsReport;
-use crate::paths::ConfigSource;
+use crate::reload::{
+    ReloadConsistency, ReloadOutcome, ReloadParticipant, ReloadParticipantOutcome, ReloadState,
+};
+use crate::remote_control::operations::{OperationReport, OperationStatus, ReloadInput};
 
 const DASHBOARD_REQUEST_ROWS: u64 = 100;
 const REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
@@ -42,6 +48,33 @@ struct SessionDriver {
     turn: Option<tokio::task::JoinHandle<Result<PromptResponse>>>,
 }
 
+/// One explicit reload action in flight. Refresh timers never create this
+/// task: it exists only after Enter or Ctrl-R asks for a reload.
+struct ReloadTask {
+    updates: tokio::sync::mpsc::UnboundedReceiver<ReloadUpdate>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ReloadTask {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+enum ReloadUpdate {
+    /// A remote request UUID is durable enough to show before the POST
+    /// completes, so an interrupted response remains recoverable.
+    Prepared {
+        request_id: String,
+        server_instance_id: String,
+        generation_before: u64,
+    },
+    RemoteSubmitted(OperationReport),
+    RemoteFinished(OperationReport),
+    LocalFinished(ReloadState),
+    Failed(String),
+}
+
 impl Default for SessionDriver {
     fn default() -> Self {
         Self {
@@ -54,61 +87,6 @@ impl Default for SessionDriver {
     }
 }
 
-enum Target {
-    Local {
-        source: ConfigSource,
-        socket: PathBuf,
-    },
-    Remote {
-        name: String,
-        client: Box<crate::remote_control::HttpControlClient>,
-    },
-}
-
-impl Target {
-    fn label(&self) -> String {
-        match self {
-            Self::Local { .. } => "local".to_string(),
-            Self::Remote { name, .. } => format!("remote:{name}"),
-        }
-    }
-
-    async fn snapshot(&self) -> Result<(StatusReport, ModelsReport, RequestsReport)> {
-        match self {
-            Self::Local { source, socket } => {
-                let status_action = DaemonStatus::new(socket, Some(source.clone()));
-                let models_action = RoutableModels::new(source.clone(), Some(socket.clone()));
-                let requests_action = RequestsAction::new(source.clone(), socket.clone());
-                let status = status_action.report();
-                let models = models_action.report();
-                let requests = requests_action.report(DASHBOARD_REQUEST_ROWS);
-                tokio::try_join!(status, models, requests)
-            }
-            Self::Remote { client, .. } => {
-                let status = client.status();
-                let models = client.models(None);
-                let requests = client.requests(Some(DASHBOARD_REQUEST_ROWS));
-                tokio::try_join!(status, models, requests)
-            }
-        }
-    }
-
-    async fn route(&self, model: String) -> Result<RouteReport> {
-        let input = RouteInput {
-            model,
-            prompt: None,
-        };
-        match self {
-            Self::Local { source, socket } => {
-                RouteAction::new(source.clone(), Some(socket.clone()))
-                    .report(input)
-                    .await
-            }
-            Self::Remote { client, .. } => client.route(&input).await,
-        }
-    }
-}
-
 /// Open the operations dashboard for a local or named remote target.
 pub async fn run(
     remote: Option<(String, RemoteContext)>,
@@ -116,39 +94,14 @@ pub async fn run(
     socket: Option<&Path>,
     initial_session: Option<SessionRequest>,
 ) -> Result<()> {
-    let target = match remote {
-        Some((name, context)) => {
-            if config.is_some() || socket.is_some() {
-                return Err(bitrouter_sdk::BitrouterError::bad_request(
-                    "remote `tui` does not accept --config or --socket; the named context is \
-                     the complete target",
-                )
-                .into());
-            }
-            Target::Remote {
-                name,
-                client: Box::new(context.client()?),
-            }
-        }
-        None => {
-            let source = crate::paths::resolve_config(config)?;
-            let socket = match socket {
-                Some(socket) => socket.to_path_buf(),
-                None => crate::daemon::socket_path_for(
-                    &source,
-                    &crate::paths::load_config(&source).await?,
-                ),
-            };
-            Target::Local { source, socket }
-        }
-    };
+    let target = InspectionTarget::resolve(remote, config, socket).await?;
 
     let mut dashboard = bitrouter_tui::dashboard::Dashboard {
         target: target.label(),
         status: "loading".to_string(),
         ..Default::default()
     };
-    dashboard.agents = available_agents(&target).await?;
+    dashboard.can_launch_agents = target.allows_agent_launch();
     refresh(&target, &mut dashboard).await;
 
     let mut session = SessionDriver::default();
@@ -176,7 +129,7 @@ pub async fn run(
 }
 
 async fn drive(
-    target: &Target,
+    target: &InspectionTarget,
     dashboard: &mut bitrouter_tui::dashboard::Dashboard,
     session: &mut SessionDriver,
     view: &mut bitrouter_tui::dashboard::DashboardView,
@@ -188,6 +141,7 @@ async fn drive(
     // immediately repeat it on Interval's eager first tick.
     refresh_tick.tick().await;
     let mut shutdown = crate::chat::signals::Shutdown::install();
+    let mut reload_task = None;
     view.draw(dashboard)
         .context("drawing operations dashboard")?;
 
@@ -198,7 +152,7 @@ async fn drive(
                     return Ok(());
                 };
                 let event = event.context("reading dashboard input")?;
-                if handle_event(target, dashboard, session, view, event).await? {
+                if handle_event(target, dashboard, session, view, &mut reload_task, event).await? {
                     return Ok(());
                 }
                 view.draw(dashboard).context("drawing operations dashboard")?;
@@ -240,16 +194,31 @@ async fn drive(
                 refresh(target, dashboard).await;
                 view.draw(dashboard).context("drawing operations dashboard")?;
             }
+            update = next_reload_update(&mut reload_task) => {
+                match update {
+                    Some(update) => {
+                        apply_reload_update(dashboard, update);
+                        view.draw(dashboard).context("drawing reload action")?;
+                    }
+                    None => {
+                        // The worker owns all ordinary error paths and sends a
+                        // typed diagnostic before closing. A closed channel
+                        // here simply makes another explicit reload available.
+                        reload_task = None;
+                    }
+                }
+            }
             _ = shutdown.recv() => return Ok(()),
         }
     }
 }
 
 async fn handle_event(
-    target: &Target,
+    target: &InspectionTarget,
     dashboard: &mut bitrouter_tui::dashboard::Dashboard,
     session: &mut SessionDriver,
     view: &mut bitrouter_tui::dashboard::DashboardView,
+    reload_task: &mut Option<ReloadTask>,
     event: Event,
 ) -> Result<bool> {
     match event {
@@ -285,6 +254,13 @@ async fn handle_event(
                 view.next_page();
                 return Ok(false);
             }
+            if key.code == KeyCode::Char('r')
+                && key.modifiers.contains(KeyModifiers::CONTROL)
+                && view.page() == bitrouter_tui::dashboard::Page::Reload
+            {
+                start_reload(target, dashboard, reload_task);
+                return Ok(false);
+            }
             match view.page() {
                 bitrouter_tui::dashboard::Page::Route => {
                     handle_route_key(target, dashboard, key).await?;
@@ -294,6 +270,12 @@ async fn handle_event(
                 }
                 bitrouter_tui::dashboard::Page::Conversation => {
                     handle_conversation_key(dashboard, session, key).await?;
+                }
+                bitrouter_tui::dashboard::Page::Policy => {
+                    handle_policy_key(target, dashboard, view, key).await?;
+                }
+                bitrouter_tui::dashboard::Page::Reload => {
+                    handle_reload_key(target, dashboard, view, reload_task, key).await?;
                 }
                 _ => handle_navigation_key(target, dashboard, view, key).await,
             }
@@ -325,18 +307,21 @@ async fn pending_turn(
     }
 }
 
-async fn available_agents(target: &Target) -> Result<Vec<bitrouter_tui::dashboard::AgentLine>> {
-    let Target::Local { source, .. } = target else {
-        return Ok(Vec::new());
-    };
-    let config = crate::paths::load_config(source).await?;
-    Ok(crate::agents::list(&config)
+fn agent_lines(
+    target: &InspectionTarget,
+    report: AgentsReport,
+) -> Vec<bitrouter_tui::dashboard::AgentLine> {
+    let can_launch = target.allows_agent_launch();
+    report
+        .agents
         .into_iter()
-        .filter_map(|row| {
+        .map(|row| {
             let harness = crate::harness::by_id(&row.id);
-            let acp = harness.map_or(row.configured, |harness| harness.acp_command.is_some());
-            let native = harness.is_some_and(|harness| harness.interactive_binary.is_some());
-            acp.then_some(bitrouter_tui::dashboard::AgentLine {
+            let acp = can_launch
+                && harness.map_or(row.configured, |harness| harness.acp_command.is_some());
+            let native =
+                can_launch && harness.is_some_and(|harness| harness.interactive_binary.is_some());
+            bitrouter_tui::dashboard::AgentLine {
                 id: match row.id.as_str() {
                     "claude-acp" => "claude".to_string(),
                     "codex-acp" => "codex".to_string(),
@@ -346,23 +331,22 @@ async fn available_agents(target: &Target) -> Result<Vec<bitrouter_tui::dashboar
                 acp,
                 configured: row.configured,
                 description: row.description,
-            })
+            }
         })
-        .collect())
+        .collect()
 }
 
 async fn open_session(
-    target: &Target,
+    target: &InspectionTarget,
     dashboard: &mut bitrouter_tui::dashboard::Dashboard,
     driver: &mut SessionDriver,
     request: SessionRequest,
 ) -> Result<()> {
-    let Target::Local { source, .. } = target else {
-        return Err(bitrouter_sdk::BitrouterError::bad_request(
+    let source = target.local_source().ok_or_else(|| {
+        bitrouter_sdk::BitrouterError::bad_request(
             "remote ACP conversations are not available; use the operations views",
         )
-        .into());
-    };
+    })?;
     if let Some(turn) = driver.turn.take() {
         turn.abort();
     }
@@ -444,12 +428,24 @@ fn handle_permission_key(
 }
 
 async fn handle_agent_key(
-    target: &Target,
+    target: &InspectionTarget,
     dashboard: &mut bitrouter_tui::dashboard::Dashboard,
     driver: &mut SessionDriver,
     view: &mut bitrouter_tui::dashboard::DashboardView,
     key: KeyEvent,
 ) -> Result<()> {
+    if !dashboard.can_launch_agents {
+        match key.code {
+            KeyCode::Enter => {
+                dashboard.error = Some(
+                    "Remote agent catalogs are read-only; start ACP sessions on the local host."
+                        .to_string(),
+                );
+            }
+            _ => handle_navigation_key(target, dashboard, view, key).await,
+        }
+        return Ok(());
+    }
     match key.code {
         KeyCode::Up => {
             let _ = bitrouter_tui::dashboard::step(
@@ -464,6 +460,14 @@ async fn handle_agent_key(
             );
         }
         KeyCode::Enter => {
+            if !dashboard
+                .agents
+                .get(dashboard.selected_agent)
+                .is_some_and(|agent| agent.acp)
+            {
+                dashboard.error = Some("Select an ACP-capable local agent first.".to_string());
+                return Ok(());
+            }
             let Some(bitrouter_tui::dashboard::Effect::StartAgent(agent)) =
                 bitrouter_tui::dashboard::step(
                     dashboard,
@@ -565,7 +569,7 @@ async fn handle_conversation_key(
 }
 
 async fn handle_navigation_key(
-    target: &Target,
+    target: &InspectionTarget,
     dashboard: &mut bitrouter_tui::dashboard::Dashboard,
     view: &mut bitrouter_tui::dashboard::DashboardView,
     key: KeyEvent,
@@ -578,20 +582,127 @@ async fn handle_navigation_key(
         KeyCode::Char('5') => view.set_page(bitrouter_tui::dashboard::Page::Models),
         KeyCode::Char('6') => view.set_page(bitrouter_tui::dashboard::Page::Requests),
         KeyCode::Char('7') => view.set_page(bitrouter_tui::dashboard::Page::Route),
+        KeyCode::Char('8') => view.set_page(bitrouter_tui::dashboard::Page::Providers),
+        KeyCode::Char('9') => view.set_page(bitrouter_tui::dashboard::Page::Telemetry),
+        KeyCode::Char('0') => view.set_page(bitrouter_tui::dashboard::Page::Policy),
         KeyCode::Char('r') => refresh(target, dashboard).await,
         _ => {}
     }
 }
 
+async fn handle_reload_key(
+    target: &InspectionTarget,
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    view: &mut bitrouter_tui::dashboard::DashboardView,
+    reload_task: &mut Option<ReloadTask>,
+    key: KeyEvent,
+) -> Result<()> {
+    match key.code {
+        KeyCode::Enter => {
+            start_reload(target, dashboard, reload_task);
+            Ok(())
+        }
+        _ => {
+            handle_navigation_key(target, dashboard, view, key).await;
+            Ok(())
+        }
+    }
+}
+
+async fn handle_policy_key(
+    target: &InspectionTarget,
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    view: &mut bitrouter_tui::dashboard::DashboardView,
+    key: KeyEvent,
+) -> Result<()> {
+    match key.code {
+        KeyCode::Up => {
+            dashboard.selected_policy = dashboard.selected_policy.saturating_sub(1);
+            dashboard.policy_detail = None;
+            dashboard.policy_scroll = 0;
+        }
+        KeyCode::Down => {
+            let count = dashboard
+                .policy
+                .as_ref()
+                .map_or(0, |policy| policy.policies.len());
+            dashboard.selected_policy = dashboard
+                .selected_policy
+                .saturating_add(1)
+                .min(count.saturating_sub(1));
+            dashboard.policy_detail = None;
+            dashboard.policy_scroll = 0;
+        }
+        KeyCode::Enter => load_selected_policy_detail(target, dashboard).await,
+        KeyCode::Char('v') if key.modifiers.is_empty() => {
+            dashboard.policy_view = dashboard.policy_view.toggle();
+            dashboard.policy_detail = None;
+            dashboard.policy_scroll = 0;
+            refresh_policy(target, dashboard).await;
+        }
+        KeyCode::PageUp => {
+            dashboard.policy_scroll = dashboard.policy_scroll.saturating_sub(8);
+        }
+        KeyCode::PageDown => {
+            dashboard.policy_scroll = dashboard.policy_scroll.saturating_add(8);
+        }
+        _ => handle_navigation_key(target, dashboard, view, key).await,
+    }
+    Ok(())
+}
+
+async fn refresh_policy(
+    target: &InspectionTarget,
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+) {
+    let view = requested_policy_view(dashboard);
+    apply_policy(
+        dashboard,
+        target.policy(PolicyInput { view, name: None }).await,
+    );
+}
+
+async fn load_selected_policy_detail(
+    target: &InspectionTarget,
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+) {
+    let name = dashboard
+        .policy
+        .as_ref()
+        .and_then(|policy| policy.policies.get(dashboard.selected_policy))
+        .cloned();
+    let Some(name) = name else {
+        mark_failure(
+            &mut dashboard.policy_detail_refresh,
+            anyhow::anyhow!("select a policy before requesting its detail"),
+        );
+        return;
+    };
+    let view = requested_policy_view(dashboard);
+    let result = target
+        .policy(PolicyInput {
+            view,
+            name: Some(name.clone()),
+        })
+        .await;
+    apply_policy_detail(dashboard, &name, result);
+}
+
 async fn handle_route_key(
-    target: &Target,
+    target: &InspectionTarget,
     dashboard: &mut bitrouter_tui::dashboard::Dashboard,
     key: KeyEvent,
 ) -> Result<()> {
     match key.code {
         KeyCode::Enter if !dashboard.route_input.trim().is_empty() => {
             let model = dashboard.route_input.trim().to_string();
-            match target.route(model).await {
+            match target
+                .route(RouteInput {
+                    model,
+                    prompt: None,
+                })
+                .await
+            {
                 Ok(report) => {
                     dashboard.route = Some(route_line(report));
                     dashboard.error = None;
@@ -616,105 +727,678 @@ async fn handle_route_key(
     Ok(())
 }
 
-async fn refresh(target: &Target, dashboard: &mut bitrouter_tui::dashboard::Dashboard) {
-    match target.snapshot().await {
-        Ok((status, models, requests)) => {
-            let route_input = std::mem::take(&mut dashboard.route_input);
-            let route = dashboard.route.take();
-            let snapshot = dashboard_from_reports(target.label(), status, models, requests);
-            apply_snapshot(dashboard, snapshot);
-            dashboard.route_input = route_input;
-            dashboard.route = route;
+async fn refresh(target: &InspectionTarget, dashboard: &mut bitrouter_tui::dashboard::Dashboard) {
+    let policy_view = requested_policy_view(dashboard);
+    let (status, models, requests, providers, agents, observe, policy, reload, authority) = tokio::join!(
+        target.status(),
+        target.models(None),
+        target.requests(RequestFilters::with_limit(DASHBOARD_REQUEST_ROWS)),
+        target.providers(),
+        target.agents(),
+        target.observe(),
+        target.policy(PolicyInput {
+            view: policy_view,
+            name: None,
+        }),
+        target.reload_state(),
+        target.control_authority(),
+    );
+
+    dashboard.target = target.label();
+    dashboard.can_launch_agents = target.allows_agent_launch();
+    apply_status(dashboard, status);
+    apply_models(dashboard, models);
+    apply_requests(dashboard, requests);
+    apply_providers(dashboard, providers);
+    apply_agents(target, dashboard, agents);
+    apply_observe(dashboard, observe);
+    apply_policy(dashboard, policy);
+    apply_reload_state(dashboard, reload);
+    apply_control_authority(dashboard, authority);
+}
+
+fn apply_status(dashboard: &mut bitrouter_tui::dashboard::Dashboard, result: Result<StatusReport>) {
+    match result {
+        Ok(status) => {
+            dashboard.connected = status.running;
+            dashboard.status = if status.running {
+                "running".to_string()
+            } else {
+                "stopped".to_string()
+            };
+            dashboard.pid = status.pid;
+            dashboard.listen = status.listen;
+            dashboard.providers = status.providers;
+            dashboard.spend = status.spend.as_ref().and_then(|spend| {
+                spend.spent.as_ref().map(|spent| {
+                    let amount = crate::metering::fmt_usd(spent.estimated_micro_usd);
+                    if spent.unpriced == 0 {
+                        format!("{amount} {} · {} requests", spent.window, spent.requests)
+                    } else {
+                        format!(
+                            "{amount}+ {} · {} requests · {} unpriced",
+                            spent.window, spent.requests, spent.unpriced
+                        )
+                    }
+                })
+            });
+            mark_success(&mut dashboard.status_refresh);
         }
         Err(error) => {
-            dashboard.connected = false;
-            dashboard.status = "unavailable".to_string();
-            dashboard.refresh_error = Some(error.to_string());
+            if dashboard.status_refresh.updated_at.is_none() {
+                dashboard.connected = false;
+                dashboard.status = "unavailable".to_string();
+            }
+            mark_failure(&mut dashboard.status_refresh, error);
         }
     }
 }
 
-/// Apply only server-owned snapshot fields. Drafts, action diagnostics, and
-/// the active ACP conversation belong to the interactive client and must not
-/// be erased by the background polling cadence.
-fn apply_snapshot(
-    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
-    snapshot: bitrouter_tui::dashboard::Dashboard,
-) {
-    dashboard.target = snapshot.target;
-    dashboard.connected = snapshot.connected;
-    dashboard.status = snapshot.status;
-    dashboard.pid = snapshot.pid;
-    dashboard.listen = snapshot.listen;
-    dashboard.providers = snapshot.providers;
-    dashboard.spend = snapshot.spend;
-    dashboard.models = snapshot.models;
-    dashboard.requests = snapshot.requests;
-    dashboard.refresh_error = None;
+fn apply_models(dashboard: &mut bitrouter_tui::dashboard::Dashboard, result: Result<ModelsReport>) {
+    match result {
+        Ok(report) => {
+            dashboard.models = report
+                .models
+                .into_iter()
+                .map(|model| bitrouter_tui::dashboard::ModelLine {
+                    id: model.id,
+                    providers: model.providers.join(", "),
+                })
+                .collect();
+            mark_success(&mut dashboard.models_refresh);
+        }
+        Err(error) => mark_failure(&mut dashboard.models_refresh, error),
+    }
 }
 
-fn dashboard_from_reports(
-    target: String,
-    status: StatusReport,
-    models: ModelsReport,
-    requests: RequestsReport,
-) -> bitrouter_tui::dashboard::Dashboard {
-    let model_lines = models
-        .models
-        .into_iter()
-        .map(|model| bitrouter_tui::dashboard::ModelLine {
-            id: model.id,
-            providers: model.providers.join(", "),
-        })
-        .collect();
-    let request_lines = requests
-        .rows
-        .iter()
-        .map(|request| {
-            let [time, model, provider, input, output, cost, _latency, status] =
-                request.display_cells();
-            bitrouter_tui::dashboard::RequestLine {
-                time,
-                model,
-                provider,
-                tokens: format!("{input}/{output}"),
-                cost,
-                status,
-            }
-        })
-        .collect();
-    let spend = status.spend.as_ref().and_then(|spend| {
-        spend.spent.as_ref().map(|spent| {
-            let amount = crate::metering::fmt_usd(spent.estimated_micro_usd);
-            if spent.unpriced == 0 {
-                format!("{amount} {} · {} requests", spent.window, spent.requests)
-            } else {
-                format!(
-                    "{amount}+ {} · {} requests · {} unpriced",
-                    spent.window, spent.requests, spent.unpriced
-                )
-            }
-        })
-    });
-    bitrouter_tui::dashboard::Dashboard {
-        target,
-        connected: status.running,
-        status: if status.running {
-            "running".to_string()
-        } else {
-            "stopped".to_string()
-        },
-        pid: status.pid,
-        listen: status.listen,
-        providers: status.providers,
-        spend,
-        models: model_lines,
-        requests: request_lines,
-        route_input: String::new(),
-        route: None,
-        error: None,
-        ..Default::default()
+fn apply_requests(
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    result: Result<RequestsReport>,
+) {
+    match result {
+        Ok(report) => {
+            dashboard.requests = report
+                .rows
+                .iter()
+                .map(|request| {
+                    let [time, model, provider, input, output, cost, _latency, status] =
+                        request.display_cells();
+                    bitrouter_tui::dashboard::RequestLine {
+                        time,
+                        model,
+                        provider,
+                        tokens: format!("{input}/{output}"),
+                        cost,
+                        status,
+                    }
+                })
+                .collect();
+            mark_success(&mut dashboard.requests_refresh);
+        }
+        Err(error) => mark_failure(&mut dashboard.requests_refresh, error),
     }
+}
+
+fn apply_providers(
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    result: Result<ProvidersReport>,
+) {
+    match result {
+        Ok(report) => {
+            dashboard.provider_inventory = report
+                .providers
+                .into_iter()
+                .map(|provider| bitrouter_tui::dashboard::ProviderLine {
+                    id: provider.id,
+                    models: provider.models,
+                    active: provider.active,
+                })
+                .collect();
+            mark_success(&mut dashboard.providers_refresh);
+        }
+        Err(error) => mark_failure(&mut dashboard.providers_refresh, error),
+    }
+}
+
+fn apply_agents(
+    target: &InspectionTarget,
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    result: Result<AgentsReport>,
+) {
+    match result {
+        Ok(report) => {
+            dashboard.agents = agent_lines(target, report);
+            dashboard.selected_agent = dashboard
+                .selected_agent
+                .min(dashboard.agents.len().saturating_sub(1));
+            mark_success(&mut dashboard.agents_refresh);
+        }
+        Err(error) => mark_failure(&mut dashboard.agents_refresh, error),
+    }
+}
+
+fn apply_observe(
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    result: Result<ObserveReport>,
+) {
+    match result {
+        Ok(report) => {
+            dashboard.telemetry = Some(bitrouter_tui::dashboard::TelemetryLine {
+                daemon_reachable: report.daemon_reachable,
+                compiled_in: report.compiled_in,
+                exporter_wired: report.exporter_wired,
+                sampler: sampler_text(&report),
+                metrics_enabled: report.metrics_enabled,
+                header_count: report.header_count,
+                resource_attribute_count: report.resource_attribute_count,
+                api_key_count: report.api_key_count,
+                api_key_cap: report.api_key_cap,
+                user_id_count: report.user_id_count,
+                user_id_cap: report.user_id_cap,
+                active_spans: report.active_spans,
+            });
+            mark_success(&mut dashboard.telemetry_refresh);
+        }
+        Err(error) => mark_failure(&mut dashboard.telemetry_refresh, error),
+    }
+}
+
+fn apply_policy(dashboard: &mut bitrouter_tui::dashboard::Dashboard, result: Result<PolicyReport>) {
+    match result {
+        Ok(report) => {
+            let selected_name = dashboard
+                .policy
+                .as_ref()
+                .and_then(|policy| policy.policies.get(dashboard.selected_policy))
+                .cloned();
+            let view = report.view;
+            let policies = report.policies;
+            let selected_policy = match selected_name
+                .as_ref()
+                .and_then(|name| policies.iter().position(|candidate| candidate == name))
+            {
+                Some(index) => index,
+                None => dashboard
+                    .selected_policy
+                    .min(policies.len().saturating_sub(1)),
+            };
+            if dashboard
+                .policy_detail
+                .as_ref()
+                .is_some_and(|detail| !policies.contains(&detail.name))
+            {
+                dashboard.policy_detail = None;
+                dashboard.policy_scroll = 0;
+            }
+            dashboard.policy = Some(bitrouter_tui::dashboard::PolicyLine {
+                view: policy_view_text(view).to_string(),
+                availability: report.availability,
+                digest: report.digest,
+                mode: report.mode,
+                policies,
+                bindings: report.bindings.into_iter().collect(),
+            });
+            dashboard.policy_view = policy_view_selection(view);
+            dashboard.selected_policy = selected_policy;
+            mark_success(&mut dashboard.policy_refresh);
+        }
+        Err(error) => mark_failure(&mut dashboard.policy_refresh, error),
+    }
+}
+
+fn apply_policy_detail(
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    name: &str,
+    result: Result<PolicyReport>,
+) {
+    match result {
+        Ok(mut report) => {
+            let detail = report.definitions.remove(name).ok_or_else(|| {
+                anyhow::anyhow!("policy detail response did not contain the selected policy")
+            });
+            match detail {
+                Ok(detail) => {
+                    dashboard.policy_detail = Some(policy_detail_line(name.to_string(), detail));
+                    dashboard.policy_scroll = 0;
+                    mark_success(&mut dashboard.policy_detail_refresh);
+                }
+                Err(error) => mark_failure(&mut dashboard.policy_detail_refresh, error),
+            }
+        }
+        Err(error) => mark_failure(&mut dashboard.policy_detail_refresh, error),
+    }
+}
+
+fn apply_control_authority(
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    result: Result<ControlAuthority>,
+) {
+    match result {
+        Ok(authority) => {
+            dashboard.control_read_authorized = Some(authority.read);
+            dashboard.control_reload_authorized = Some(authority.reload);
+            mark_success(&mut dashboard.authority_refresh);
+        }
+        Err(error) => mark_failure(&mut dashboard.authority_refresh, error),
+    }
+}
+
+fn policy_detail_line(
+    name: String,
+    detail: PolicyDetail,
+) -> bitrouter_tui::dashboard::PolicyDetailLine {
+    bitrouter_tui::dashboard::PolicyDetailLine {
+        name,
+        tiers: detail
+            .tiers
+            .into_iter()
+            .map(|(tier, target)| bitrouter_tui::dashboard::PolicyTierLine {
+                tier,
+                target: target.to_string(),
+            })
+            .collect(),
+        routes: detail
+            .routes
+            .into_iter()
+            .map(|(route, tier)| bitrouter_tui::dashboard::PolicyRouteLine { route, tier })
+            .collect(),
+        default_tier: detail.default_tier,
+        tool_use_tier: detail.tool_use_tier,
+        tool_safe_tiers: detail.tool_safe_tiers,
+        certificates: detail
+            .certificates
+            .into_iter()
+            .map(
+                |(name, certificate)| bitrouter_tui::dashboard::PolicyCertificateLine {
+                    name,
+                    selected_tier: certificate.selected_tier,
+                    evidence_digest: certificate.evidence_digest,
+                    compiler_config_digest: certificate.compiler_config_digest,
+                    evaluator_config_digest: certificate.evaluator_config_digest,
+                },
+            )
+            .collect(),
+    }
+}
+
+fn requested_policy_view(dashboard: &bitrouter_tui::dashboard::Dashboard) -> PolicyView {
+    match dashboard.policy_view {
+        bitrouter_tui::dashboard::PolicyViewSelection::Active => PolicyView::Active,
+        bitrouter_tui::dashboard::PolicyViewSelection::Disk => PolicyView::Disk,
+    }
+}
+
+fn policy_view_selection(view: PolicyView) -> bitrouter_tui::dashboard::PolicyViewSelection {
+    match view {
+        PolicyView::Active => bitrouter_tui::dashboard::PolicyViewSelection::Active,
+        PolicyView::Disk => bitrouter_tui::dashboard::PolicyViewSelection::Disk,
+    }
+}
+
+fn apply_reload_state(
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    result: Result<ReloadState>,
+) {
+    match result {
+        Ok(state) => {
+            dashboard.reload = Some(reload_line(state));
+            mark_success(&mut dashboard.reload_refresh);
+        }
+        Err(error) => mark_failure(&mut dashboard.reload_refresh, error),
+    }
+}
+
+fn start_reload(
+    target: &InspectionTarget,
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    reload_task: &mut Option<ReloadTask>,
+) {
+    if reload_task.is_some() {
+        return;
+    }
+    if dashboard.control_reload_authorized == Some(false) {
+        mark_failure(
+            &mut dashboard.reload_action,
+            anyhow::anyhow!(
+                "this control credential does not grant reload; refresh capability discovery after its scope changes"
+            ),
+        );
+        return;
+    }
+
+    dashboard.reload_in_flight = true;
+    dashboard.reload_action.error = None;
+    let (sender, updates) = tokio::sync::mpsc::unbounded_channel();
+    let target = target.clone();
+    let handle = tokio::spawn(async move {
+        run_reload_task(target, sender).await;
+    });
+    *reload_task = Some(ReloadTask { updates, handle });
+}
+
+async fn next_reload_update(reload_task: &mut Option<ReloadTask>) -> Option<ReloadUpdate> {
+    match reload_task {
+        Some(task) => task.updates.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn run_reload_task(
+    target: InspectionTarget,
+    updates: tokio::sync::mpsc::UnboundedSender<ReloadUpdate>,
+) {
+    if target.is_remote() {
+        run_remote_reload_task(target, updates).await;
+        return;
+    }
+
+    match target.reload().await {
+        Ok(ReloadSubmission::Local(state)) => {
+            let _ = updates.send(ReloadUpdate::LocalFinished(state));
+        }
+        Ok(ReloadSubmission::Remote(_)) => {
+            let _ = updates.send(ReloadUpdate::Failed(
+                "local reload action resolved to a remote operation".to_string(),
+            ));
+        }
+        Err(error) => {
+            let _ = updates.send(ReloadUpdate::Failed(error.to_string()));
+        }
+    }
+}
+
+async fn run_remote_reload_task(
+    target: InspectionTarget,
+    updates: tokio::sync::mpsc::UnboundedSender<ReloadUpdate>,
+) {
+    let state = match target.reload_state().await {
+        Ok(state) => state,
+        Err(error) => {
+            let _ = updates.send(ReloadUpdate::Failed(error.to_string()));
+            return;
+        }
+    };
+    let input = ReloadInput {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        expected_server_instance_id: state.server_instance_id.clone(),
+        expected_generation: state.generation,
+    };
+    if updates
+        .send(ReloadUpdate::Prepared {
+            request_id: input.request_id.clone(),
+            server_instance_id: input.expected_server_instance_id.clone(),
+            generation_before: input.expected_generation,
+        })
+        .is_err()
+    {
+        return;
+    }
+
+    let mut report = match target.submit_remote_reload(&input).await {
+        Ok(report) => report,
+        Err(error) => {
+            let _ = updates.send(ReloadUpdate::Failed(format!(
+                "reload submission may be unknown for request {} on instance {}; inspect \
+                 operations/{}?instance={}: {error}",
+                input.request_id,
+                input.expected_server_instance_id,
+                input.request_id,
+                input.expected_server_instance_id,
+            )));
+            return;
+        }
+    };
+    if updates
+        .send(ReloadUpdate::RemoteSubmitted(report.clone()))
+        .is_err()
+    {
+        return;
+    }
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    while report.is_running() {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        tokio::time::sleep(remaining.min(Duration::from_millis(250))).await;
+        match target
+            .operation(&input.request_id, &input.expected_server_instance_id)
+            .await
+        {
+            Ok(next) => report = next,
+            Err(error) => {
+                let _ = updates.send(ReloadUpdate::Failed(format!(
+                    "reload outcome may be unknown for request {} on instance {}; inspect \
+                     operations/{}?instance={}: {error}",
+                    input.request_id,
+                    input.expected_server_instance_id,
+                    input.request_id,
+                    input.expected_server_instance_id,
+                )));
+                return;
+            }
+        }
+    }
+    let _ = updates.send(ReloadUpdate::RemoteFinished(report));
+}
+
+fn apply_reload_update(dashboard: &mut bitrouter_tui::dashboard::Dashboard, update: ReloadUpdate) {
+    match update {
+        ReloadUpdate::Prepared {
+            request_id,
+            server_instance_id,
+            generation_before,
+        } => {
+            dashboard.reload_operation = Some(bitrouter_tui::dashboard::ReloadOperationLine {
+                lookup: format!("operations/{request_id}?instance={server_instance_id}"),
+                request_id,
+                server_instance_id,
+                generation_before,
+                status: "submitting".to_string(),
+                completed_at_unix_ms: None,
+            });
+        }
+        ReloadUpdate::RemoteSubmitted(operation) => {
+            dashboard.reload_operation = Some(operation_line(operation));
+        }
+        ReloadUpdate::RemoteFinished(operation) => {
+            let diagnostic = operation_diagnostic(&operation);
+            dashboard.reload_operation = Some(operation_line(operation));
+            dashboard.reload_in_flight = false;
+            finish_reload_action(dashboard, diagnostic);
+        }
+        ReloadUpdate::LocalFinished(state) => {
+            let diagnostic = reload_state_diagnostic(&state);
+            dashboard.reload = Some(reload_line(state));
+            mark_success(&mut dashboard.reload_refresh);
+            dashboard.reload_in_flight = false;
+            finish_reload_action(dashboard, diagnostic);
+        }
+        ReloadUpdate::Failed(error) => {
+            dashboard.reload_in_flight = false;
+            mark_failure(&mut dashboard.reload_action, anyhow::anyhow!(error));
+        }
+    }
+}
+
+fn finish_reload_action(
+    dashboard: &mut bitrouter_tui::dashboard::Dashboard,
+    diagnostic: Option<String>,
+) {
+    match diagnostic {
+        Some(diagnostic) => mark_failure(&mut dashboard.reload_action, anyhow::anyhow!(diagnostic)),
+        None => mark_success(&mut dashboard.reload_action),
+    }
+}
+
+fn reload_line(state: ReloadState) -> bitrouter_tui::dashboard::ReloadLine {
+    let (last_outcome, participants, restart_required_fields) =
+        state.last_outcome.as_ref().map_or_else(
+            || (None, Vec::new(), Vec::new()),
+            |report| {
+                (
+                    Some(reload_outcome_text(report.outcome).to_string()),
+                    report
+                        .participants
+                        .iter()
+                        .map(
+                            |participant| bitrouter_tui::dashboard::ReloadParticipantLine {
+                                participant: reload_participant_text(participant.participant)
+                                    .to_string(),
+                                outcome: reload_participant_outcome_text(participant.outcome)
+                                    .to_string(),
+                                detail: participant
+                                    .error
+                                    .as_ref()
+                                    .map(|error| format!("{}: {}", error.code, error.message)),
+                            },
+                        )
+                        .collect(),
+                    report.restart_required_fields.clone(),
+                )
+            },
+        );
+    bitrouter_tui::dashboard::ReloadLine {
+        server_instance_id: state.server_instance_id,
+        generation: state.generation,
+        running: state.running,
+        running_generation: state.running_generation,
+        consistency: reload_consistency_text(state.consistency).to_string(),
+        last_outcome,
+        participants,
+        restart_required_fields,
+        mixed_state_history: state.mixed_state_history.len(),
+    }
+}
+
+fn operation_line(report: OperationReport) -> bitrouter_tui::dashboard::ReloadOperationLine {
+    bitrouter_tui::dashboard::ReloadOperationLine {
+        request_id: report.request_id,
+        server_instance_id: report.server_instance_id,
+        generation_before: report.generation_before,
+        status: operation_status_text(report.status).to_string(),
+        lookup: report.lookup_url,
+        completed_at_unix_ms: report.completed_at_unix_ms,
+    }
+}
+
+fn reload_state_diagnostic(state: &ReloadState) -> Option<String> {
+    if state.consistency == ReloadConsistency::Mixed {
+        return Some(
+            "reload left a mixed runtime state; inspect participant results before retrying"
+                .to_string(),
+        );
+    }
+    state
+        .last_outcome
+        .as_ref()
+        .and_then(|report| match report.outcome {
+            ReloadOutcome::Succeeded => None,
+            ReloadOutcome::Failed => Some(
+                "reload failed before applying every requested change; inspect participant results"
+                    .to_string(),
+            ),
+            ReloadOutcome::PartiallyApplied => Some(
+                "reload partially applied; inspect participant results before retrying".to_string(),
+            ),
+            ReloadOutcome::Unknown => {
+                Some("reload outcome is unknown; inspect current state before retrying".to_string())
+            }
+        })
+}
+
+fn operation_diagnostic(report: &OperationReport) -> Option<String> {
+    match report.status {
+        OperationStatus::Succeeded => None,
+        OperationStatus::Running => Some(format!(
+            "reload is still running; inspect {} before submitting another reload",
+            report.lookup_url
+        )),
+        OperationStatus::Failed => Some(format!(
+            "reload failed; inspect {} before retrying",
+            report.lookup_url
+        )),
+        OperationStatus::PartiallyApplied => Some(format!(
+            "reload partially applied; inspect {} before retrying",
+            report.lookup_url
+        )),
+        OperationStatus::Unknown => Some(format!(
+            "reload outcome is unknown; inspect {} before retrying",
+            report.lookup_url
+        )),
+    }
+}
+
+fn reload_consistency_text(consistency: ReloadConsistency) -> &'static str {
+    match consistency {
+        ReloadConsistency::Consistent => "consistent",
+        ReloadConsistency::Mixed => "mixed",
+    }
+}
+
+fn reload_outcome_text(outcome: ReloadOutcome) -> &'static str {
+    match outcome {
+        ReloadOutcome::Succeeded => "succeeded",
+        ReloadOutcome::Failed => "failed",
+        ReloadOutcome::PartiallyApplied => "partially_applied",
+        ReloadOutcome::Unknown => "unknown",
+    }
+}
+
+fn reload_participant_text(participant: ReloadParticipant) -> &'static str {
+    match participant {
+        ReloadParticipant::RoutingTable => "routing_table",
+        ReloadParticipant::UpstreamTimeoutClients => "upstream_timeout_clients",
+        ReloadParticipant::PolicyTable => "policy_table",
+        ReloadParticipant::NamedPolicyRuntime => "named_policy_runtime",
+        ReloadParticipant::AccessPolicyStore => "access_policy_store",
+    }
+}
+
+fn reload_participant_outcome_text(outcome: ReloadParticipantOutcome) -> &'static str {
+    match outcome {
+        ReloadParticipantOutcome::Applied => "applied",
+        ReloadParticipantOutcome::Unchanged => "unchanged",
+        ReloadParticipantOutcome::Failed => "failed",
+        ReloadParticipantOutcome::NotAttempted => "not_attempted",
+    }
+}
+
+fn operation_status_text(status: OperationStatus) -> &'static str {
+    match status {
+        OperationStatus::Running => "running",
+        OperationStatus::Succeeded => "succeeded",
+        OperationStatus::Failed => "failed",
+        OperationStatus::PartiallyApplied => "partially_applied",
+        OperationStatus::Unknown => "unknown",
+    }
+}
+
+fn sampler_text(report: &ObserveReport) -> Option<String> {
+    report
+        .sampler
+        .as_ref()
+        .map(|sampler| match report.sampler_arg {
+            Some(argument) => format!("{sampler} ({argument})"),
+            None => sampler.clone(),
+        })
+}
+
+fn policy_view_text(view: PolicyView) -> &'static str {
+    match view {
+        PolicyView::Active => "active",
+        PolicyView::Disk => "disk",
+    }
+}
+
+fn mark_success(state: &mut bitrouter_tui::dashboard::RefreshState) {
+    state.updated_at = Some(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+    state.error = None;
+}
+
+fn mark_failure(state: &mut bitrouter_tui::dashboard::RefreshState, error: anyhow::Error) {
+    state.error = Some(error.to_string());
 }
 
 fn route_line(report: RouteReport) -> bitrouter_tui::dashboard::RouteLine {
@@ -741,26 +1425,156 @@ mod tests {
     use super::*;
 
     #[test]
-    fn snapshot_refresh_preserves_interactive_diagnostics() {
+    fn control_inventory_dashboard_contract_matches_reachable_pages() -> anyhow::Result<()> {
+        use crate::remote_control::inventory::{self, Action};
+        use bitrouter_tui::dashboard::Page;
+
+        let contracts = [
+            (Action::Status, "overview", Page::Home),
+            (Action::Models, "models", Page::Models),
+            (Action::Route, "preview", Page::Route),
+            (Action::Requests, "requests", Page::Requests),
+            (Action::Providers, "providers", Page::Providers),
+            (Action::Observe, "telemetry", Page::Telemetry),
+            (Action::PolicyStatus, "policy", Page::Policy),
+            (Action::PolicyShow, "policy", Page::Policy),
+            (Action::Agents, "agents", Page::Agents),
+            (Action::Reload, "reload", Page::Reload),
+        ];
+        if inventory::ACTIONS.len() != contracts.len() {
+            anyhow::bail!(
+                "control inventory has {} actions but the dashboard contract maps {}",
+                inventory::ACTIONS.len(),
+                contracts.len()
+            );
+        }
+
+        for (action, label, page) in contracts {
+            let mut matches = inventory::ACTIONS.iter().filter(|row| row.action == action);
+            let row = matches.next().ok_or_else(|| {
+                anyhow::anyhow!("control inventory has no dashboard contract for {action:?}")
+            })?;
+            if matches.next().is_some() {
+                anyhow::bail!("control inventory has multiple dashboard contracts for {action:?}");
+            }
+            if row.dashboard != label {
+                anyhow::bail!(
+                    "control action `{}` advertises dashboard `{}`, expected `{label}`",
+                    row.id,
+                    row.dashboard
+                );
+            }
+
+            let mut current = Page::Home;
+            let mut reachable = false;
+            for _ in 0..=contracts.len() {
+                if current == page {
+                    reachable = true;
+                    break;
+                }
+                current = current.next();
+            }
+            if !reachable {
+                anyhow::bail!(
+                    "control action `{}` names an unreachable dashboard page `{label}`",
+                    row.id
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn failed_panel_refresh_keeps_other_panels_and_diagnostics() {
         let mut dashboard = bitrouter_tui::dashboard::Dashboard {
             error: Some("Could not start agent".to_string()),
-            refresh_error: Some("connection interrupted".to_string()),
             notice: Some("routing fallback".to_string()),
-            ..Default::default()
-        };
-        let snapshot = bitrouter_tui::dashboard::Dashboard {
-            target: "local".to_string(),
-            connected: true,
-            status: "running".to_string(),
+            models: vec![bitrouter_tui::dashboard::ModelLine {
+                id: "active-model".to_string(),
+                providers: "primary".to_string(),
+            }],
+            providers_refresh: bitrouter_tui::dashboard::RefreshState {
+                updated_at: Some("2026-09-08T00:00:00Z".to_string()),
+                error: None,
+            },
             ..Default::default()
         };
 
-        apply_snapshot(&mut dashboard, snapshot);
+        mark_failure(
+            &mut dashboard.providers_refresh,
+            anyhow::anyhow!("provider read interrupted"),
+        );
 
         assert_eq!(dashboard.error.as_deref(), Some("Could not start agent"));
         assert_eq!(dashboard.notice.as_deref(), Some("routing fallback"));
-        assert_eq!(dashboard.refresh_error, None);
-        assert!(dashboard.connected);
+        assert_eq!(dashboard.models[0].id, "active-model");
+        assert_eq!(
+            dashboard.providers_refresh.error.as_deref(),
+            Some("provider read interrupted")
+        );
+        assert_eq!(
+            dashboard.providers_refresh.updated_at.as_deref(),
+            Some("2026-09-08T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn refreshed_capability_scope_reenables_reload() {
+        let mut dashboard = bitrouter_tui::dashboard::Dashboard::default();
+
+        apply_control_authority(
+            &mut dashboard,
+            Ok(ControlAuthority {
+                read: true,
+                reload: false,
+            }),
+        );
+        assert_eq!(dashboard.control_reload_authorized, Some(false));
+
+        apply_control_authority(
+            &mut dashboard,
+            Ok(ControlAuthority {
+                read: true,
+                reload: true,
+            }),
+        );
+        assert_eq!(dashboard.control_read_authorized, Some(true));
+        assert_eq!(dashboard.control_reload_authorized, Some(true));
+        assert!(dashboard.authority_refresh.error.is_none());
+    }
+
+    #[test]
+    fn reload_transport_failure_keeps_the_prepared_lookup() -> anyhow::Result<()> {
+        let mut dashboard = bitrouter_tui::dashboard::Dashboard {
+            reload_in_flight: true,
+            ..Default::default()
+        };
+        apply_reload_update(
+            &mut dashboard,
+            ReloadUpdate::Prepared {
+                request_id: "request-id".to_string(),
+                server_instance_id: "instance-id".to_string(),
+                generation_before: 7,
+            },
+        );
+        apply_reload_update(
+            &mut dashboard,
+            ReloadUpdate::Failed("transport disconnected".to_string()),
+        );
+
+        let Some(operation) = dashboard.reload_operation.as_ref() else {
+            return Err(anyhow::anyhow!("prepared reload operation was lost"));
+        };
+        assert_eq!(operation.request_id, "request-id");
+        assert_eq!(operation.server_instance_id, "instance-id");
+        assert_eq!(operation.status, "submitting");
+        assert!(operation.lookup.contains("request-id?instance=instance-id"));
+        assert!(!dashboard.reload_in_flight);
+        assert_eq!(
+            dashboard.reload_action.error.as_deref(),
+            Some("transport disconnected")
+        );
+        Ok(())
     }
 
     #[test]

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -14,6 +14,7 @@ pub mod acp_cli;
 pub mod acp_runtime;
 pub mod actions;
 pub mod adequacy;
+pub mod administration_target;
 pub mod agent_registry;
 pub mod agents;
 pub mod assemble;

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -20,6 +20,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
+use bitrouter::actions::administration::{PolicyInput, PolicyView};
+use bitrouter::actions::requests::RequestFilters;
+use bitrouter::administration_target::{InspectionTarget, ReloadSubmission};
 use bitrouter::commands;
 use bitrouter::daemon::{self, DaemonCommand, DaemonResponse};
 use bitrouter::output::reports::admin::{
@@ -40,7 +43,6 @@ use bitrouter::output::reports::optimization::{
     ArmReport, OptimizationControllerReport, TreatmentReport,
 };
 use bitrouter::output::reports::policy::PolicyReport;
-use bitrouter::output::reports::requests::RequestsReport;
 use bitrouter::output::reports::routing::{ProviderRow, ProvidersReport};
 use bitrouter::output::reports::tools::{
     ServerStatusView, ServerToolsView, ToolInfo, ToolsDiscoverReport, ToolsListReport,
@@ -51,9 +53,8 @@ use bitrouter::output::reports::trajectory::{
     replay_report as trajectory_replay_report,
 };
 use bitrouter::output::{CliReport, Output};
-use bitrouter_mcp::actions::models::ModelsReport;
-use bitrouter_mcp::actions::route::{RouteInput, RouteReport};
-use bitrouter_mcp::actions::status::StatusReport;
+use bitrouter::remote_control::operations::{OperationReport, OperationStatus};
+use bitrouter_mcp::actions::route::RouteInput;
 use bitrouter_sdk::config;
 
 async fn supervise_http_shutdown<Http, Control, Hup, Term>(
@@ -259,6 +260,11 @@ enum Command {
         #[arg(long)]
         socket: Option<PathBuf>,
     },
+    /// Inspect a retained remote administration operation.
+    Operations {
+        #[command(subcommand)]
+        action: OperationsAction,
+    },
     /// Report a running daemon's status (pid, listen address, model count).
     /// Prints `running: no` when no daemon is reachable.
     ///
@@ -285,6 +291,18 @@ enum Command {
         /// Maximum number of recent requests to return.
         #[arg(long, default_value_t = bitrouter::actions::requests::MAX_REQUEST_ROWS)]
         limit: u64,
+        /// Inclusive RFC3339 lower bound. Requires `--until`.
+        #[arg(long)]
+        since: Option<String>,
+        /// Exclusive RFC3339 upper bound. Requires `--since`.
+        #[arg(long)]
+        until: Option<String>,
+        /// Keep only requests resolved to this model id.
+        #[arg(long)]
+        model: Option<String>,
+        /// Keep only requests served by this provider id.
+        #[arg(long)]
+        provider: Option<String>,
         /// Path to `bitrouter.yaml` (used to locate the local control socket).
         #[arg(short, long)]
         config: Option<PathBuf>,
@@ -1052,6 +1070,9 @@ enum AgentsAction {
         /// (`bitrouter init` is the explicit way to scaffold a file).
         #[arg(short, long)]
         config: Option<PathBuf>,
+        /// Explicit local control socket for the daemon's accepted catalog.
+        #[arg(long)]
+        socket: Option<PathBuf>,
     },
     /// Inspect commands advertised by a fresh ACP session.
     Inspect {
@@ -1175,6 +1196,18 @@ enum KeyAction {
 }
 
 #[derive(Subcommand)]
+enum OperationsAction {
+    /// Show one retained reload operation owned by this credential.
+    Show {
+        /// Reload request UUID returned by `bitrouter reload`.
+        request_id: String,
+        /// Daemon boot instance UUID returned with the operation.
+        #[arg(long)]
+        instance: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum PolicyAction {
     /// Write a starter access-control policy file to the policy dir.
     Create {
@@ -1221,14 +1254,26 @@ enum PolicyAction {
     },
     /// Show policy path, digest, runtime mode, and preset bindings.
     Status {
+        /// Read `disk` locally by default; a remote context defaults to `active`.
+        #[arg(long, value_enum)]
+        view: Option<PolicyViewArg>,
         #[arg(short, long)]
         config: Option<PathBuf>,
+        /// Explicit local control socket for an active policy read.
+        #[arg(long)]
+        socket: Option<PathBuf>,
     },
     /// Show one named policy after validation.
     Show {
         name: String,
+        /// Read `disk` locally by default; a remote context defaults to `active`.
+        #[arg(long, value_enum)]
+        view: Option<PolicyViewArg>,
         #[arg(short, long)]
         config: Option<PathBuf>,
+        /// Explicit local control socket for an active policy read.
+        #[arg(long)]
+        socket: Option<PathBuf>,
     },
     /// Hot-reload the policy lock through the daemon control socket.
     Reload {
@@ -1280,6 +1325,23 @@ enum PolicyAction {
         #[arg(long)]
         socket: Option<PathBuf>,
     },
+}
+
+/// CLI spelling for the typed policy source.  The action contract itself stays
+/// free of clap concerns in `actions::administration`.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum PolicyViewArg {
+    Active,
+    Disk,
+}
+
+impl From<PolicyViewArg> for PolicyView {
+    fn from(view: PolicyViewArg) -> Self {
+        match view {
+            PolicyViewArg::Active => Self::Active,
+            PolicyViewArg::Disk => Self::Disk,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -1434,6 +1496,9 @@ enum ProviderAction {
         /// (`bitrouter init` is the explicit way to scaffold a file).
         #[arg(short, long)]
         config: Option<PathBuf>,
+        /// Explicit local control socket for the daemon's accepted provider catalog.
+        #[arg(long)]
+        socket: Option<PathBuf>,
     },
     /// Log in to an upstream provider — interactive credential setup.
     ///
@@ -1747,8 +1812,7 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
     let Some(command) = cli.command else {
         if cli.context.as_deref().is_some_and(|name| name != "local") {
             return Err(bitrouter_sdk::BitrouterError::bad_request(
-                "a remote context requires an explicit supported action: `status`, `requests`, \
-                 `models`, `route`, or `code`",
+                "a remote context requires an explicit administration action",
             )
             .into());
         }
@@ -1772,27 +1836,7 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             .transpose()?
             .flatten()
     };
-    if remote_context.is_some()
-        && !matches!(
-            &command,
-            Command::Status { .. }
-                | Command::Requests { .. }
-                | Command::Route { .. }
-                | Command::Models { .. }
-                | Command::Code {
-                    options: CodeArgs { agent: None, .. },
-                }
-                | Command::Tui {
-                    options: CodeArgs { agent: None, .. },
-                }
-        )
-    {
-        return Err(bitrouter_sdk::BitrouterError::bad_request(
-            "this command is local-only; remote contexts support `status`, `requests`, \
-             `models`, `route`, and `code`",
-        )
-        .into());
-    }
+    validate_remote_invocation(&command, remote_context.is_some())?;
 
     match command {
         Command::Serve { config } => {
@@ -1822,9 +1866,40 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             Ok(())
         }
         Command::Reload { config, socket } => {
+            if remote_context.is_some() {
+                let target = inspection_target(
+                    remote_context.as_ref(),
+                    cli.context.as_deref(),
+                    config.as_deref(),
+                    socket.as_deref(),
+                )
+                .await?;
+                let ReloadSubmission::Remote(report) = target.reload().await? else {
+                    anyhow::bail!("remote reload resolved to a local control target")
+                };
+                return emit_operation_result(output, &report);
+            }
             let socket = resolve_client_socket(config.as_deref(), socket.as_deref()).await?;
             output.emit(&reload(&socket).await?)?;
             Ok(())
+        }
+        Command::Operations { action } => {
+            let remote = remote_context.as_ref().ok_or_else(|| {
+                bitrouter_sdk::BitrouterError::bad_request(
+                    "`operations show` requires a named remote context",
+                )
+            })?;
+            let target =
+                inspection_target(Some(remote), cli.context.as_deref(), None, None).await?;
+            match action {
+                OperationsAction::Show {
+                    request_id,
+                    instance,
+                } => {
+                    let report = target.operation(&request_id, &instance).await?;
+                    emit_operation_result(output, &report)
+                }
+            }
         }
         Command::Status {
             config,
@@ -1837,42 +1912,47 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
                      `bitrouter requests`."
                 );
             }
-            if let Some(context) = &remote_context {
-                reject_remote_local_target_flags(config.as_deref(), socket.as_deref())?;
-                if requests {
-                    output.emit(&context.client()?.requests(None).await?)?;
-                } else {
-                    output.emit(&context.client()?.status().await?)?;
-                }
-                return Ok(());
-            }
-            let socket = resolve_client_socket(config.as_deref(), socket.as_deref()).await?;
+            let target = inspection_target(
+                remote_context.as_ref(),
+                cli.context.as_deref(),
+                config.as_deref(),
+                socket.as_deref(),
+            )
+            .await?;
             if requests {
-                output.emit(
-                    &request_table(
-                        config.as_deref(),
-                        &socket,
-                        bitrouter::actions::requests::MAX_REQUEST_ROWS,
-                    )
-                    .await?,
-                )?;
+                output.emit(&target.requests(RequestFilters::default()).await?)?;
             } else {
-                output.emit(&status(config.as_deref(), &socket).await?)?;
+                output.emit(&target.status().await?)?;
             }
             Ok(())
         }
         Command::Requests {
             limit,
+            since,
+            until,
+            model,
+            provider,
             config,
             socket,
         } => {
-            if let Some(context) = &remote_context {
-                reject_remote_local_target_flags(config.as_deref(), socket.as_deref())?;
-                output.emit(&context.client()?.requests(Some(limit)).await?)?;
-                return Ok(());
-            }
-            let socket = resolve_client_socket(config.as_deref(), socket.as_deref()).await?;
-            output.emit(&request_table(config.as_deref(), &socket, limit).await?)?;
+            let target = inspection_target(
+                remote_context.as_ref(),
+                cli.context.as_deref(),
+                config.as_deref(),
+                socket.as_deref(),
+            )
+            .await?;
+            output.emit(
+                &target
+                    .requests(RequestFilters {
+                        limit,
+                        since,
+                        until,
+                        model,
+                        provider,
+                    })
+                    .await?,
+            )?;
             Ok(())
         }
         Command::Route {
@@ -1881,19 +1961,14 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             config,
             socket,
         } => {
-            if let Some(context) = &remote_context {
-                reject_remote_local_target_flags(config.as_deref(), socket.as_deref())?;
-                output.emit(
-                    &context
-                        .client()?
-                        .route(&RouteInput { model, prompt })
-                        .await?,
-                )?;
-                return Ok(());
-            }
-            let source = bitrouter::paths::resolve_config(config.as_deref())?;
-            let socket = resolve_client_socket_from(&source, socket.as_deref()).await?;
-            output.emit(&route(RouteInput { model, prompt }, &source, &socket).await?)?;
+            let target = inspection_target(
+                remote_context.as_ref(),
+                cli.context.as_deref(),
+                config.as_deref(),
+                socket.as_deref(),
+            )
+            .await?;
+            output.emit(&target.route(RouteInput { model, prompt }).await?)?;
             Ok(())
         }
         Command::Init {
@@ -1940,13 +2015,14 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             Ok(())
         }
         Command::Models { config, provider } => {
-            if let Some(context) = &remote_context {
-                reject_remote_local_target_flags(config.as_deref(), None)?;
-                output.emit(&context.client()?.models(provider.as_deref()).await?)?;
-                return Ok(());
-            }
-            let source = bitrouter::paths::resolve_config(config.as_deref())?;
-            output.emit(&models(&source, provider.as_deref()).await?)?;
+            let target = inspection_target(
+                remote_context.as_ref(),
+                cli.context.as_deref(),
+                config.as_deref(),
+                None,
+            )
+            .await?;
+            output.emit(&target.models(provider.as_deref()).await?)?;
             Ok(())
         }
         Command::Context { action } => {
@@ -1965,15 +2041,47 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             Ok(())
         }
         Command::Tools { action } => tools(action, output).await,
-        Command::Observe { action } => observe(action, output).await,
-        Command::Policy { action } => policy(action, output).await,
+        Command::Observe { action } => {
+            administration_observe(
+                action,
+                output,
+                remote_context.as_ref(),
+                cli.context.as_deref(),
+            )
+            .await
+        }
+        Command::Policy { action } => {
+            administration_policy(
+                action,
+                output,
+                remote_context.as_ref(),
+                cli.context.as_deref(),
+            )
+            .await
+        }
         Command::Eval { action } => eval(action, output).await,
         Command::Optimize { action } => optimize(action, output).await,
         Command::Trajectory { config, action } => {
             trajectory(config.as_deref(), action, output).await
         }
-        Command::Providers { action } => providers(action, output).await,
-        Command::Agents { action } => agents_cmd(action, output).await,
+        Command::Providers { action } => {
+            administration_providers(
+                action,
+                output,
+                remote_context.as_ref(),
+                cli.context.as_deref(),
+            )
+            .await
+        }
+        Command::Agents { action } => {
+            administration_agents(
+                action,
+                output,
+                remote_context.as_ref(),
+                cli.context.as_deref(),
+            )
+            .await
+        }
         Command::Launch {
             agent,
             agent_compat,
@@ -3273,14 +3381,149 @@ async fn resolve_client_socket_from(
 }
 
 fn reject_remote_local_target_flags(config: Option<&Path>, socket: Option<&Path>) -> Result<()> {
-    if config.is_some() || socket.is_some() {
-        return Err(bitrouter_sdk::BitrouterError::bad_request(
-            "a remote context does not accept --config or --socket; the named context is the \
-             complete target",
-        )
-        .into());
+    bitrouter::administration_target::reject_remote_local_flags(config, socket)
+}
+
+fn emit_operation_result(output: &Output, report: &OperationReport) -> Result<()> {
+    output.emit(report)?;
+    if report.succeeded() {
+        return Ok(());
     }
-    Ok(())
+    let status = match report.status {
+        OperationStatus::Running => "is still running",
+        OperationStatus::Failed => "failed",
+        OperationStatus::PartiallyApplied => "partially applied",
+        OperationStatus::Unknown => "has an unknown outcome",
+        OperationStatus::Succeeded => "succeeded",
+    };
+    anyhow::bail!(
+        "reload {status}; inspect `bitrouter --context <name> operations show {} --instance {}` before retrying",
+        report.request_id,
+        report.server_instance_id
+    )
+}
+
+/// Validate remote eligibility and target flags before any command branch can
+/// load a local config, provider environment, or database.  The named context
+/// is the complete target; administration reads are passive and explicitly
+/// represented by the control inventory rather than an independent CLI list.
+fn validate_remote_invocation(command: &Command, remote: bool) -> Result<()> {
+    if !remote {
+        return Ok(());
+    }
+    match command {
+        Command::Agents {
+            action:
+                AgentsAction::List {
+                    remote: true, ..
+                },
+        } => Err(bitrouter_sdk::BitrouterError::bad_request(
+            "`agents list --remote` fetches the external ACP registry and cannot run against a remote BitRouter context",
+        )
+        .into()),
+        Command::Agents {
+            action:
+                AgentsAction::List {
+                    remote: false,
+                    config,
+                    socket,
+                },
+        } => reject_remote_local_target_flags(config.as_deref(), socket.as_deref()),
+        Command::Agents {
+            action: AgentsAction::Check { .. },
+        } => Err(bitrouter_sdk::BitrouterError::bad_request(
+            "`agents check` launches an agent and is unavailable for a remote context",
+        )
+        .into()),
+        Command::Code { options } | Command::Tui { options } if options.agent.is_none() => {
+            reject_remote_local_target_flags(options.config.as_deref(), options.socket.as_deref())
+        }
+        _ => {
+            if let Some(leaf) = remote_cli_leaf(command) {
+                bitrouter::remote_control::inventory::by_cli(leaf).ok_or_else(|| {
+                    anyhow::anyhow!("control inventory has no action for CLI leaf `{leaf}`")
+                })?;
+                let (config, socket) = remote_target_flags(command).ok_or_else(|| {
+                    anyhow::anyhow!("remote CLI leaf `{leaf}` has no target-flag contract")
+                })?;
+                return reject_remote_local_target_flags(config, socket);
+            }
+            if let Some(leaf) = remote_resource_leaf(command) {
+                bitrouter::remote_control::inventory::RESOURCES
+                    .iter()
+                    .find(|resource| resource.cli_leaf == Some(leaf))
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("control inventory has no resource for CLI leaf `{leaf}`")
+                    })?;
+                return Ok(());
+            }
+            Err(bitrouter_sdk::BitrouterError::bad_request(
+                "this command is local-only for a remote context",
+            )
+            .into())
+        }
+    }
+}
+
+fn remote_cli_leaf(command: &Command) -> Option<&'static str> {
+    match command {
+        Command::Reload { .. } => Some("reload"),
+        Command::Status { requests: true, .. } | Command::Requests { .. } => Some("requests"),
+        Command::Status {
+            requests: false, ..
+        } => Some("status"),
+        Command::Models { .. } => Some("models"),
+        Command::Route { .. } => Some("route"),
+        Command::Providers {
+            action: ProviderAction::List { .. },
+        } => Some("providers list"),
+        Command::Observe {
+            action: ObserveAction::Status { .. },
+        } => Some("observe status"),
+        Command::Policy {
+            action: PolicyAction::Status { .. },
+        } => Some("policy status"),
+        Command::Policy {
+            action: PolicyAction::Show { .. },
+        } => Some("policy show"),
+        Command::Agents {
+            action: AgentsAction::List { remote: false, .. },
+        } => Some("agents list"),
+        _ => None,
+    }
+}
+
+fn remote_resource_leaf(command: &Command) -> Option<&'static str> {
+    match command {
+        Command::Operations {
+            action: OperationsAction::Show { .. },
+        } => Some("operations show"),
+        _ => None,
+    }
+}
+
+fn remote_target_flags(command: &Command) -> Option<(Option<&Path>, Option<&Path>)> {
+    match command {
+        Command::Reload { config, socket }
+        | Command::Status { config, socket, .. }
+        | Command::Requests { config, socket, .. }
+        | Command::Route { config, socket, .. }
+        | Command::Providers {
+            action: ProviderAction::List { config, socket },
+        }
+        | Command::Observe {
+            action: ObserveAction::Status { config, socket },
+        }
+        | Command::Policy {
+            action:
+                PolicyAction::Status { config, socket, .. } | PolicyAction::Show { config, socket, .. },
+        }
+        | Command::Agents {
+            action: AgentsAction::List { config, socket, .. },
+        } => Some((config.as_deref(), socket.as_deref())),
+        Command::Models { config, .. } => Some((config.as_deref(), None)),
+        _ => None,
+    }
 }
 
 async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
@@ -3319,10 +3562,6 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
         source.clone(),
         socket_path.clone(),
     )?;
-    let remote_control = match remote_control {
-        Some(server) => Some(server.bind().await?),
-        None => None,
-    };
 
     let config_path_for_reload = match source {
         bitrouter::paths::ConfigSource::File(path) => Some(path.as_path()),
@@ -3371,6 +3610,12 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
         }
         bitrouter::paths::ConfigSource::Default { .. } => bitrouter::reload::ReloadSource::Default,
     };
+    let administration = bitrouter::actions::administration::Administration {
+        source: source.clone(),
+        routing: assembled.routing_table.clone(),
+        policy: assembled.policy_runtime.clone(),
+        observe: observe_provider.clone(),
+    };
     let acp_runtime_for_control = assembled.acp_runtime.clone();
     let reloader: Arc<dyn daemon::DaemonReloader> = Arc::new(
         bitrouter::reload::AppReloader::new(
@@ -3382,6 +3627,17 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
         .with_policy_runtime(assembled.policy_runtime)
         .with_policy_table_router(assembled.policy_table_router),
     );
+
+    let remote_control = match remote_control {
+        Some(server) => Some(
+            server
+                .with_administration(administration.clone())
+                .with_reloader(reloader.clone())
+                .bind()
+                .await?,
+        ),
+        None => None,
+    };
 
     daemon::write_pid_file(&pid_path).await?;
     println!(
@@ -3489,7 +3745,7 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
             }
         }
     };
-    let control = daemon::run_control_socket_with_acp_runtime(
+    let control = daemon::run_control_socket_with_acp_runtime_and_administration(
         socket_path,
         app.clone(),
         listen,
@@ -3499,6 +3755,7 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
             runtime: acp_runtime_for_control,
             metering: bitrouter::metering::MeteringStore::new(assembled.db.clone()),
         },
+        Some(administration),
     );
 
     // SIGHUP triggers a config reload — reload should be available via either
@@ -3953,59 +4210,6 @@ async fn reload(socket: &Path) -> Result<DaemonActionReport> {
     }
 }
 
-/// `bitrouter status` — the control-socket probe, plus the CLI's own chrome.
-///
-/// The probe itself is the shared `status` action
-/// ([`bitrouter::actions::status`]), so this leaf and the origin MCP server's
-/// `status` tool return the same report from the same code — including the
-/// `spend` block, which both surfaces fill from the same metering database.
-async fn status(config: Option<&Path>, socket: &Path) -> Result<StatusReport> {
-    // Best-effort: an unresolvable config costs the `spend` block, not the
-    // command. `--config` is honoured so `status -c other.yaml` reads the
-    // metering database that config points at, not the default home's.
-    let source = bitrouter::paths::resolve_config(config).ok();
-    let report = bitrouter::actions::status::DaemonStatus::new(socket, source.clone())
-        .report()
-        .await?;
-    // #607 self-update nudge — emitted to stderr so stdout stays a pure JSON
-    // result (`status 2>/dev/null | jq` must not see the nudge). CLI-only:
-    // it is a prompt for the human at the terminal, not part of the answer.
-    if let Some(source) = source {
-        bitrouter::update::maybe_nudge(source.home(), &bitrouter::style::Palette::for_stderr())
-            .await;
-    }
-    Ok(report)
-}
-
-/// `bitrouter status --requests` — the settled-request table.
-///
-/// Never fails: every source degrades to absence, because a monitoring view
-/// that errors out is worse than one reporting less. The store opens read-only
-/// and works with no daemon running, which is why "nothing recorded" and
-/// "nothing listening" stay distinguishable in the report.
-async fn request_table(config: Option<&Path>, socket: &Path, limit: u64) -> Result<RequestsReport> {
-    let source = bitrouter::paths::resolve_config(config)?;
-    bitrouter::actions::requests::RequestsAction::new(source, socket.to_path_buf())
-        .report(limit)
-        .await
-}
-
-/// `bitrouter route` — the CLI surface of the shared `route` action.
-///
-/// The daemon-first / config-fallback behaviour, the policy table, and the
-/// report all live in [`bitrouter::actions::route`], which the MCP
-/// `route_preview` tool goes through too. This is the leaf, not a second
-/// implementation.
-async fn route(
-    input: RouteInput,
-    source: &bitrouter::paths::ConfigSource,
-    socket: &Path,
-) -> Result<RouteReport> {
-    bitrouter::actions::route::RouteAction::new(source.clone(), Some(socket.to_path_buf()))
-        .report(input)
-        .await
-}
-
 // ===== management commands =====
 
 /// Read a provider API key from stdin (for `providers login --key-stdin`).
@@ -4039,21 +4243,220 @@ async fn key(action: KeyAction) -> Result<KeySignReport> {
     }
 }
 
-/// `bitrouter models` — the CLI surface of the `list_models`
-/// [action](bitrouter::actions::models), so this leaf and the origin MCP
-/// server's `list_models` tool return the same report.
-///
-/// `--provider` narrows the shared report rather than the query, which is what
-/// keeps it the same filter the tool's `provider` argument applies.
-async fn models(
-    source: &bitrouter::paths::ConfigSource,
-    provider: Option<&str>,
-) -> Result<ModelsReport> {
-    let socket = resolve_client_socket_from(source, None).await.ok();
-    let report = bitrouter::actions::models::RoutableModels::new(source.clone(), socket)
-        .report()
-        .await?;
-    Ok(report.filtered(provider))
+async fn inspection_target(
+    remote_context: Option<&bitrouter::contexts::RemoteContext>,
+    context_name: Option<&str>,
+    config: Option<&Path>,
+    socket: Option<&Path>,
+) -> Result<InspectionTarget> {
+    let remote = match remote_context {
+        Some(context) => {
+            let name = context_name
+                .ok_or_else(|| anyhow::anyhow!("remote context name is unavailable"))?;
+            Some((name.to_string(), context.clone()))
+        }
+        None => None,
+    };
+    InspectionTarget::resolve(remote, config, socket).await
+}
+
+fn selected_policy_view(view: Option<PolicyViewArg>, remote: bool) -> PolicyView {
+    match view {
+        Some(view) => view.into(),
+        None if remote => PolicyView::Active,
+        None => PolicyView::Disk,
+    }
+}
+
+async fn administration_policy(
+    action: PolicyAction,
+    output: &Output,
+    remote_context: Option<&bitrouter::contexts::RemoteContext>,
+    context_name: Option<&str>,
+) -> Result<()> {
+    if remote_context.is_none() && is_legacy_local_policy_read(&action) {
+        return policy(action, output).await;
+    }
+    match action {
+        PolicyAction::Status {
+            view,
+            config,
+            socket,
+        } => {
+            let target = inspection_target(
+                remote_context,
+                context_name,
+                config.as_deref(),
+                socket.as_deref(),
+            )
+            .await?;
+            output.emit(
+                &target
+                    .policy(PolicyInput {
+                        view: selected_policy_view(view, remote_context.is_some()),
+                        name: None,
+                    })
+                    .await?,
+            )?;
+            Ok(())
+        }
+        PolicyAction::Show {
+            name,
+            view,
+            config,
+            socket,
+        } => {
+            let target = inspection_target(
+                remote_context,
+                context_name,
+                config.as_deref(),
+                socket.as_deref(),
+            )
+            .await?;
+            output.emit(
+                &target
+                    .policy(PolicyInput {
+                        view: selected_policy_view(view, remote_context.is_some()),
+                        name: Some(name),
+                    })
+                    .await?,
+            )?;
+            Ok(())
+        }
+        action => {
+            if remote_context.is_some() {
+                return Err(bitrouter_sdk::BitrouterError::bad_request(
+                    "this policy action is local-only for a remote context",
+                )
+                .into());
+            }
+            policy(action, output).await
+        }
+    }
+}
+
+fn is_legacy_local_policy_read(action: &PolicyAction) -> bool {
+    matches!(
+        action,
+        PolicyAction::Status { view: None, .. } | PolicyAction::Show { view: None, .. }
+    )
+}
+
+async fn administration_providers(
+    action: ProviderAction,
+    output: &Output,
+    remote_context: Option<&bitrouter::contexts::RemoteContext>,
+    context_name: Option<&str>,
+) -> Result<()> {
+    match action {
+        ProviderAction::List { config, socket } => {
+            let target = inspection_target(
+                remote_context,
+                context_name,
+                config.as_deref(),
+                socket.as_deref(),
+            )
+            .await?;
+            if let Some(source) = target.local_source() {
+                output.emit(&legacy_providers_report(source).await?)?;
+            } else {
+                output.emit(&target.providers().await?)?;
+            }
+            Ok(())
+        }
+        action => {
+            if remote_context.is_some() {
+                return Err(bitrouter_sdk::BitrouterError::bad_request(
+                    "provider credential administration is local-only for a remote context",
+                )
+                .into());
+            }
+            providers(action, output).await
+        }
+    }
+}
+
+async fn administration_observe(
+    action: ObserveAction,
+    output: &Output,
+    remote_context: Option<&bitrouter::contexts::RemoteContext>,
+    context_name: Option<&str>,
+) -> Result<()> {
+    match action {
+        ObserveAction::Status { config, socket } => {
+            let target = inspection_target(
+                remote_context,
+                context_name,
+                config.as_deref(),
+                socket.as_deref(),
+            )
+            .await?;
+            if let Some(socket) = target.local_socket() {
+                output.emit(&observe_status(socket).await?)?;
+            } else {
+                output.emit(&target.observe().await?)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Preserve the established local observe report, including its local socket
+/// and exporter endpoint fields. The redacted administration report is used
+/// for every remote target and by the dashboard.
+async fn observe_status(socket: &Path) -> Result<ObserveStatusReport> {
+    use bitrouter_telemetry::OTEL_ENABLED;
+
+    let (snapshot, daemon_reachable) =
+        match daemon::send_command(socket, &DaemonCommand::ObserveStatus).await {
+            Ok(DaemonResponse::ObserveStatus { payload }) => (payload, true),
+            Ok(DaemonResponse::Error { message }) => return Err(anyhow::anyhow!(message)),
+            Ok(other) => return Err(anyhow::anyhow!("unexpected response: {other:?}")),
+            Err(error) if daemon::is_not_reachable(&error) => {
+                (daemon::ObserveStatusPayload::unwired(OTEL_ENABLED), false)
+            }
+            Err(error) => return Err(error),
+        };
+
+    Ok(ObserveStatusReport {
+        daemon_reachable,
+        snapshot,
+        socket: socket.display().to_string(),
+    })
+}
+
+async fn administration_agents(
+    action: AgentsAction,
+    output: &Output,
+    remote_context: Option<&bitrouter::contexts::RemoteContext>,
+    context_name: Option<&str>,
+) -> Result<()> {
+    match action {
+        AgentsAction::List {
+            remote: false,
+            config,
+            socket,
+        } => {
+            let target = inspection_target(
+                remote_context,
+                context_name,
+                config.as_deref(),
+                socket.as_deref(),
+            )
+            .await?;
+            output.emit(&target.agents().await?)?;
+            Ok(())
+        }
+        action => {
+            if remote_context.is_some() {
+                return Err(bitrouter_sdk::BitrouterError::bad_request(
+                    "agent launch and external-registry actions are local-only for a remote context",
+                )
+                .into());
+            }
+            agents_cmd(action, output).await
+        }
+    }
 }
 
 async fn policy(action: PolicyAction, output: &Output) -> Result<()> {
@@ -4129,6 +4532,7 @@ async fn policy(action: PolicyAction, output: &Output) -> Result<()> {
                 path: Some(config_path.display().to_string()),
                 candidate_path: None,
                 digest: Some(verification.policy_digest.clone()),
+                source: None,
                 mode: "n/a".into(),
                 policies: Vec::new(),
                 bindings: Default::default(),
@@ -4140,14 +4544,14 @@ async fn policy(action: PolicyAction, output: &Output) -> Result<()> {
                 applied: false,
             })?;
         }
-        PolicyAction::Status { config } => {
+        PolicyAction::Status { config, .. } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let config_path = require_policy_config_path(&source)?;
             output.emit(
                 &routing_policy_report(config_path, "status", false, Vec::new(), None).await?,
             )?;
         }
-        PolicyAction::Show { name, config } => {
+        PolicyAction::Show { name, config, .. } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let config_path = require_policy_config_path(&source)?;
             output.emit(
@@ -4205,6 +4609,7 @@ async fn policy(action: PolicyAction, output: &Output) -> Result<()> {
                 path: Some(active.display().to_string()),
                 candidate_path: Some(candidate.display().to_string()),
                 digest: Some(candidate_lock.digest),
+                source: None,
                 mode: "n/a".into(),
                 policies: candidate_lock.document.policies.keys().cloned().collect(),
                 bindings: Default::default(),
@@ -5134,6 +5539,7 @@ async fn routing_policy_report(
         path: path.map(|path| path.display().to_string()),
         candidate_path: None,
         digest: loaded.as_ref().map(|lock| lock.digest.clone()),
+        source: matches!(action, "status" | "show").then(|| "disk".to_string()),
         mode: match cfg.policy.mode {
             config::PolicyRuntimeMode::Frozen => "frozen",
             config::PolicyRuntimeMode::Adaptive => "adaptive",
@@ -5149,19 +5555,9 @@ async fn routing_policy_report(
 
 async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
     match action {
-        ProviderAction::List { config } => {
+        ProviderAction::List { config, .. } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
-            let cfg = bitrouter::paths::load_config(&source).await?;
-            let providers = commands::list_providers(&cfg)
-                .into_iter()
-                .map(|p| ProviderRow {
-                    id: p.id,
-                    models: p.model_count,
-                    active: p.active,
-                    api_base: p.api_base,
-                })
-                .collect();
-            output.emit(&ProvidersReport { providers })?;
+            output.emit(&legacy_providers_report(&source).await?)?;
             Ok(())
         }
         ProviderAction::Login {
@@ -5239,6 +5635,24 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
             }
         }
     }
+}
+
+/// Preserve the local `providers list` report shape. Remote administration
+/// never uses this adapter because provider API bases are not a remote read.
+async fn legacy_providers_report(
+    source: &bitrouter::paths::ConfigSource,
+) -> Result<ProvidersReport> {
+    let cfg = bitrouter::paths::load_config(source).await?;
+    let providers = commands::list_providers(&cfg)
+        .into_iter()
+        .map(|provider| ProviderRow {
+            id: provider.id,
+            models: provider.model_count,
+            active: provider.active,
+            api_base: provider.api_base,
+        })
+        .collect();
+    Ok(ProvidersReport { providers })
 }
 
 async fn tools(action: ToolsAction, output: &Output) -> Result<()> {
@@ -5321,49 +5735,11 @@ async fn tools(action: ToolsAction, output: &Output) -> Result<()> {
     }
 }
 
-// ===== observe =====
-
-async fn observe(action: ObserveAction, output: &Output) -> Result<()> {
-    match action {
-        ObserveAction::Status { config, socket } => {
-            let socket = resolve_client_socket(config.as_deref(), socket.as_deref()).await?;
-            output.emit(&observe_status(&socket).await?)?;
-            Ok(())
-        }
-    }
-}
-
-/// `bitrouter observe status` — ask the running daemon for the OTel
-/// exporter snapshot, pretty-print (or JSON-dump) the result. When no
-/// daemon is reachable, fall back to a "stopped" report that still
-/// carries the compile-time `OTEL_ENABLED` flag so the user can tell
-/// "feature off" from "daemon down."
-async fn observe_status(socket: &Path) -> Result<ObserveStatusReport> {
-    use bitrouter_telemetry::OTEL_ENABLED;
-
-    let (snapshot, daemon_reachable) =
-        match daemon::send_command(socket, &DaemonCommand::ObserveStatus).await {
-            Ok(DaemonResponse::ObserveStatus { payload }) => (payload, true),
-            Ok(DaemonResponse::Error { message }) => return Err(anyhow::anyhow!(message)),
-            Ok(other) => return Err(anyhow::anyhow!("unexpected response: {other:?}")),
-            Err(e) if daemon::is_not_reachable(&e) => {
-                (daemon::ObserveStatusPayload::unwired(OTEL_ENABLED), false)
-            }
-            Err(e) => return Err(e),
-        };
-
-    Ok(ObserveStatusReport {
-        daemon_reachable,
-        snapshot,
-        socket: socket.display().to_string(),
-    })
-}
-
 async fn agents_cmd(action: AgentsAction, output: &Output) -> Result<()> {
     use bitrouter::agents as agents_cmd;
 
     match action {
-        AgentsAction::List { remote, config } => {
+        AgentsAction::List { remote, config, .. } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;
             let agents = agents_cmd::list(&cfg)
@@ -6852,7 +7228,7 @@ mod tests {
     /// would hide exactly the tools a missing row would hide.
     fn every_tool() -> bitrouter_mcp::server::BitrouterMcp {
         use bitrouter_mcp::actions::models::{ModelsQuery, ModelsReport};
-        use bitrouter_mcp::actions::route::{ResolvedVia, RouteQuery};
+        use bitrouter_mcp::actions::route::{ResolvedVia, RouteQuery, RouteReport};
         use bitrouter_mcp::actions::skills::{SkillDetail, SkillsQuery, SkillsReport};
         use bitrouter_mcp::actions::status::{StatusQuery, StatusReport};
         use bitrouter_mcp::backend::CallerAuth;
@@ -7023,6 +7399,164 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn control_action_arguments(leaf: &str) -> Option<Vec<&'static str>> {
+        let args = match leaf {
+            "reload" => vec!["bitrouter", "--context", "workstation", "reload"],
+            "status" => vec!["bitrouter", "--context", "workstation", "status"],
+            "models" => vec![
+                "bitrouter",
+                "--context",
+                "workstation",
+                "models",
+                "--provider",
+                "openai",
+            ],
+            "route" => vec![
+                "bitrouter",
+                "--context",
+                "workstation",
+                "route",
+                "openai/gpt-5",
+            ],
+            "requests" => vec![
+                "bitrouter",
+                "--context",
+                "workstation",
+                "requests",
+                "--limit",
+                "100",
+                "--since",
+                "2026-01-01T00:00:00Z",
+                "--until",
+                "2026-01-01T01:00:00Z",
+                "--model",
+                "openai/gpt-5",
+                "--provider",
+                "openai",
+            ],
+            "providers list" => vec!["bitrouter", "--context", "workstation", "providers", "list"],
+            "observe status" => vec!["bitrouter", "--context", "workstation", "observe", "status"],
+            "policy status" => vec![
+                "bitrouter",
+                "--context",
+                "workstation",
+                "policy",
+                "status",
+                "--view",
+                "active",
+            ],
+            "policy show" => vec![
+                "bitrouter",
+                "--context",
+                "workstation",
+                "policy",
+                "show",
+                "default",
+                "--view",
+                "disk",
+            ],
+            "agents list" => vec!["bitrouter", "--context", "workstation", "agents", "list"],
+            _ => return None,
+        };
+        Some(args)
+    }
+
+    #[test]
+    fn every_control_action_parses_and_is_remote_eligible() -> anyhow::Result<()> {
+        for action in bitrouter::remote_control::inventory::ACTIONS {
+            let args = control_action_arguments(action.cli_leaf).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "control action `{}` has no Clap argument fixture for `{}`",
+                    action.id,
+                    action.cli_leaf
+                )
+            })?;
+            let cli = Cli::try_parse_from(args)
+                .with_context(|| format!("parse control action `{}`", action.id))?;
+            let command = cli.command.ok_or_else(|| {
+                anyhow::anyhow!("control action `{}` parsed without a command", action.id)
+            })?;
+            assert_eq!(remote_cli_leaf(&command), Some(action.cli_leaf));
+            validate_remote_invocation(&command, true)
+                .with_context(|| format!("validate control action `{}`", action.id))?;
+        }
+
+        for resource in bitrouter::remote_control::inventory::RESOURCES {
+            let Some(leaf) = resource.cli_leaf else {
+                continue;
+            };
+            let cli = Cli::try_parse_from([
+                "bitrouter",
+                "--context",
+                "workstation",
+                "operations",
+                "show",
+                "7ab707f8-50d1-4ba0-9aeb-8f4cb196712b",
+                "--instance",
+                "a68fed5e-18e0-4ed8-9023-9ad286a8351d",
+            ])?;
+            let command = cli.command.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "control resource `{}` parsed without a command",
+                    resource.id
+                )
+            })?;
+            assert_eq!(remote_resource_leaf(&command), Some(leaf));
+            validate_remote_invocation(&command, true)
+                .with_context(|| format!("validate control resource `{}`", resource.id))?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn remote_control_actions_reject_local_target_flags_before_execution() -> anyhow::Result<()> {
+        for action in bitrouter::remote_control::inventory::ACTIONS {
+            let mut args = control_action_arguments(action.cli_leaf).ok_or_else(|| {
+                anyhow::anyhow!("missing control fixture for `{}`", action.cli_leaf)
+            })?;
+            args.extend(["--config", "/must-not-be-read/bitrouter.yaml"]);
+            if action.cli_leaf != "models" {
+                args.extend(["--socket", "/must-not-be-read/bitrouter.sock"]);
+            }
+            let cli = Cli::try_parse_from(args)
+                .with_context(|| format!("parse target flags for `{}`", action.id))?;
+            let command = cli.command.ok_or_else(|| {
+                anyhow::anyhow!("control action `{}` parsed without a command", action.id)
+            })?;
+            let error = validate_remote_invocation(&command, true)
+                .err()
+                .ok_or_else(|| anyhow::anyhow!("{} accepted a local target flag", action.id))?;
+            assert!(
+                error
+                    .to_string()
+                    .contains("does not accept --config or --socket"),
+                "{}: {error:#}",
+                action.id
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn local_policy_reads_without_view_keep_the_legacy_contract() {
+        assert!(is_legacy_local_policy_read(&PolicyAction::Status {
+            view: None,
+            config: None,
+            socket: None,
+        }));
+        assert!(is_legacy_local_policy_read(&PolicyAction::Show {
+            name: "default".to_string(),
+            view: None,
+            config: None,
+            socket: None,
+        }));
+        assert!(!is_legacy_local_policy_read(&PolicyAction::Status {
+            view: Some(PolicyViewArg::Disk),
+            config: None,
+            socket: None,
+        }));
     }
 
     /// The agreement itself: the tool advertises the row's schema, so a client

--- a/apps/bitrouter/src/metering/store.rs
+++ b/apps/bitrouter/src/metering/store.rs
@@ -348,6 +348,15 @@ pub struct RequestRow {
     pub episode_id: Option<String>,
 }
 
+/// One bounded page from the host-wide request inspection query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestPage {
+    /// Newest-first rows, never exceeding the requested limit.
+    pub rows: Vec<RequestRow>,
+    /// A further matching row existed after this page.
+    pub truncated: bool,
+}
+
 impl From<requests::Model> for RequestRow {
     fn from(m: requests::Model) -> Self {
         Self {
@@ -583,6 +592,44 @@ impl MeteringStore {
         Ok(rows)
     }
 
+    /// The newest host-wide rows matching the supplied time/model/provider
+    /// filters. Filters are applied in the database before the page limit, and
+    /// one extra row makes truncation observable without an unbounded scan.
+    pub async fn recent_requests_filtered(
+        &self,
+        window: TimeWindow,
+        model: Option<&str>,
+        provider: Option<&str>,
+        limit: u64,
+    ) -> Result<RequestPage> {
+        let start = window_start(window).to_rfc3339();
+        let mut query = requests::Entity::find()
+            .filter(requests::Column::CreatedAt.gte(start))
+            .order_by_desc(requests::Column::CreatedAt)
+            .order_by_desc(requests::Column::RequestId);
+        if let Some(model) = model {
+            query = query.filter(requests::Column::ModelId.eq(model));
+        }
+        if let Some(provider) = provider {
+            query = query.filter(requests::Column::ProviderId.eq(provider));
+        }
+        if let TimeWindow::Custom { end, .. } = window {
+            query = query.filter(requests::Column::CreatedAt.lt(end.to_rfc3339()));
+        }
+        let mut rows = query
+            .limit(limit.saturating_add(1))
+            .all(&self.db)
+            .await
+            .map_err(|e| BitrouterError::internal(format!("recent_requests_filtered: {e}")))?;
+        let truncated = rows.len() > limit as usize;
+        if truncated {
+            rows.pop();
+        }
+        let mut rows: Vec<RequestRow> = rows.into_iter().map(RequestRow::from).collect();
+        self.attach_episodes(&mut rows).await;
+        Ok(RequestPage { rows, truncated })
+    }
+
     /// Fill in each row's trajectory episode id, where one exists.
     ///
     /// A second statement rather than a join: `trajectory_requests` belongs to
@@ -775,16 +822,41 @@ impl MeteringStore {
 
     /// Total spend + request count within `window`, across every caller.
     pub async fn spend_summary(&self, window: TimeWindow) -> Result<SpendSummary> {
+        self.spend_summary_filtered(window, None, None).await
+    }
+
+    /// Total spend + request count within the selected host-wide filters.
+    ///
+    /// This deliberately uses the same predicates as
+    /// [`Self::recent_requests_filtered`], except for its page limit. A total
+    /// computed before model/provider filtering, or after limiting rows, would
+    /// describe a different set of requests from the page beside it.
+    pub async fn spend_summary_filtered(
+        &self,
+        window: TimeWindow,
+        model: Option<&str>,
+        provider: Option<&str>,
+    ) -> Result<SpendSummary> {
         let start = window_start(window).to_rfc3339();
-        let charges: Vec<(i64, String)> = requests::Entity::find()
+        let mut query = requests::Entity::find()
             .select_only()
             .column(requests::Column::EstimatedChargeMicroUsd)
             .column(requests::Column::ChargeStatus)
-            .filter(requests::Column::CreatedAt.gte(start))
+            .filter(requests::Column::CreatedAt.gte(start));
+        if let Some(model) = model {
+            query = query.filter(requests::Column::ModelId.eq(model));
+        }
+        if let Some(provider) = provider {
+            query = query.filter(requests::Column::ProviderId.eq(provider));
+        }
+        if let TimeWindow::Custom { end, .. } = window {
+            query = query.filter(requests::Column::CreatedAt.lt(end.to_rfc3339()));
+        }
+        let charges: Vec<(i64, String)> = query
             .into_tuple()
             .all(&self.db)
             .await
-            .map_err(|e| BitrouterError::internal(format!("spend_summary: {e}")))?;
+            .map_err(|e| BitrouterError::internal(format!("spend_summary_filtered: {e}")))?;
         Ok(summarize(charges))
     }
 

--- a/apps/bitrouter/src/metering/tests.rs
+++ b/apps/bitrouter/src/metering/tests.rs
@@ -1474,6 +1474,67 @@ async fn recent_requests_returns_newest_first_and_honors_the_limit() -> Result<(
 }
 
 #[tokio::test]
+async fn filtered_request_page_and_summary_apply_the_same_bounds_before_limit() -> anyhow::Result<()>
+{
+    let pool = pool().await;
+    let store = MeteringStore::new(pool.clone());
+    let recorder = MeteringRecorder::new(store.clone(), pricing());
+
+    for (request_id, model, provider) in [
+        ("matched-old", "gpt-5", "openai"),
+        ("matched-new", "gpt-5", "openai"),
+        ("wrong-provider", "gpt-5", "anthropic"),
+        ("wrong-model", "gpt-4", "openai"),
+        ("at-exclusive-end", "gpt-5", "openai"),
+    ] {
+        let mut request = ctx("filtered", 10, 5);
+        request.request_id = request_id.to_string();
+        request.model_id = model.to_string();
+        request.provider_id = provider.to_string();
+        recorder.record(&mut request).await?;
+    }
+
+    pool.execute(Statement::from_string(
+        DatabaseBackend::Sqlite,
+        "UPDATE requests SET created_at = CASE request_id
+            WHEN 'matched-old' THEN '2026-09-01T00:00:00+00:00'
+            WHEN 'matched-new' THEN '2026-09-01T00:01:00+00:00'
+            WHEN 'wrong-provider' THEN '2026-09-01T00:02:00+00:00'
+            WHEN 'wrong-model' THEN '2026-09-01T00:03:00+00:00'
+            WHEN 'at-exclusive-end' THEN '2026-09-02T00:00:00+00:00'
+            ELSE created_at
+        END"
+        .to_string(),
+    ))
+    .await?;
+
+    let start = chrono::DateTime::parse_from_rfc3339("2026-09-01T00:00:00Z")
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+        .map_err(|_| bitrouter_sdk::BitrouterError::internal("invalid test start timestamp"))?;
+    let end = chrono::DateTime::parse_from_rfc3339("2026-09-02T00:00:00Z")
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+        .map_err(|_| bitrouter_sdk::BitrouterError::internal("invalid test end timestamp"))?;
+    let window = TimeWindow::Custom { start, end };
+    let page = store
+        .recent_requests_filtered(window, Some("gpt-5"), Some("openai"), 1)
+        .await?;
+    assert_eq!(page.rows.len(), 1);
+    assert_eq!(page.rows[0].request_id, "matched-new");
+    assert!(page.truncated, "the second matching row must be observable");
+
+    let summary = store
+        .spend_summary_filtered(window, Some("gpt-5"), Some("openai"))
+        .await?;
+    assert_eq!(summary.requests, 2, "filters precede the page limit");
+    assert_eq!(
+        summary.spend_micro_usd, 140,
+        "the exclusive end is excluded"
+    );
+    assert_eq!(summary.unpriced, 0);
+    Ok(())
+}
+
+#[tokio::test]
 async fn get_total_rate_counts_every_caller_not_one_key() -> Result<()> {
     let pool = pool().await;
     let store = MeteringStore::new(pool.clone());

--- a/apps/bitrouter/src/output/reports/administration.rs
+++ b/apps/bitrouter/src/output/reports/administration.rs
@@ -1,0 +1,160 @@
+//! Human renderers for safe live-administration reports.
+
+use crate::actions::administration::{
+    AgentsReport, ObserveReport, PolicyReport, PolicyView, ProvidersReport,
+};
+use crate::output::CliReport;
+use crate::output::human::{Health, Human, Table};
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}
+
+fn policy_view(view: PolicyView) -> &'static str {
+    match view {
+        PolicyView::Active => "active",
+        PolicyView::Disk => "disk",
+    }
+}
+
+impl CliReport for ProvidersReport {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        if self.providers.is_empty() {
+            human.line("(no accepted providers)")?;
+        } else {
+            let mut table = Table::new(["ID", "MODELS", "ACTIVE"]);
+            for provider in &self.providers {
+                table.push([
+                    provider.id.clone(),
+                    provider.models.to_string(),
+                    yes_no(provider.active).to_string(),
+                ]);
+            }
+            human.table(&table)?;
+        }
+        human.note(&format!(
+            "resolved via {} daemon configuration",
+            self.resolved_via
+        ))
+    }
+}
+
+impl CliReport for AgentsReport {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        if self.agents.is_empty() {
+            human.line("(no configured or catalog agents)")?;
+        } else {
+            let mut table = Table::new(["ID", "CONFIGURED", "CATALOG", "DESCRIPTION"]);
+            for agent in &self.agents {
+                table.push([
+                    agent.id.clone(),
+                    yes_no(agent.configured).to_string(),
+                    yes_no(agent.in_catalog).to_string(),
+                    agent.description.clone(),
+                ]);
+            }
+            human.table(&table)?;
+        }
+        human.note(if self.readiness_checked {
+            "readiness was checked"
+        } else {
+            "catalog only; this read did not launch or check an agent"
+        })
+    }
+}
+
+impl CliReport for ObserveReport {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        if !self.daemon_reachable {
+            human.status_block(Health::Down, "bitrouter observe — daemon stopped")?;
+            human.field("compiled", yes_no(self.compiled_in))?;
+            return human.note("Run `bitrouter start` to inspect the live telemetry exporter.");
+        }
+        let (health, headline) = if self.exporter_wired {
+            (Health::Up, "OTel exporter is wired")
+        } else if self.compiled_in {
+            (
+                Health::Down,
+                "OTel feature compiled in, exporter not configured",
+            )
+        } else {
+            (Health::Down, "OTel feature not compiled in")
+        };
+        human.status_block(health, &format!("bitrouter observe — {headline}"))?;
+        human.field("compiled", yes_no(self.compiled_in))?;
+        human.field("wired", yes_no(self.exporter_wired))?;
+        if let Some(sampler) = &self.sampler {
+            let sampler = match self.sampler_arg {
+                Some(argument) => format!("{sampler} (arg={argument})"),
+                None => sampler.clone(),
+            };
+            human.field("sampler", sampler)?;
+        }
+        human.field("metrics", if self.metrics_enabled { "on" } else { "off" })?;
+        human.field("headers", self.header_count)?;
+        human.field("res-attrs", self.resource_attribute_count)?;
+        human.field(
+            "api-keys",
+            format!("{} / {}", self.api_key_count, self.api_key_cap),
+        )?;
+        human.field(
+            "users",
+            format!("{} / {}", self.user_id_count, self.user_id_cap),
+        )?;
+        human.field("in-flight", self.active_spans)
+    }
+}
+
+impl CliReport for PolicyReport {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        human.line(&format!("policy {}", policy_view(self.view)))?;
+        human.field("availability", &self.availability)?;
+        if let Some(digest) = &self.digest {
+            human.field("digest", digest)?;
+        }
+        human.field("mode", &self.mode)?;
+        if !self.policies.is_empty() {
+            human.field("policies", self.policies.join(", "))?;
+        }
+        for (preset, policy) in &self.bindings {
+            human.line(&format!("  @{preset} -> {policy}"))?;
+        }
+        if !self.definitions.is_empty() {
+            human.blank()?;
+            let mut table = Table::new(["POLICY", "TIERS", "ROUTES", "CERTIFICATES"]);
+            for (name, detail) in &self.definitions {
+                table.push([
+                    name.clone(),
+                    detail.tiers.keys().cloned().collect::<Vec<_>>().join(", "),
+                    detail.routes.len().to_string(),
+                    detail.certificates.len().to_string(),
+                ]);
+            }
+            human.table(&table)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::administration::ProviderEntry;
+    use crate::output::{Format, Output};
+
+    #[test]
+    fn provider_report_does_not_render_an_api_base() -> anyhow::Result<()> {
+        let report = ProvidersReport {
+            resolved_via: "live".to_string(),
+            providers: vec![ProviderEntry {
+                id: "openai".to_string(),
+                models: 2,
+                active: true,
+            }],
+        };
+        let rendered = String::from_utf8(Output::new(Format::Human).render_to_vec(&report))?;
+        assert!(rendered.contains("openai"));
+        assert!(!rendered.contains("API_BASE"));
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -5,6 +5,7 @@
 //! implementations. Submodules are added as groups are converted.
 
 pub mod admin;
+pub mod administration;
 pub mod agents;
 pub mod commands;
 pub mod config;
@@ -12,6 +13,7 @@ pub mod daemon;
 pub mod eval;
 pub mod mcp;
 pub mod observe;
+pub mod operations;
 pub mod optimization;
 pub mod policy;
 pub mod requests;

--- a/apps/bitrouter/src/output/reports/operations.rs
+++ b/apps/bitrouter/src/output/reports/operations.rs
@@ -1,0 +1,168 @@
+//! Human renderers for guarded reload state and retained remote operations.
+
+use crate::output::CliReport;
+use crate::output::human::{Health, Human, Table};
+use crate::reload::{
+    ReloadConsistency, ReloadOutcome, ReloadParticipant, ReloadParticipantOutcome, ReloadReport,
+    ReloadState,
+};
+use crate::remote_control::operations::{OperationReport, OperationStatus};
+
+fn operation_status(status: OperationStatus) -> &'static str {
+    match status {
+        OperationStatus::Running => "running",
+        OperationStatus::Succeeded => "succeeded",
+        OperationStatus::Failed => "failed",
+        OperationStatus::PartiallyApplied => "partially_applied",
+        OperationStatus::Unknown => "unknown",
+    }
+}
+
+fn operation_health(status: OperationStatus) -> Health {
+    match status {
+        OperationStatus::Succeeded => Health::Up,
+        OperationStatus::Failed | OperationStatus::PartiallyApplied => Health::Down,
+        OperationStatus::Running | OperationStatus::Unknown => Health::Unknown,
+    }
+}
+
+fn outcome(outcome: ReloadOutcome) -> &'static str {
+    match outcome {
+        ReloadOutcome::Succeeded => "succeeded",
+        ReloadOutcome::Failed => "failed",
+        ReloadOutcome::PartiallyApplied => "partially_applied",
+        ReloadOutcome::Unknown => "unknown",
+    }
+}
+
+fn participant_outcome(outcome: ReloadParticipantOutcome) -> &'static str {
+    match outcome {
+        ReloadParticipantOutcome::Applied => "applied",
+        ReloadParticipantOutcome::Unchanged => "unchanged",
+        ReloadParticipantOutcome::Failed => "failed",
+        ReloadParticipantOutcome::NotAttempted => "not_attempted",
+    }
+}
+
+fn participant(participant: ReloadParticipant) -> &'static str {
+    match participant {
+        ReloadParticipant::RoutingTable => "routing_table",
+        ReloadParticipant::UpstreamTimeoutClients => "upstream_timeout_clients",
+        ReloadParticipant::PolicyTable => "policy_table",
+        ReloadParticipant::NamedPolicyRuntime => "named_policy_runtime",
+        ReloadParticipant::AccessPolicyStore => "access_policy_store",
+    }
+}
+
+fn consistency(consistency: ReloadConsistency) -> &'static str {
+    match consistency {
+        ReloadConsistency::Consistent => "consistent",
+        ReloadConsistency::Mixed => "mixed",
+    }
+}
+
+fn render_reload_report(human: &mut Human<'_>, report: &ReloadReport) -> std::io::Result<()> {
+    human.field("outcome", outcome(report.outcome))?;
+    human.field("generation", report.generation)?;
+    human.field("started", &report.started_at)?;
+    human.field("completed", &report.completed_at)?;
+    if !report.restart_required_fields.is_empty() {
+        human.field("restart", report.restart_required_fields.join(", "))?;
+    }
+    let mut table = Table::new(["PARTICIPANT", "OUTCOME", "DETAIL"]);
+    for row in &report.participants {
+        table.push([
+            participant(row.participant).to_string(),
+            participant_outcome(row.outcome).to_string(),
+            row.error.as_ref().map_or_else(String::new, |error| {
+                format!("{}: {}", error.code, error.message)
+            }),
+        ]);
+    }
+    human.table(&table)
+}
+
+impl CliReport for OperationReport {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        human.status_block(
+            operation_health(self.status),
+            &format!("reload {}", operation_status(self.status)),
+        )?;
+        human.field("request", &self.request_id)?;
+        human.field("instance", &self.server_instance_id)?;
+        human.field("generation", self.generation_before)?;
+        human.field("accepted", self.accepted_at_unix_ms)?;
+        if let Some(completed) = self.completed_at_unix_ms {
+            human.field("completed", completed)?;
+        }
+        human.field("lookup", &self.lookup_url)?;
+        if let Some(report) = &self.result {
+            human.blank()?;
+            render_reload_report(human, report)?;
+        }
+        if !self.succeeded() {
+            human.note(
+                "Inspect this operation and current state before submitting another reload.",
+            )?;
+        }
+        Ok(())
+    }
+
+    fn exit_code(&self) -> i32 {
+        i32::from(!self.succeeded())
+    }
+}
+
+impl CliReport for ReloadState {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        let health = if self.running {
+            Health::Unknown
+        } else if self.consistency == ReloadConsistency::Mixed {
+            Health::Down
+        } else {
+            Health::Up
+        };
+        human.status_block(health, "reload coordinator state")?;
+        human.field("instance", &self.server_instance_id)?;
+        human.field("generation", self.generation)?;
+        human.field("running", if self.running { "yes" } else { "no" })?;
+        if let Some(generation) = self.running_generation {
+            human.field("running-gen", generation)?;
+        }
+        human.field("consistency", consistency(self.consistency))?;
+        if let Some(report) = &self.last_outcome {
+            human.blank()?;
+            render_reload_report(human, report)?;
+        }
+        if !self.mixed_state_history.is_empty() {
+            human.note("Mixed-state history is retained for this daemon boot; inspect the reports before retrying.")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Format, Output};
+
+    #[test]
+    fn running_operation_explains_how_to_recover() -> anyhow::Result<()> {
+        let report = OperationReport {
+            request_id: "request-id".to_string(),
+            server_instance_id: "instance-id".to_string(),
+            generation_before: 4,
+            status: OperationStatus::Running,
+            accepted_at_unix_ms: 1,
+            completed_at_unix_ms: None,
+            retain_until_unix_ms: None,
+            lookup_url: "operations/request-id?instance=instance-id".to_string(),
+            result: None,
+        };
+        let rendered = String::from_utf8(Output::new(Format::Human).render_to_vec(&report))?;
+        assert!(rendered.contains("reload running"));
+        assert!(rendered.contains("Inspect this operation"));
+        assert_eq!(report.exit_code(), 1);
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/output/reports/policy.rs
+++ b/apps/bitrouter/src/output/reports/policy.rs
@@ -15,6 +15,10 @@ pub struct PolicyReport {
     pub candidate_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,
+    /// Additive provenance for compatibility reads. Existing local
+    /// `status` and `show` continue to read the policy lock from disk.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
     pub mode: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub policies: Vec<String>,
@@ -39,6 +43,9 @@ impl CliReport for PolicyReport {
         if let Some(digest) = &self.digest {
             h.line(&format!("  digest: {digest}"))?;
         }
+        if let Some(source) = &self.source {
+            h.line(&format!("  source: {source}"))?;
+        }
         h.line(&format!("  mode: {}", self.mode))?;
         if !self.policies.is_empty() {
             h.line(&format!("  policies: {}", self.policies.join(", ")))?;
@@ -59,6 +66,36 @@ impl CliReport for PolicyReport {
         if self.applied {
             h.line("  applied: yes")?;
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_disk_show_keeps_its_json_shape_and_marks_the_source() -> anyhow::Result<()> {
+        let report = PolicyReport {
+            action: "show".to_string(),
+            path: Some("/tmp/policy-lock.yaml".to_string()),
+            candidate_path: None,
+            digest: Some("digest".to_string()),
+            source: Some("disk".to_string()),
+            mode: "frozen".to_string(),
+            policies: vec!["default".to_string()],
+            bindings: BTreeMap::new(),
+            changes: Vec::new(),
+            policy: Some(serde_json::json!({"tiers": {"fast": "openai/gpt-5"}})),
+            applied: false,
+        };
+
+        let value = serde_json::to_value(report)?;
+        assert_eq!(value["action"], "show");
+        assert_eq!(value["path"], "/tmp/policy-lock.yaml");
+        assert_eq!(value["policy"]["tiers"]["fast"], "openai/gpt-5");
+        assert_eq!(value["applied"], false);
+        assert_eq!(value["source"], "disk");
         Ok(())
     }
 }

--- a/apps/bitrouter/src/output/reports/requests.rs
+++ b/apps/bitrouter/src/output/reports/requests.rs
@@ -42,6 +42,7 @@
 //! surface keep the rule `tui <agent>`'s cost line keeps: a currency figure states
 //! whose spend it is.
 
+use chrono::Datelike;
 use serde::{Deserialize, Serialize};
 
 use crate::metering::fmt_usd;
@@ -61,7 +62,7 @@ const HEADERS: [&str; 8] = [
 /// Derived from the data rather than stored, so it can never disagree with the
 /// rows beside it: an empty list because nothing ran and an empty list because
 /// the daemon is gone are different facts and must read differently.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Mode {
     /// A daemon is answering, and history is readable.
@@ -73,7 +74,7 @@ pub enum Mode {
 }
 
 /// The running daemon, as its control socket describes it.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct DaemonView {
     /// Process id.
     pub pid: u32,
@@ -88,7 +89,7 @@ pub struct DaemonView {
 /// Not [`RequestRow`] itself: that type is the metering store's display read,
 /// and serializing it here would make its field names a public JSON contract
 /// that could not then be changed without a break.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct RequestView {
     /// Request id — also the join key into the trajectory store.
     pub request_id: String,
@@ -166,12 +167,106 @@ impl RequestView {
     }
 }
 
+/// The server-resolved request selection used to produce this report.
+///
+/// The input accepts optional timestamps so an ordinary request can mean
+/// "today". A report must not leave that relative choice implicit: it returns
+/// the absolute interval the host actually read.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct RequestFilterView {
+    /// Inclusive RFC3339 lower bound chosen by the server.
+    pub since: String,
+    /// Exclusive RFC3339 upper bound chosen by the server.
+    pub until: String,
+    /// Resolved-model filter, when requested.
+    pub model: Option<String>,
+    /// Serving-provider filter, when requested.
+    pub provider: Option<String>,
+}
+
+impl RequestFilterView {
+    /// Construct the public view from already validated, absolute values.
+    pub fn new(
+        since: String,
+        until: String,
+        model: Option<String>,
+        provider: Option<String>,
+    ) -> Self {
+        Self {
+            since,
+            until,
+            model,
+            provider,
+        }
+    }
+}
+
+/// Whether one independently queried metering component was observed.
+///
+/// Numeric fields stay additive-compatible with the original report. This
+/// flag tells a reader whether their zero is an observed zero or a placeholder
+/// retained while another component was unavailable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MeteringComponentAvailability {
+    /// The store query completed successfully.
+    Available,
+    /// The store could not be opened or this component's query failed.
+    Unavailable,
+}
+
+/// Availability is per component because summary, rate, and rows are separate
+/// reads. A successful component remains useful when a sibling fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct MeteringAvailability {
+    /// Aggregate spend and request count over the selected filters.
+    pub summary: MeteringComponentAvailability,
+    /// Host-wide trailing-minute rate.
+    pub rate: MeteringComponentAvailability,
+    /// The newest-first request page and its truncation flag.
+    pub rows: MeteringComponentAvailability,
+}
+
+impl MeteringAvailability {
+    /// A fully observed snapshot.
+    pub const fn available() -> Self {
+        Self {
+            summary: MeteringComponentAvailability::Available,
+            rate: MeteringComponentAvailability::Available,
+            rows: MeteringComponentAvailability::Available,
+        }
+    }
+
+    /// No metering data was available, such as when the database cannot open.
+    pub const fn unavailable() -> Self {
+        Self {
+            summary: MeteringComponentAvailability::Unavailable,
+            rate: MeteringComponentAvailability::Unavailable,
+            rows: MeteringComponentAvailability::Unavailable,
+        }
+    }
+}
+
+/// Inputs assembled by the action after the independently queried metering
+/// components have settled. This stays separate from the serialized report so
+/// a store row does not accidentally become a public JSON contract.
+#[derive(Debug, Clone)]
+pub struct RequestReportData {
+    pub window: String,
+    pub filters: RequestFilterView,
+    pub summary: SpendSummary,
+    pub rate: RateMetrics,
+    pub rows: Vec<RequestRow>,
+    pub metering: MeteringAvailability,
+    pub truncated: bool,
+}
+
 /// Result of `bitrouter status --requests`.
 ///
 /// Deliberately not `Default`: `scope` would come back `""`, a report
 /// claiming no scope at all, which is the one thing this surface must never
-/// emit. [`RequestsReport::new`] is the only way to build one.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// emit. The constructors keep that invariant centralized.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct RequestsReport {
     /// Which of the three states this report represents.
     pub mode: Mode,
@@ -201,10 +296,20 @@ pub struct RequestsReport {
     pub tokens_per_minute: f64,
     /// Newest-first settled requests.
     pub rows: Vec<RequestView>,
+    /// The absolute time bounds and optional filters the host applied.
+    pub filters: RequestFilterView,
+    /// Whether another matching row existed after the returned page.
+    pub truncated: bool,
+    /// Which independently queried metering components were observed.
+    pub metering: MeteringAvailability,
+    /// Scope of the rate fields, which are intentionally not narrowed by the
+    /// report's time/model/provider filters.
+    pub rate_scope: String,
 }
 
 /// The one scope these figures have ever had.
 const SCOPE: &str = "all callers";
+const RATE_SCOPE: &str = "all callers, trailing minute";
 
 impl RequestsReport {
     /// Assemble from one poll of the store and the control socket.
@@ -218,7 +323,34 @@ impl RequestsReport {
         rate: RateMetrics,
         rows: Vec<RequestRow>,
     ) -> Self {
-        let mode = match (daemon.is_some(), rows.is_empty()) {
+        let now = chrono::Utc::now();
+        let until = match window {
+            TimeWindow::Custom { end, .. } => end,
+            _ => now,
+        };
+        let filters = RequestFilterView::new(
+            window_start(window, now).to_rfc3339(),
+            until.to_rfc3339(),
+            None,
+            None,
+        );
+        Self::new_filtered(
+            daemon,
+            RequestReportData {
+                window: window_label(window).to_string(),
+                filters,
+                summary,
+                rate,
+                rows,
+                metering: MeteringAvailability::available(),
+                truncated: false,
+            },
+        )
+    }
+
+    /// Assemble a report for one validated, potentially filtered page.
+    pub fn new_filtered(daemon: Option<DaemonView>, data: RequestReportData) -> Self {
+        let mode = match (daemon.is_some(), data.rows.is_empty()) {
             (true, _) => Mode::Live,
             (false, false) => Mode::HistoryOnly,
             (false, true) => Mode::Empty,
@@ -226,16 +358,34 @@ impl RequestsReport {
         Self {
             mode,
             daemon,
-            window: window_label(window).to_string(),
+            window: data.window,
             scope: SCOPE.to_string(),
             // Nothing priced is not the same as nothing spent.
-            spend_micro_usd: (summary.unpriced < summary.requests || summary.requests == 0)
-                .then_some(summary.spend_micro_usd),
-            requests: summary.requests,
-            unpriced_requests: summary.unpriced,
-            requests_per_minute: rate.requests_per_minute,
-            tokens_per_minute: rate.tokens_per_minute,
-            rows: rows.into_iter().map(RequestView::from).collect(),
+            spend_micro_usd: (data.metering.summary == MeteringComponentAvailability::Available
+                && (data.summary.unpriced < data.summary.requests || data.summary.requests == 0))
+                .then_some(data.summary.spend_micro_usd),
+            requests: data.summary.requests,
+            unpriced_requests: data.summary.unpriced,
+            requests_per_minute: data.rate.requests_per_minute,
+            tokens_per_minute: data.rate.tokens_per_minute,
+            rows: data.rows.into_iter().map(RequestView::from).collect(),
+            filters: data.filters,
+            truncated: data.truncated,
+            metering: data.metering,
+            rate_scope: RATE_SCOPE.to_string(),
+        }
+    }
+
+    /// Replace raw upstream errors with bounded, categorized remote-safe text.
+    ///
+    /// Local reports retain their stored diagnostic because the host owner may
+    /// use it to investigate a failed request. Remote reports must never carry
+    /// a provider URL, bearer token, prompt fragment, or upstream response.
+    pub fn sanitize_for_remote(&mut self) {
+        for row in &mut self.rows {
+            if let Some(error) = row.error.as_deref() {
+                row.error = Some(remote_error_summary(error).to_string());
+            }
         }
     }
 
@@ -252,6 +402,9 @@ impl RequestsReport {
     fn headline(&self) -> String {
         match (&self.daemon, self.mode) {
             (Some(d), _) => format!("live · pid {} · {} · {} models", d.pid, d.listen, d.models),
+            (None, _) if self.metering.rows == MeteringComponentAvailability::Unavailable => {
+                "metering unavailable — daemon not running".to_string()
+            }
             (None, Mode::HistoryOnly) => "history only — daemon not running".to_string(),
             (None, _) => "nothing recorded yet — try bitrouter serve".to_string(),
         }
@@ -268,15 +421,24 @@ impl RequestsReport {
             Some(micro_usd) => fmt_usd(micro_usd),
             None => "unreported".to_string(),
         };
+        let summary = match self.metering.summary {
+            MeteringComponentAvailability::Available => format!("{} req", self.requests),
+            MeteringComponentAvailability::Unavailable => "summary unavailable".to_string(),
+        };
+        let rate = match self.metering.rate {
+            MeteringComponentAvailability::Available => format!(
+                "{:.1} req/min · {} tok/min ({})",
+                self.requests_per_minute,
+                tokens(self.tokens_per_minute as i64),
+                self.rate_scope,
+            ),
+            MeteringComponentAvailability::Unavailable => "rate unavailable".to_string(),
+        };
         let mut line = format!(
-            "{} {spend} · {} req · {:.1} req/min · {} tok/min · {}",
-            self.window,
-            self.requests,
-            self.requests_per_minute,
-            tokens(self.tokens_per_minute as i64),
-            self.scope,
+            "{} {spend} · {summary} · {rate} · {}",
+            self.window, self.scope,
         );
-        if self.requests == 0 {
+        if self.metering.summary == MeteringComponentAvailability::Available && self.requests == 0 {
             line.push_str("  ·  no requests in this window");
         }
         line
@@ -287,18 +449,55 @@ impl RequestsReport {
     /// A partial total is worse than a labelled one: the reader has no way to
     /// tell a cheap window from an unmeasured one unless the gap is named.
     fn caveat(&self) -> Option<String> {
-        match (self.unpriced_requests, self.spend_micro_usd) {
-            (0, _) => None,
-            (n, None) => Some(format!(
-                "no charge evidence for any of these {n} requests — the daemon \
-                 recorded them but could not price them"
-            )),
-            (n, Some(_)) => Some(format!(
-                "{n} of {} requests have no charge evidence; the total above is \
-                 a floor, not a price",
-                self.requests
-            )),
+        let mut caveats = Vec::new();
+        if self.metering.summary == MeteringComponentAvailability::Unavailable {
+            caveats.push("metering summary unavailable".to_string());
         }
+        if self.metering.rate == MeteringComponentAvailability::Unavailable {
+            caveats.push("metering rate unavailable".to_string());
+        }
+        if self.metering.rows == MeteringComponentAvailability::Unavailable {
+            caveats.push("metering request rows unavailable".to_string());
+        }
+        if self.metering.summary == MeteringComponentAvailability::Available {
+            let pricing = match (self.unpriced_requests, self.spend_micro_usd) {
+                (0, _) => None,
+                (n, None) => Some(format!(
+                    "no charge evidence for any of these {n} requests — the daemon \
+                     recorded them but could not price them"
+                )),
+                (n, Some(_)) => Some(format!(
+                    "{n} of {} requests have no charge evidence; the total above is \
+                     a floor, not a price",
+                    self.requests
+                )),
+            };
+            if let Some(pricing) = pricing {
+                caveats.push(pricing);
+            }
+        }
+        if caveats.is_empty() {
+            None
+        } else {
+            Some(caveats.join("; "))
+        }
+    }
+}
+
+fn remote_error_summary(error: &str) -> &'static str {
+    let category = error
+        .chars()
+        .take(256)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if category.contains("rate limit") || category.contains("rate_limited") {
+        "upstream rate limited"
+    } else if category.contains("timeout") || category.contains("timed out") {
+        "upstream timed out"
+    } else if category.contains("policy") || category.contains("content filter") {
+        "upstream rejected request"
+    } else {
+        "upstream request failed"
     }
 }
 
@@ -331,6 +530,32 @@ fn window_label(window: TimeWindow) -> &'static str {
         TimeWindow::ThisWeek => "this week",
         TimeWindow::ThisMonth => "this month",
         TimeWindow::Custom { .. } => "window",
+    }
+}
+
+/// The legacy constructor only receives a named window. Its report still
+/// returns absolute bounds, although filtered callers use their already
+/// resolved bounds through [`RequestsReport::new_filtered`].
+fn window_start(
+    window: TimeWindow,
+    now: chrono::DateTime<chrono::Utc>,
+) -> chrono::DateTime<chrono::Utc> {
+    let midnight = now.date_naive().and_time(chrono::NaiveTime::MIN).and_utc();
+    match window {
+        TimeWindow::LastMinute => now - chrono::Duration::minutes(1),
+        TimeWindow::LastHour => now - chrono::Duration::hours(1),
+        TimeWindow::Today => midnight,
+        TimeWindow::ThisWeek => {
+            midnight - chrono::Duration::days(now.weekday().num_days_from_monday().into())
+        }
+        TimeWindow::ThisMonth => {
+            let first = chrono::NaiveDate::from_ymd_opt(now.year(), now.month(), 1);
+            match first {
+                Some(first) => first.and_time(chrono::NaiveTime::MIN).and_utc(),
+                None => midnight,
+            }
+        }
+        TimeWindow::Custom { start, .. } => start,
     }
 }
 
@@ -583,6 +808,58 @@ mod tests {
         let cells = RequestView::from(r).cells();
         assert!(!cells[7].contains('\n'), "newlines would break the row");
         assert!(cells[7].chars().count() <= ERROR_CHARS + 1, "{}", cells[7]);
+    }
+
+    #[test]
+    fn remote_reports_replace_raw_upstream_errors_with_safe_categories() {
+        let secret = "https://provider.example/v1?token=brk_do-not-disclose";
+        let mut failed = row();
+        failed.error = Some(format!("request timed out at {secret}"));
+        let mut report = report(None, vec![failed]);
+        assert!(
+            report.rows[0]
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains(secret))
+        );
+
+        report.sanitize_for_remote();
+
+        assert_eq!(report.rows[0].error.as_deref(), Some("upstream timed out"));
+        assert!(!json(&report).to_string().contains(secret));
+    }
+
+    #[test]
+    fn unavailable_metering_is_not_rendered_as_observed_zero_usage() {
+        let report = RequestsReport::new_filtered(
+            None,
+            RequestReportData {
+                window: "today".to_string(),
+                filters: RequestFilterView::new(
+                    "2026-09-08T00:00:00+00:00".to_string(),
+                    "2026-09-08T10:30:00+00:00".to_string(),
+                    None,
+                    None,
+                ),
+                summary: SpendSummary::default(),
+                rate: RateMetrics::default(),
+                rows: Vec::new(),
+                metering: MeteringAvailability::unavailable(),
+                truncated: false,
+            },
+        );
+        let value = json(&report);
+        assert_eq!(value["spend_micro_usd"], serde_json::Value::Null);
+        assert_eq!(value["metering"]["summary"], "unavailable");
+        assert_eq!(value["metering"]["rate"], "unavailable");
+        assert!(report.rollup().contains("summary unavailable"));
+        assert!(report.rollup().contains("rate unavailable"));
+        assert!(report.headline().contains("metering unavailable"));
+        assert!(
+            report
+                .caveat()
+                .is_some_and(|note| note.contains("request rows unavailable"))
+        );
     }
 
     #[test]

--- a/apps/bitrouter/src/policy/store.rs
+++ b/apps/bitrouter/src/policy/store.rs
@@ -24,6 +24,13 @@ pub struct PolicyStore {
     path: RwLock<Option<PathBuf>>,
 }
 
+/// Policies read and validated from disk but not yet installed in the live
+/// store. The reload coordinator prepares this before it changes any other
+/// runtime participant.
+pub(crate) struct PreparedPolicyStore {
+    policies: HashMap<String, Policy>,
+}
+
 impl PolicyStore {
     /// An empty store.
     pub fn new() -> Self {
@@ -57,12 +64,38 @@ impl PolicyStore {
     /// no-op for stores not built from a directory. The new set REPLACES the
     /// old set (a deleted yaml file → that policy is gone).
     pub async fn reload(&self) -> Result<()> {
-        let dir = self.path.read().expect("policy lock poisoned").clone();
-        let Some(dir) = dir else {
+        let Some(prepared) = self.prepare_reload().await? else {
             return Ok(());
         };
-        let fresh = scan_policy_dir(&dir).await?;
-        *self.policies.write().expect("policy lock poisoned") = fresh;
+        self.commit_prepared(prepared)
+    }
+
+    /// Read a complete replacement policy set without altering the live store.
+    /// `None` means this in-memory store has no source directory and therefore
+    /// has no reload work.
+    pub(crate) async fn prepare_reload(&self) -> Result<Option<PreparedPolicyStore>> {
+        let dir = match self.path.read() {
+            Ok(path) => path.clone(),
+            Err(_) => {
+                return Err(BitrouterError::internal(
+                    "reading policy reload source failed",
+                ));
+            }
+        };
+        let Some(dir) = dir else {
+            return Ok(None);
+        };
+        let policies = scan_policy_dir(&dir).await?;
+        Ok(Some(PreparedPolicyStore { policies }))
+    }
+
+    /// Install an already prepared replacement policy set.
+    pub(crate) fn commit_prepared(&self, prepared: PreparedPolicyStore) -> Result<()> {
+        let mut policies = self
+            .policies
+            .write()
+            .map_err(|_| BitrouterError::internal("installing reloaded policies failed"))?;
+        *policies = prepared.policies;
         Ok(())
     }
 

--- a/apps/bitrouter/src/policy_lock.rs
+++ b/apps/bitrouter/src/policy_lock.rs
@@ -2718,6 +2718,7 @@ struct PolicySnapshot {
     path: Option<PathBuf>,
     digest: Option<String>,
     routers: BTreeMap<String, Arc<PolicyTableRouter>>,
+    administration: Option<crate::actions::administration::PolicyReport>,
 }
 
 /// Fully built policy candidate that has not yet replaced the live snapshot.
@@ -2869,6 +2870,11 @@ impl PolicyRuntime {
             path: loaded.as_ref().map(|lock| lock.path.clone()),
             digest: loaded.as_ref().map(|lock| lock.digest.clone()),
             routers,
+            administration: Some(crate::actions::administration::PolicyReport::from_loaded(
+                config,
+                loaded.as_ref(),
+                crate::actions::administration::PolicyView::Active,
+            )),
         })))
     }
 
@@ -2877,6 +2883,21 @@ impl PolicyRuntime {
             .snapshot
             .write()
             .unwrap_or_else(PoisonError::into_inner) = prepared.0;
+    }
+
+    /// Inspection data captured with the same policy version used for routing.
+    pub fn administration_snapshot(&self) -> crate::actions::administration::PolicyReport {
+        let snapshot = match self.snapshot.read() {
+            Ok(snapshot) => snapshot.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        };
+        snapshot.administration.clone().unwrap_or_else(|| {
+            crate::actions::administration::PolicyReport::from_loaded(
+                &Config::default(),
+                None,
+                crate::actions::administration::PolicyView::Active,
+            )
+        })
     }
 
     pub fn status(&self, mode: PolicyRuntimeMode) -> PolicyRuntimeStatus {

--- a/apps/bitrouter/src/reload.rs
+++ b/apps/bitrouter/src/reload.rs
@@ -13,11 +13,875 @@
 //! provider with an empty `api_base`, and an `auto_discover` provider
 //! would then silently drop every model.
 
+use std::collections::{BTreeSet, VecDeque};
+use std::fmt;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::daemon::DaemonReloader;
 use crate::policy::PolicyStore;
+use chrono::{SecondsFormat, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+const MAX_MIXED_STATE_HISTORY: usize = 32;
+
+/// Maximum time a reload may spend reading and validating all replacement
+/// inputs before it changes any live participant.
+pub const PREPARATION_TIMEOUT_SECONDS: u64 = 60;
+
+/// Consistency of the runtime configuration after the last completed reload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadConsistency {
+    /// Every participant in the last completed reload reached its intended
+    /// state, or a failed candidate made no live change.
+    Consistent,
+    /// A reload may have changed some live participants before it failed or
+    /// was interrupted. Operators must inspect the participant report.
+    Mixed,
+}
+
+/// A terminal reload outcome. `Unknown` is reserved for an interrupted
+/// in-process attempt after mutation began; it is never evidence of failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadOutcome {
+    Succeeded,
+    Failed,
+    PartiallyApplied,
+    Unknown,
+}
+
+/// A live subsystem participating in a daemon reload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadParticipant {
+    RoutingTable,
+    UpstreamTimeoutClients,
+    PolicyTable,
+    NamedPolicyRuntime,
+    AccessPolicyStore,
+}
+
+/// What one reload participant actually did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadParticipantOutcome {
+    Applied,
+    Unchanged,
+    Failed,
+    NotAttempted,
+}
+
+/// A safe, structured participant failure. Raw configuration and upstream
+/// errors may carry credentials, so the externally visible message is fixed
+/// and the detailed error remains in process logs only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReloadFailure {
+    pub code: String,
+    pub message: String,
+}
+
+impl ReloadFailure {
+    fn new(code: &str, message: &str) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.to_string(),
+        }
+    }
+}
+
+/// The actual result for one reload participant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReloadParticipantReport {
+    pub participant: ReloadParticipant,
+    pub outcome: ReloadParticipantOutcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<ReloadFailure>,
+}
+
+/// A completed reload attempt. The report deliberately does not claim a
+/// cross-subsystem transaction: a partial outcome identifies every participant
+/// that changed before a later failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReloadReport {
+    pub server_instance_id: String,
+    pub generation: u64,
+    pub outcome: ReloadOutcome,
+    pub participants: Vec<ReloadParticipantReport>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub restart_required_fields: Vec<String>,
+    /// RFC 3339 UTC timestamp captured when execution started.
+    pub started_at: String,
+    /// RFC 3339 UTC timestamp captured when this terminal report was recorded.
+    pub completed_at: String,
+}
+
+impl ReloadReport {
+    fn pending(instance: String, generation: u64) -> Self {
+        Self {
+            server_instance_id: instance,
+            generation,
+            outcome: ReloadOutcome::Failed,
+            participants: ReloadParticipant::all()
+                .into_iter()
+                .map(|participant| ReloadParticipantReport {
+                    participant,
+                    outcome: ReloadParticipantOutcome::NotAttempted,
+                    error: None,
+                })
+                .collect(),
+            restart_required_fields: Vec::new(),
+            started_at: now_rfc3339(),
+            completed_at: String::new(),
+        }
+    }
+
+    /// Build a successful report for coordinator-backed fakes in crate tests.
+    #[cfg(test)]
+    pub(crate) fn succeeded(instance: String, generation: u64) -> Self {
+        let mut report = Self::pending(instance, generation);
+        for participant in &mut report.participants {
+            participant.outcome = ReloadParticipantOutcome::Unchanged;
+        }
+        report.outcome = ReloadOutcome::Succeeded;
+        report.completed_at = now_rfc3339();
+        report
+    }
+
+    pub(crate) fn unsupported() -> Self {
+        let mut report = Self::pending("unsupported".to_string(), 0);
+        report.participant_failed(
+            ReloadParticipant::RoutingTable,
+            ReloadFailure::new(
+                "unsupported_reload",
+                "this daemon does not support coordinated reload",
+            ),
+        );
+        report.outcome = ReloadOutcome::Failed;
+        report.completed_at = now_rfc3339();
+        report
+    }
+
+    fn participant_mut(
+        &mut self,
+        participant: ReloadParticipant,
+    ) -> Option<&mut ReloadParticipantReport> {
+        self.participants
+            .iter_mut()
+            .find(|entry| entry.participant == participant)
+    }
+
+    fn participant_applied(&mut self, participant: ReloadParticipant) {
+        if let Some(entry) = self.participant_mut(participant) {
+            entry.outcome = ReloadParticipantOutcome::Applied;
+            entry.error = None;
+        }
+    }
+
+    fn participant_unchanged(&mut self, participant: ReloadParticipant) {
+        if let Some(entry) = self.participant_mut(participant) {
+            entry.outcome = ReloadParticipantOutcome::Unchanged;
+            entry.error = None;
+        }
+    }
+
+    fn participant_failed(&mut self, participant: ReloadParticipant, error: ReloadFailure) {
+        if let Some(entry) = self.participant_mut(participant) {
+            entry.outcome = ReloadParticipantOutcome::Failed;
+            entry.error = Some(error);
+        }
+    }
+
+    fn finish(&mut self, outcome: ReloadOutcome) {
+        self.outcome = outcome;
+        self.completed_at = now_rfc3339();
+    }
+
+    fn safe_summary(&self) -> &'static str {
+        match self.outcome {
+            ReloadOutcome::Succeeded => "reload succeeded",
+            ReloadOutcome::Failed => "reload failed before applying every requested change",
+            ReloadOutcome::PartiallyApplied => {
+                "reload partially applied; inspect participant results"
+            }
+            ReloadOutcome::Unknown => {
+                "reload outcome is unknown; inspect live state before retrying"
+            }
+        }
+    }
+
+    fn any_applied(&self) -> bool {
+        self.participants
+            .iter()
+            .any(|entry| entry.outcome == ReloadParticipantOutcome::Applied)
+    }
+}
+
+impl ReloadParticipant {
+    fn all() -> [Self; 5] {
+        [
+            Self::RoutingTable,
+            Self::UpstreamTimeoutClients,
+            Self::PolicyTable,
+            Self::NamedPolicyRuntime,
+            Self::AccessPolicyStore,
+        ]
+    }
+}
+
+/// State exposed by the coordinator. A generation marks a terminal attempt
+/// boundary; it is not an atomic snapshot of every request path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ReloadState {
+    pub server_instance_id: String,
+    pub generation: u64,
+    pub running: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub running_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_outcome: Option<ReloadReport>,
+    pub consistency: ReloadConsistency,
+    /// Bounded reports for prior mixed/unknown states in this process boot.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mixed_state_history: Vec<ReloadReport>,
+}
+
+/// Rejection before a reload operation is admitted. These conditions leave the
+/// generation unchanged and cannot mutate live configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadAdmissionError {
+    Unsupported,
+    ServerInstanceChanged,
+    StaleGeneration,
+    ReloadInProgress,
+    GenerationExhausted,
+}
+
+impl ReloadAdmissionError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Unsupported => "unsupported_reload",
+            Self::ServerInstanceChanged => "server_instance_changed",
+            Self::StaleGeneration => "stale_generation",
+            Self::ReloadInProgress => "reload_in_progress",
+            Self::GenerationExhausted => "generation_exhausted",
+        }
+    }
+}
+
+impl fmt::Display for ReloadAdmissionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for ReloadAdmissionError {}
+
+/// A coordinator-issued capability to execute exactly one admitted reload.
+/// It is intentionally non-cloneable: dropping it before mutation cancels the
+/// admission, and dropping it after mutation records an unknown mixed state.
+pub struct ReloadReservation {
+    coordinator: Arc<ReloadCoordinator>,
+    ticket: uuid::Uuid,
+    server_instance_id: String,
+    generation: u64,
+    mutation_started: AtomicBool,
+    completed: AtomicBool,
+    progress: Mutex<Option<ReloadReport>>,
+}
+
+impl ReloadReservation {
+    /// Boot identity this reservation was issued under.
+    pub fn server_instance_id(&self) -> &str {
+        &self.server_instance_id
+    }
+
+    /// The generation assigned to this attempt when it reaches a terminal
+    /// report. The coordinator's public generation advances only then.
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    fn mark_mutation_started(&self) {
+        self.mutation_started.store(true, Ordering::Release);
+    }
+
+    fn update_progress(&self, report: &ReloadReport) {
+        let mut progress = match self.progress.lock() {
+            Ok(progress) => progress,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *progress = Some(report.clone());
+    }
+
+    fn progress(&self) -> Option<ReloadReport> {
+        match self.progress.lock() {
+            Ok(progress) => progress.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    fn belongs_to(&self, coordinator: &Arc<ReloadCoordinator>) -> bool {
+        Arc::ptr_eq(&self.coordinator, coordinator)
+    }
+}
+
+impl Drop for ReloadReservation {
+    fn drop(&mut self) {
+        if self.completed.load(Ordering::Acquire) {
+            return;
+        }
+        if self.mutation_started.load(Ordering::Acquire) {
+            self.coordinator.interrupted(self, self.progress());
+        } else {
+            self.coordinator.abandon(self);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CoordinatorState {
+    server_instance_id: String,
+    generation: u64,
+    running: Option<(uuid::Uuid, u64)>,
+    last_outcome: Option<ReloadReport>,
+    consistency: ReloadConsistency,
+    mixed_state_history: VecDeque<ReloadReport>,
+}
+
+/// Process-local ownership of reload admission, execution state, and mixed
+/// state history. It never accesses the remote operation registry: callers
+/// retain their registry lock, reserve here, install their record, then run the
+/// reservation after releasing that registry lock.
+pub(crate) struct ReloadCoordinator {
+    state: Mutex<CoordinatorState>,
+}
+
+impl ReloadCoordinator {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(CoordinatorState {
+                server_instance_id: uuid::Uuid::new_v4().to_string(),
+                generation: 0,
+                running: None,
+                last_outcome: None,
+                consistency: ReloadConsistency::Consistent,
+                mixed_state_history: VecDeque::new(),
+            }),
+        })
+    }
+
+    pub(crate) fn state(&self) -> ReloadState {
+        let state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        ReloadState {
+            server_instance_id: state.server_instance_id.clone(),
+            generation: state.generation,
+            running: state.running.is_some(),
+            running_generation: state.running.map(|(_, generation)| generation),
+            last_outcome: state.last_outcome.clone(),
+            consistency: state.consistency,
+            mixed_state_history: state.mixed_state_history.iter().cloned().collect(),
+        }
+    }
+
+    pub(crate) fn reserve_remote(
+        self: &Arc<Self>,
+        expected_instance: &str,
+        expected_generation: u64,
+    ) -> Result<ReloadReservation, ReloadAdmissionError> {
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if state.server_instance_id != expected_instance {
+            return Err(ReloadAdmissionError::ServerInstanceChanged);
+        }
+        if state.generation != expected_generation {
+            return Err(ReloadAdmissionError::StaleGeneration);
+        }
+        Self::reserve_locked(self, &mut state)
+    }
+
+    pub(crate) fn reserve_local(
+        self: &Arc<Self>,
+    ) -> Result<ReloadReservation, ReloadAdmissionError> {
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        Self::reserve_locked(self, &mut state)
+    }
+
+    fn reserve_locked(
+        coordinator: &Arc<Self>,
+        state: &mut CoordinatorState,
+    ) -> Result<ReloadReservation, ReloadAdmissionError> {
+        if state.running.is_some() {
+            return Err(ReloadAdmissionError::ReloadInProgress);
+        }
+        let generation = state
+            .generation
+            .checked_add(1)
+            .ok_or(ReloadAdmissionError::GenerationExhausted)?;
+        let ticket = uuid::Uuid::new_v4();
+        state.running = Some((ticket, generation));
+        Ok(ReloadReservation {
+            coordinator: Arc::clone(coordinator),
+            ticket,
+            server_instance_id: state.server_instance_id.clone(),
+            generation,
+            mutation_started: AtomicBool::new(false),
+            completed: AtomicBool::new(false),
+            progress: Mutex::new(None),
+        })
+    }
+
+    pub(crate) fn complete(&self, reservation: &ReloadReservation, mut report: ReloadReport) {
+        report.completed_at = now_rfc3339();
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if state.running != Some((reservation.ticket, reservation.generation)) {
+            return;
+        }
+        state.running = None;
+        state.generation = reservation.generation;
+        state.consistency = match report.outcome {
+            ReloadOutcome::Succeeded => ReloadConsistency::Consistent,
+            ReloadOutcome::PartiallyApplied | ReloadOutcome::Unknown => ReloadConsistency::Mixed,
+            // A failed candidate with no reported live mutation cannot repair
+            // a previous mixed state. Keep its warning visible until a later
+            // full success establishes a coherent replacement.
+            ReloadOutcome::Failed => state.consistency,
+        };
+        if matches!(
+            report.outcome,
+            ReloadOutcome::PartiallyApplied | ReloadOutcome::Unknown
+        ) {
+            state.mixed_state_history.push_back(report.clone());
+            while state.mixed_state_history.len() > MAX_MIXED_STATE_HISTORY {
+                let _ = state.mixed_state_history.pop_front();
+            }
+        }
+        state.last_outcome = Some(report);
+        reservation.completed.store(true, Ordering::Release);
+    }
+
+    fn abandon(&self, reservation: &ReloadReservation) {
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if state.running == Some((reservation.ticket, reservation.generation)) {
+            state.running = None;
+        }
+    }
+
+    fn interrupted(&self, reservation: &ReloadReservation, progress: Option<ReloadReport>) {
+        let mut report = match progress {
+            Some(report) => report,
+            None => ReloadReport::pending(
+                reservation.server_instance_id.clone(),
+                reservation.generation,
+            ),
+        };
+        // Keep every participant result that was recorded before cancellation.
+        // An interrupted attempt is overall unknown, but overwriting an earlier
+        // `Applied` result would hide a live change precisely when operators
+        // need to inspect the mixed runtime state.
+        report.finish(ReloadOutcome::Unknown);
+        self.complete(reservation, report);
+    }
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+/// Return configuration fields that are not owned by the live reload
+/// participants. This is intentionally conservative: a field is admitted only
+/// when its current runtime consumer can observe a replacement without
+/// rebuilding the daemon pipeline.
+fn restart_required_fields(
+    current: &bitrouter_sdk::config::Config,
+    candidate: &bitrouter_sdk::config::Config,
+    unclassified_fields: Option<&BTreeSet<String>>,
+) -> Vec<String> {
+    let mut fields = BTreeSet::new();
+    if let Some(unclassified_fields) = unclassified_fields {
+        fields.extend(unclassified_fields.iter().cloned());
+    }
+
+    if current.server.listen != candidate.server.listen {
+        fields.insert("server.listen".to_string());
+    }
+    if current.server.control_socket != candidate.server.control_socket {
+        fields.insert("server.control_socket".to_string());
+    }
+    if current.server.log_level != candidate.server.log_level {
+        fields.insert("server.log_level".to_string());
+    }
+    if current.server.skip_auth != candidate.server.skip_auth {
+        fields.insert("server.skip_auth".to_string());
+    }
+    // This switch changes whether assembly fills provider defaults and merges
+    // the public registry. The reloader can refresh its routing table, but it
+    // cannot rebuild every startup-owned consumer that was assembled from the
+    // resulting provider set, such as auth adapters and pricing state.
+    if current.inherit_defaults != candidate.inherit_defaults {
+        fields.insert("inherit_defaults".to_string());
+    }
+    if current.control != candidate.control {
+        fields.insert("control".to_string());
+    }
+    if current.chat != candidate.chat {
+        fields.insert("chat".to_string());
+    }
+    if current.database.url != candidate.database.url {
+        fields.insert("database.url".to_string());
+    }
+    if serialized_values_differ(&current.eval, &candidate.eval) {
+        fields.insert("eval".to_string());
+    }
+    if current.trajectory != candidate.trajectory {
+        fields.insert("trajectory".to_string());
+    }
+    if current.continuation != candidate.continuation {
+        fields.insert("continuation".to_string());
+    }
+    if current.plugins != candidate.plugins {
+        fields.insert("plugins".to_string());
+    }
+    if mcp_config_changed(current, candidate) {
+        fields.insert("mcp".to_string());
+    }
+    if mcp_servers_changed(current, candidate) {
+        fields.insert("mcp_servers".to_string());
+    }
+    if server_tools_changed(current, candidate) {
+        fields.insert("server_tools".to_string());
+    }
+    if agents_changed(current, candidate) {
+        fields.insert("agents".to_string());
+    }
+    if current.upstream.fallback_backoff_ms != candidate.upstream.fallback_backoff_ms {
+        fields.insert("upstream.fallback_backoff_ms".to_string());
+    }
+    if pricing_signature(current) != pricing_signature(candidate) {
+        fields.insert("providers.*.models.*.pricing".to_string());
+    }
+
+    // These providers install protocol or authentication adapters during
+    // assembly. Their routing entries can change, but adding or removing the
+    // adapter-bearing provider itself needs a rebuilt executor.
+    for provider_id in [
+        "bitrouter",
+        "github-copilot",
+        "anthropic",
+        "claude-code",
+        "openai-codex",
+        "supergrok",
+        bitrouter_providers::antigravity::PROVIDER_ID,
+    ] {
+        if current.providers.contains_key(provider_id)
+            != candidate.providers.contains_key(provider_id)
+        {
+            fields.insert(format!("providers.{provider_id}"));
+        }
+    }
+
+    fields.into_iter().collect()
+}
+
+/// Return paths present in the raw server-owned candidate that the current
+/// configuration schema does not describe. The SDK deliberately accepts
+/// unknown fields for forward-compatible local files, but remote reload must
+/// be conservative: an ignored nested field is not proof that a live consumer
+/// can apply it. Dynamic maps remain open only where their schema explicitly
+/// says what their values are (for example `providers.<id>`).
+fn unclassified_config_paths(value: &serde_json::Value) -> BTreeSet<String> {
+    let schema = schemars::schema_for!(bitrouter_sdk::config::Config);
+    let root = schema.as_value();
+    let mut fields = BTreeSet::new();
+    collect_unclassified_schema_paths(value, root, root, "", &mut fields);
+    fields
+}
+
+fn collect_unclassified_schema_paths(
+    value: &serde_json::Value,
+    schema: &serde_json::Value,
+    root: &serde_json::Value,
+    path: &str,
+    fields: &mut BTreeSet<String>,
+) {
+    let Some(schema) = resolve_schema(schema, root) else {
+        if !path.is_empty() {
+            fields.insert(path.to_string());
+        }
+        return;
+    };
+    if schema.as_bool() == Some(false) {
+        if !path.is_empty() {
+            fields.insert(path.to_string());
+        }
+        return;
+    }
+    if schema.as_bool() == Some(true) {
+        return;
+    }
+    if !schema_accepts_value_kind(schema, value) {
+        if !path.is_empty() {
+            fields.insert(path.to_string());
+        }
+        return;
+    }
+
+    for union in ["anyOf", "oneOf"] {
+        if let Some(variants) = schema.get(union).and_then(serde_json::Value::as_array) {
+            let mut best: Option<BTreeSet<String>> = None;
+            for variant in variants {
+                let mut candidate = BTreeSet::new();
+                collect_unclassified_schema_paths(value, variant, root, path, &mut candidate);
+                if candidate.is_empty() {
+                    return;
+                }
+                if best
+                    .as_ref()
+                    .is_none_or(|current| candidate.len() < current.len())
+                {
+                    best = Some(candidate);
+                }
+            }
+            if let Some(best) = best {
+                fields.extend(best);
+            }
+            return;
+        }
+    }
+
+    let all_of = schema.get("allOf").and_then(serde_json::Value::as_array);
+    let has_direct_object_shape = schema.get("properties").is_some()
+        || schema.get("additionalProperties").is_some()
+        || schema.get("unevaluatedProperties").is_some()
+        || schema.get("patternProperties").is_some();
+
+    if !(all_of.is_some() && !has_direct_object_shape) {
+        match value {
+            serde_json::Value::Object(values) => {
+                let properties = schema
+                    .get("properties")
+                    .and_then(serde_json::Value::as_object);
+                let additional = schema
+                    .get("additionalProperties")
+                    .or_else(|| schema.get("unevaluatedProperties"));
+                for (name, child) in values {
+                    let child_path = schema_child_path(path, name);
+                    if let Some(property) = schema_property(properties, path, name) {
+                        collect_unclassified_schema_paths(
+                            child,
+                            property,
+                            root,
+                            &child_path,
+                            fields,
+                        );
+                    } else if let Some(additional) = additional {
+                        if additional.as_bool() == Some(false) {
+                            fields.insert(child_path);
+                        } else if additional.as_bool() != Some(true) {
+                            collect_unclassified_schema_paths(
+                                child,
+                                additional,
+                                root,
+                                &child_path,
+                                fields,
+                            );
+                        }
+                    } else {
+                        fields.insert(child_path);
+                    }
+                }
+            }
+            serde_json::Value::Array(values) => {
+                if let Some(items) = schema.get("items") {
+                    for (index, child) in values.iter().enumerate() {
+                        let child_path = format!("{path}[{index}]");
+                        collect_unclassified_schema_paths(child, items, root, &child_path, fields);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(all_of) = all_of {
+        for part in all_of {
+            collect_unclassified_schema_paths(value, part, root, path, fields);
+        }
+    }
+}
+
+fn schema_property<'a>(
+    properties: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    parent_path: &str,
+    name: &str,
+) -> Option<&'a serde_json::Value> {
+    let properties = properties?;
+    if let Some(property) = properties.get(name) {
+        return Some(property);
+    }
+    // This accepted serde alias predates remote administration. Schemars
+    // documents the canonical `mode` name only, but the parser gives
+    // `policy.writeback` the exact same live meaning.
+    if parent_path == "policy" && name == "writeback" {
+        return properties.get("mode");
+    }
+    None
+}
+
+fn resolve_schema<'a>(
+    schema: &'a serde_json::Value,
+    root: &'a serde_json::Value,
+) -> Option<&'a serde_json::Value> {
+    match schema.get("$ref").and_then(serde_json::Value::as_str) {
+        Some(reference) => reference
+            .strip_prefix('#')
+            .and_then(|pointer| root.pointer(pointer)),
+        None => Some(schema),
+    }
+}
+
+fn schema_child_path(parent: &str, child: &str) -> String {
+    if parent.is_empty() {
+        child.to_string()
+    } else {
+        format!("{parent}.{child}")
+    }
+}
+
+fn schema_accepts_value_kind(schema: &serde_json::Value, value: &serde_json::Value) -> bool {
+    let Some(types) = schema.get("type") else {
+        return true;
+    };
+    match types {
+        serde_json::Value::String(kind) => json_value_matches_kind(value, kind),
+        serde_json::Value::Array(kinds) => kinds.iter().any(|kind| {
+            kind.as_str()
+                .is_some_and(|kind| json_value_matches_kind(value, kind))
+        }),
+        _ => true,
+    }
+}
+
+fn json_value_matches_kind(value: &serde_json::Value, kind: &str) -> bool {
+    match kind {
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "string" => value.is_string(),
+        "boolean" => value.is_boolean(),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        _ => true,
+    }
+}
+
+fn serialized_values_differ<T: Serialize>(current: &T, candidate: &T) -> bool {
+    match (
+        serde_json::to_value(current),
+        serde_json::to_value(candidate),
+    ) {
+        (Ok(current), Ok(candidate)) => current != candidate,
+        // Serialization is local and deterministic for these schema types. A
+        // future failure means the field's consumer has changed, so reject the
+        // remote attempt rather than claim the field is reloadable.
+        _ => true,
+    }
+}
+
+fn mcp_config_changed(
+    current: &bitrouter_sdk::config::Config,
+    candidate: &bitrouter_sdk::config::Config,
+) -> bool {
+    let current = &current.mcp;
+    let candidate = &candidate.mcp;
+    current.aggregate.enabled != candidate.aggregate.enabled
+        || current.aggregate.route != candidate.aggregate.route
+        || current.cache.enabled != candidate.cache.enabled
+        || current.cache.tools_list_ttl_secs != candidate.cache.tools_list_ttl_secs
+        || current.cache.resources_list_ttl_secs != candidate.cache.resources_list_ttl_secs
+        || current.cache.resources_templates_list_ttl_secs
+            != candidate.cache.resources_templates_list_ttl_secs
+        || current.cache.prompts_list_ttl_secs != candidate.cache.prompts_list_ttl_secs
+        || current.cache.max_entries_per_server != candidate.cache.max_entries_per_server
+        || current.upstream_protocol != candidate.upstream_protocol
+}
+
+fn mcp_servers_changed(
+    current: &bitrouter_sdk::config::Config,
+    candidate: &bitrouter_sdk::config::Config,
+) -> bool {
+    current.mcp_servers.len() != candidate.mcp_servers.len()
+        || current.mcp_servers.iter().any(|(id, current_server)| {
+            candidate
+                .mcp_servers
+                .get(id)
+                .is_none_or(|candidate_server| {
+                    current_server.name != candidate_server.name
+                        || current_server.transport != candidate_server.transport
+                        || current_server.aggregate != candidate_server.aggregate
+                        || current_server.tool_prefix != candidate_server.tool_prefix
+                })
+        })
+}
+
+fn agents_changed(
+    current: &bitrouter_sdk::config::Config,
+    candidate: &bitrouter_sdk::config::Config,
+) -> bool {
+    current.agents.len() != candidate.agents.len()
+        || current.agents.iter().any(|(id, current_agent)| {
+            candidate.agents.get(id).is_none_or(|candidate_agent| {
+                current_agent.name != candidate_agent.name
+                    || current_agent.transport != candidate_agent.transport
+            })
+        })
+}
+
+fn server_tools_changed(
+    current: &bitrouter_sdk::config::Config,
+    candidate: &bitrouter_sdk::config::Config,
+) -> bool {
+    // This comparison never leaves the process. Several tool settings contain
+    // credential-bearing values but do not implement `Serialize`; `Debug` is
+    // only used to compare the in-memory values and is never logged or exposed.
+    format!("{:?}", current.server_tools) != format!("{:?}", candidate.server_tools)
+}
+
+fn pricing_signature(config: &bitrouter_sdk::config::Config) -> Vec<String> {
+    let mut entries = Vec::new();
+    for (provider_id, provider) in &config.providers {
+        for model in &provider.models {
+            if let Some(pricing) = &model.pricing {
+                let provider_model_id = model.provider_model_id.as_deref().unwrap_or_default();
+                entries.push(format!(
+                    "{provider_id}|{}|{}|{pricing:?}",
+                    model.id, provider_model_id
+                ));
+            }
+        }
+    }
+    entries.sort();
+    entries
+}
 
 /// Re-activate providers that have a credential in the OAuth store, loading the
 /// default store. Best-effort: an unreadable store is a no-op. Mirrors the
@@ -28,6 +892,18 @@ fn activate_stored_credential_providers(config: &mut bitrouter_sdk::config::Conf
     {
         bitrouter_providers::activate_stored_credential_providers(config, &store);
     }
+}
+
+/// Apply the same non-mutating configuration enrichment used when the daemon
+/// constructs a replacement routing snapshot. Keeping this in one helper makes
+/// the current and candidate shapes comparable before remote classification.
+async fn resolve_reloadable_config(config: &mut bitrouter_sdk::config::Config) {
+    bitrouter_providers::apply_builtin_defaults(config);
+    crate::claude_code::enable_if_logged_in(config);
+    crate::assemble::merge_registry_into(config).await;
+    activate_stored_credential_providers(config);
+    // Discovery is bounded by the SDK and completes before any live swap.
+    bitrouter_sdk::config::discover_models(config).await;
 }
 
 /// Whether the daemon is running against a `bitrouter.yaml` on disk
@@ -55,6 +931,12 @@ pub struct AppReloader {
     /// built-in catalog can be applied above the SDK — and swap it in
     /// via `ConfigRoutingTable::replace_config`.
     routing_table: Arc<bitrouter_sdk::config::ConfigRoutingTable>,
+    /// The fully assembled configuration at daemon startup. Local reloads may
+    /// refresh the routing snapshot with fields whose actual consumers were
+    /// wired only at startup; remote admission must keep comparing those
+    /// fields to this immutable baseline rather than accepting that stale
+    /// local snapshot as evidence that they became live-reloadable.
+    startup_config: bitrouter_sdk::config::Config,
     /// Concrete upstream HTTP executor. Timeout knobs are client-level, so a
     /// config reload must rebuild the live executor's client set too.
     upstream_executor: Arc<bitrouter_sdk::language_model::HttpExecutor>,
@@ -64,10 +946,84 @@ pub struct AppReloader {
     /// without this the daemon kept serving the tiers it started with, and
     /// only `restart` applied an edit.
     policy_table_router: Option<Arc<crate::policy_table_router::PolicyTableRouter>>,
-    /// Serializes the complete multi-subsystem reload transaction. The routing
-    /// table's own lock is narrower and cannot protect policy prepare/commit.
-    reload_lock: tokio::sync::Mutex<()>,
+    /// Owns admission for local IPC, SIGHUP, and guarded remote reloads. The
+    /// routing table's own lock is narrower and cannot protect preparation or
+    /// the other live participants.
+    coordinator: Arc<ReloadCoordinator>,
     source: ReloadSource,
+    /// Test-only boundary fault. Production builds have no way to configure
+    /// this; it exists so the coordinator's truthful partial-state reporting
+    /// can be exercised without adding a runtime fault-injection surface.
+    #[cfg(test)]
+    test_apply_failure: Option<ReloadParticipant>,
+    #[cfg(test)]
+    test_pause_after_prepare: Option<Arc<TestPreparationPause>>,
+    #[cfg(test)]
+    test_pause_during_prepare: Option<Arc<TestPreparationPause>>,
+    #[cfg(test)]
+    test_preparation_timeout: Option<Duration>,
+}
+
+#[derive(Clone, Copy)]
+enum ReloadInvocation {
+    Local,
+    Remote,
+}
+
+#[cfg(test)]
+struct TestPreparationPause {
+    prepared: tokio::sync::Notify,
+    resume: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+impl TestPreparationPause {
+    fn new() -> Self {
+        Self {
+            prepared: tokio::sync::Notify::new(),
+            resume: tokio::sync::Notify::new(),
+        }
+    }
+}
+
+struct PreparedReload {
+    config: bitrouter_sdk::config::Config,
+    timeout_clients: bitrouter_sdk::language_model::executor::PreparedProviderTimeouts,
+    policy_table: PreparedPolicyTable,
+    named_policy_runtime: Option<crate::policy_lock::PreparedPolicySnapshot>,
+    access_policy_store: Option<crate::policy::store::PreparedPolicyStore>,
+}
+
+enum PreparedPolicyTable {
+    Apply(Arc<crate::policy_table_router::PolicyTable>),
+    Unchanged,
+}
+
+struct PreparationError {
+    participant: ReloadParticipant,
+    failure: ReloadFailure,
+    restart_required_fields: Vec<String>,
+}
+
+impl PreparationError {
+    fn failed(participant: ReloadParticipant, code: &str, message: &str) -> Self {
+        Self {
+            participant,
+            failure: ReloadFailure::new(code, message),
+            restart_required_fields: Vec::new(),
+        }
+    }
+
+    fn restart_required(fields: Vec<String>) -> Self {
+        Self {
+            participant: ReloadParticipant::RoutingTable,
+            failure: ReloadFailure::new(
+                "restart_required",
+                "candidate changes a field that is only applied at daemon startup",
+            ),
+            restart_required_fields: fields,
+        }
+    }
 }
 
 impl AppReloader {
@@ -78,14 +1034,24 @@ impl AppReloader {
         upstream_executor: Arc<bitrouter_sdk::language_model::HttpExecutor>,
         source: ReloadSource,
     ) -> Self {
+        let startup_config = routing_table.snapshot_config();
         Self {
             policy_store,
             routing_table,
+            startup_config,
             upstream_executor,
             policy_runtime: None,
             policy_table_router: None,
-            reload_lock: tokio::sync::Mutex::new(()),
+            coordinator: ReloadCoordinator::new(),
             source,
+            #[cfg(test)]
+            test_apply_failure: None,
+            #[cfg(test)]
+            test_pause_after_prepare: None,
+            #[cfg(test)]
+            test_pause_during_prepare: None,
+            #[cfg(test)]
+            test_preparation_timeout: None,
         }
     }
 
@@ -99,32 +1065,410 @@ impl AppReloader {
         self
     }
 
-    /// Rebuild the `policy_table:` spec from the fresh config and install it
-    /// into the live transform.
-    ///
-    /// Mirrors the assembly-time derivation exactly — including the
-    /// `policy.mode` overlay on the adequacy section — so a reloaded table and
-    /// a restarted one are the same table. An empty `tiers:` map yields an
-    /// inert spec rather than leaving the previous one in force: removing
-    /// every tier must actually stop the rewriting.
-    fn replace_policy_table(&self, fresh: &bitrouter_sdk::config::Config) -> anyhow::Result<()> {
-        let Some(router) = &self.policy_table_router else {
-            return Ok(());
-        };
+    #[cfg(test)]
+    fn with_test_apply_failure(mut self, participant: ReloadParticipant) -> Self {
+        self.test_apply_failure = Some(participant);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_test_pause_after_prepare(mut self, pause: Arc<TestPreparationPause>) -> Self {
+        self.test_pause_after_prepare = Some(pause);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_test_pause_during_prepare(mut self, pause: Arc<TestPreparationPause>) -> Self {
+        self.test_pause_during_prepare = Some(pause);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_test_preparation_timeout(mut self, timeout: Duration) -> Self {
+        self.test_preparation_timeout = Some(timeout);
+        self
+    }
+
+    fn should_fail_apply(&self, participant: ReloadParticipant) -> bool {
+        #[cfg(test)]
+        {
+            self.test_apply_failure == Some(participant)
+        }
+        #[cfg(not(test))]
+        {
+            let _ = participant;
+            false
+        }
+    }
+
+    async fn wait_after_prepare(&self) {
+        #[cfg(test)]
+        if let Some(pause) = &self.test_pause_after_prepare {
+            pause.prepared.notify_one();
+            pause.resume.notified().await;
+        }
+    }
+
+    async fn wait_during_prepare(&self) {
+        #[cfg(test)]
+        if let Some(pause) = &self.test_pause_during_prepare {
+            pause.prepared.notify_one();
+            pause.resume.notified().await;
+        }
+    }
+
+    fn preparation_timeout(&self) -> Duration {
+        #[cfg(test)]
+        if let Some(timeout) = self.test_preparation_timeout {
+            return timeout;
+        }
+        Duration::from_secs(PREPARATION_TIMEOUT_SECONDS)
+    }
+
+    /// Build a replacement policy table before any live participant changes.
+    /// A daemon that started without this transform cannot add it later because
+    /// the transform is part of the built pipeline, so remote reload correctly
+    /// classifies that shape as restart-required.
+    fn prepare_policy_table(
+        &self,
+        fresh: &bitrouter_sdk::config::Config,
+    ) -> Result<PreparedPolicyTable, PreparationError> {
         let mut effective = fresh.policy_table.clone();
         effective.adequacy = fresh
             .policy
             .mode
             .apply_to_adequacy(&fresh.policy_table.adequacy);
-        let table = crate::policy_table_router::PolicyTable::from_config(&effective)
-            .unwrap_or_else(crate::policy_table_router::PolicyTable::inert);
-        if router.replace_table(table) {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(
-                "policy table lock was poisoned; the daemon is still serving the previous tiers"
-            ))
+        let candidate = match crate::policy_table_router::PolicyTable::from_config(&effective) {
+            Some(table) => table,
+            None => crate::policy_table_router::PolicyTable::inert(),
+        };
+        match (&self.policy_table_router, effective.tiers.is_empty()) {
+            (Some(_), _) => Ok(PreparedPolicyTable::Apply(candidate)),
+            (None, true) => Ok(PreparedPolicyTable::Unchanged),
+            (None, false) => Err(PreparationError::restart_required(vec![
+                "policy_table".to_string(),
+            ])),
         }
+    }
+
+    async fn prepare_candidate(
+        &self,
+    ) -> Result<(bitrouter_sdk::config::Config, Option<BTreeSet<String>>), PreparationError> {
+        let (mut fresh, fields) = match &self.source {
+            ReloadSource::File(path) => {
+                let raw = tokio::fs::read_to_string(path).await.map_err(|error| {
+                    tracing::warn!(error = %error, "reload could not read configuration candidate");
+                    PreparationError::failed(
+                        ReloadParticipant::RoutingTable,
+                        "config_prepare_failed",
+                        "reload could not read the server configuration",
+                    )
+                })?;
+                let config = bitrouter_sdk::config::parse_with(
+                    &raw,
+                    bitrouter_sdk::config::env_lookup,
+                )
+                .map_err(|error| {
+                    tracing::warn!(error = %error, "reload configuration candidate is invalid");
+                    PreparationError::failed(
+                        ReloadParticipant::RoutingTable,
+                        "config_prepare_failed",
+                        "reload configuration is invalid",
+                    )
+                })?;
+                let substituted = bitrouter_sdk::config::substitute_env(&raw).map_err(|error| {
+                    tracing::warn!(error = %error, "reload configuration substitution failed");
+                    PreparationError::failed(
+                        ReloadParticipant::RoutingTable,
+                        "config_prepare_failed",
+                        "reload configuration is invalid",
+                    )
+                })?;
+                let value =
+                    serde_saphyr::from_str::<serde_json::Value>(&substituted).map_err(|error| {
+                        tracing::warn!(error = %error, "reload configuration shape is invalid");
+                        PreparationError::failed(
+                            ReloadParticipant::RoutingTable,
+                            "config_prepare_failed",
+                            "reload configuration is invalid",
+                        )
+                    })?;
+                if !value.is_object() {
+                    return Err(PreparationError::failed(
+                        ReloadParticipant::RoutingTable,
+                        "config_prepare_failed",
+                        "reload configuration must be a mapping",
+                    ));
+                }
+                (config, Some(unclassified_config_paths(&value)))
+            }
+            ReloadSource::Default => {
+                let mut config = bitrouter_providers::zero_config();
+                crate::cloud::enable_in_zero_config(&mut config);
+                (config, None)
+            }
+        };
+
+        // Discovery is bounded by the SDK and runs here rather than during the
+        // live routing-table swap. Every later participant consumes this exact
+        // prepared candidate.
+        resolve_reloadable_config(&mut fresh).await;
+        Ok((fresh, fields))
+    }
+
+    async fn prepare(
+        &self,
+        invocation: ReloadInvocation,
+    ) -> Result<PreparedReload, PreparationError> {
+        self.wait_during_prepare().await;
+        let (config, unclassified_fields) = self.prepare_candidate().await?;
+        if matches!(invocation, ReloadInvocation::Remote) {
+            let restart_required = restart_required_fields(
+                &self.startup_config,
+                &config,
+                unclassified_fields.as_ref(),
+            );
+            if !restart_required.is_empty() {
+                return Err(PreparationError::restart_required(restart_required));
+            }
+        }
+        let policy_table = self.prepare_policy_table(&config)?;
+        let named_policy_runtime = match &self.policy_runtime {
+            Some(runtime) => {
+                let path = match &self.source {
+                    ReloadSource::File(path) => Some(path.as_path()),
+                    ReloadSource::Default => None,
+                };
+                Some(runtime.prepare_for_config(&config, path).await.map_err(|error| {
+                    tracing::warn!(error = %error, "reload named policy preparation failed");
+                    PreparationError::failed(
+                        ReloadParticipant::NamedPolicyRuntime,
+                        "policy_prepare_failed",
+                        "named policy preparation failed",
+                    )
+                })?)
+            }
+            None => None,
+        };
+        let (global_timeouts, provider_timeouts) =
+            crate::assemble::resolved_upstream_timeouts(&config);
+        let timeout_clients = self
+            .upstream_executor
+            .prepare_provider_timeouts(global_timeouts, provider_timeouts)
+            .map_err(|error| {
+                tracing::warn!(error = %error, "reload timeout client preparation failed");
+                PreparationError::failed(
+                    ReloadParticipant::UpstreamTimeoutClients,
+                    "timeout_prepare_failed",
+                    "upstream timeout client preparation failed",
+                )
+            })?;
+        let access_policy_store = self.policy_store.prepare_reload().await.map_err(|error| {
+            tracing::warn!(error = %error, "reload access-policy preparation failed");
+            PreparationError::failed(
+                ReloadParticipant::AccessPolicyStore,
+                "access_policy_prepare_failed",
+                "access-policy preparation failed",
+            )
+        })?;
+        Ok(PreparedReload {
+            config,
+            timeout_clients,
+            policy_table,
+            named_policy_runtime,
+            access_policy_store,
+        })
+    }
+
+    async fn execute_reservation(
+        &self,
+        reservation: ReloadReservation,
+        invocation: ReloadInvocation,
+        env: Vec<(String, String)>,
+    ) -> ReloadReport {
+        let mut report = ReloadReport::pending(
+            reservation.server_instance_id.clone(),
+            reservation.generation,
+        );
+        reservation.update_progress(&report);
+
+        // A reservation is a private coordinator capability. Refuse to run it
+        // against another app instance before an override is installed or any
+        // candidate input is read; dropping it then clears its original
+        // coordinator's admission.
+        if !reservation.belongs_to(&self.coordinator) {
+            report.participant_failed(
+                ReloadParticipant::RoutingTable,
+                ReloadFailure::new(
+                    "invalid_reservation",
+                    "reload reservation does not belong to this daemon",
+                ),
+            );
+            report.finish(ReloadOutcome::Failed);
+            reservation.update_progress(&report);
+            return report;
+        }
+
+        // The reservation excludes every other local, remote, and SIGHUP
+        // reload. Installing the owner-trusted IPC override here keeps it in
+        // that same critical section; remote requests never pass an override.
+        if matches!(invocation, ReloadInvocation::Local) && !env.is_empty() {
+            let overrides = env.into_iter().collect();
+            bitrouter_sdk::config::set_env_overrides(overrides);
+            tracing::info!("env override map updated by local reload");
+        }
+
+        let prepared = match tokio::time::timeout(
+            self.preparation_timeout(),
+            self.prepare(invocation),
+        )
+        .await
+        {
+            Ok(Ok(prepared)) => prepared,
+            Ok(Err(error)) => {
+                report.participant_failed(error.participant, error.failure);
+                report.restart_required_fields = error.restart_required_fields;
+                report.finish(ReloadOutcome::Failed);
+                reservation.update_progress(&report);
+                self.coordinator.complete(&reservation, report.clone());
+                return report;
+            }
+            Err(_) => {
+                report.participant_failed(
+                    ReloadParticipant::RoutingTable,
+                    ReloadFailure::new(
+                        "preparation_timed_out",
+                        "reload preparation exceeded its time limit",
+                    ),
+                );
+                report.finish(ReloadOutcome::Failed);
+                reservation.update_progress(&report);
+                self.coordinator.complete(&reservation, report.clone());
+                return report;
+            }
+        };
+
+        // Test-only seam verifies that every later participant consumes these
+        // objects even if the source files change after preparation.
+        self.wait_after_prepare().await;
+        reservation.mark_mutation_started();
+        if self.should_fail_apply(ReloadParticipant::RoutingTable) {
+            report.participant_failed(
+                ReloadParticipant::RoutingTable,
+                ReloadFailure::new("fault_injected", "routing table update failed"),
+            );
+        } else {
+            match self
+                .routing_table
+                .replace_prepared_config(prepared.config)
+                .await
+            {
+                Ok(()) => report.participant_applied(ReloadParticipant::RoutingTable),
+                Err(error) => {
+                    tracing::warn!(error = %error, "reload routing table swap failed");
+                    report.participant_failed(
+                        ReloadParticipant::RoutingTable,
+                        ReloadFailure::new("routing_apply_failed", "routing table update failed"),
+                    );
+                }
+            }
+        }
+        reservation.update_progress(&report);
+
+        if self.should_fail_apply(ReloadParticipant::UpstreamTimeoutClients) {
+            report.participant_failed(
+                ReloadParticipant::UpstreamTimeoutClients,
+                ReloadFailure::new("fault_injected", "upstream timeout client update failed"),
+            );
+        } else {
+            self.upstream_executor
+                .commit_provider_timeouts(prepared.timeout_clients);
+            report.participant_applied(ReloadParticipant::UpstreamTimeoutClients);
+        }
+        reservation.update_progress(&report);
+
+        if self.should_fail_apply(ReloadParticipant::PolicyTable) {
+            report.participant_failed(
+                ReloadParticipant::PolicyTable,
+                ReloadFailure::new("fault_injected", "policy table update failed"),
+            );
+        } else {
+            match prepared.policy_table {
+                PreparedPolicyTable::Apply(table) => match &self.policy_table_router {
+                    Some(router) if router.replace_table(table) => {
+                        report.participant_applied(ReloadParticipant::PolicyTable);
+                    }
+                    Some(_) => report.participant_failed(
+                        ReloadParticipant::PolicyTable,
+                        ReloadFailure::new(
+                            "policy_table_apply_failed",
+                            "policy table update failed",
+                        ),
+                    ),
+                    None => report.participant_unchanged(ReloadParticipant::PolicyTable),
+                },
+                PreparedPolicyTable::Unchanged => {
+                    report.participant_unchanged(ReloadParticipant::PolicyTable);
+                }
+            }
+        }
+        reservation.update_progress(&report);
+
+        if self.should_fail_apply(ReloadParticipant::NamedPolicyRuntime) {
+            report.participant_failed(
+                ReloadParticipant::NamedPolicyRuntime,
+                ReloadFailure::new("fault_injected", "named policy runtime update failed"),
+            );
+        } else {
+            match (self.policy_runtime.as_ref(), prepared.named_policy_runtime) {
+                (Some(runtime), Some(prepared_runtime)) => {
+                    runtime.commit(prepared_runtime);
+                    report.participant_applied(ReloadParticipant::NamedPolicyRuntime);
+                }
+                _ => report.participant_unchanged(ReloadParticipant::NamedPolicyRuntime),
+            }
+        }
+        reservation.update_progress(&report);
+
+        if self.should_fail_apply(ReloadParticipant::AccessPolicyStore) {
+            report.participant_failed(
+                ReloadParticipant::AccessPolicyStore,
+                ReloadFailure::new("fault_injected", "access-policy store update failed"),
+            );
+        } else {
+            match prepared.access_policy_store {
+                Some(prepared_store) => match self.policy_store.commit_prepared(prepared_store) {
+                    Ok(()) => report.participant_applied(ReloadParticipant::AccessPolicyStore),
+                    Err(error) => {
+                        tracing::warn!(error = %error, "reload access-policy store swap failed");
+                        report.participant_failed(
+                            ReloadParticipant::AccessPolicyStore,
+                            ReloadFailure::new(
+                                "access_policy_apply_failed",
+                                "access-policy store update failed",
+                            ),
+                        );
+                    }
+                },
+                None => report.participant_unchanged(ReloadParticipant::AccessPolicyStore),
+            }
+        }
+
+        let failed = report
+            .participants
+            .iter()
+            .any(|entry| entry.outcome == ReloadParticipantOutcome::Failed);
+        let outcome = if !failed {
+            ReloadOutcome::Succeeded
+        } else if report.any_applied() {
+            ReloadOutcome::PartiallyApplied
+        } else {
+            ReloadOutcome::Failed
+        };
+        report.finish(outcome);
+        reservation.update_progress(&report);
+        self.coordinator.complete(&reservation, report.clone());
+        report
     }
 
     /// Attach the app's named routing-policy registry to the same reload fanout.
@@ -132,126 +1476,45 @@ impl AppReloader {
         self.policy_runtime = Some(runtime);
         self
     }
-
-    async fn replace_routing_and_timeouts(
-        &self,
-        fresh: bitrouter_sdk::config::Config,
-    ) -> bitrouter_sdk::Result<()> {
-        let (global_timeouts, provider_timeouts) =
-            crate::assemble::resolved_upstream_timeouts(&fresh);
-        self.routing_table.replace_config(fresh).await?;
-        self.upstream_executor
-            .reload_provider_timeouts(global_timeouts, provider_timeouts)?;
-        Ok(())
-    }
-
-    async fn replace_file_backed(
-        &self,
-        fresh: bitrouter_sdk::config::Config,
-        path: &std::path::Path,
-    ) -> anyhow::Result<()> {
-        let prepared = match &self.policy_runtime {
-            Some(runtime) => Some(runtime.prepare_for_config(&fresh, Some(path)).await?),
-            None => None,
-        };
-        self.replace_policy_table(&fresh)?;
-        self.replace_routing_and_timeouts(fresh).await?;
-        if let (Some(runtime), Some(prepared)) = (&self.policy_runtime, prepared) {
-            runtime.commit(prepared);
-        }
-        Ok(())
-    }
-
-    async fn replace_default(&self, fresh: bitrouter_sdk::config::Config) -> anyhow::Result<()> {
-        let prepared = match &self.policy_runtime {
-            Some(runtime) => Some(runtime.prepare_for_config(&fresh, None).await?),
-            None => None,
-        };
-        self.replace_policy_table(&fresh)?;
-        self.replace_routing_and_timeouts(fresh).await?;
-        if let (Some(runtime), Some(prepared)) = (&self.policy_runtime, prepared) {
-            runtime.commit(prepared);
-        }
-        Ok(())
-    }
 }
 
 #[async_trait::async_trait]
 impl DaemonReloader for AppReloader {
     async fn reload(&self) -> anyhow::Result<()> {
-        let _reload_guard = self.reload_lock.lock().await;
-        let mut errors: Vec<String> = Vec::new();
-        let routing_outcome = match &self.source {
-            // File source: re-read the YAML (so `${VAR}` substitution
-            // picks up any env override the CLI just installed), then
-            // apply the built-in catalog. This is done in the app layer
-            // — not via the SDK's `RoutingTable::reload`, which sits
-            // below `bitrouter-providers` and so can't fill empty
-            // built-in fields — so a provider like `openai: {}` keeps
-            // its `api_base` / `api_protocol` / `api_key`. Without it an
-            // `auto_discover` provider would reload with an empty
-            // `api_base` and silently drop every model. `replace_config`
-            // then runs `discover_models` against the populated config.
-            ReloadSource::File(path) => match bitrouter_sdk::config::load(path).await {
-                Ok(mut fresh) => {
-                    bitrouter_providers::apply_builtin_defaults(&mut fresh);
-                    // Auto-enable the `claude-code` subscription provider when a
-                    // credential is in the OAuth store, before the registry merge
-                    // fills its fields — so a sign-in survives a hot-reload.
-                    crate::claude_code::enable_if_logged_in(&mut fresh);
-                    // Re-merge the registry too, so a reload picks up newly-set
-                    // credentials (a `bitrouter reload` run after exporting a
-                    // provider key activates that provider's canonical models).
-                    crate::assemble::merge_registry_into(&mut fresh).await;
-                    // Then re-activate any provider that has an OAuth /
-                    // subscription credential in the store — those live outside
-                    // the config, so the registry's credential gate can't see
-                    // them and the merge's `apply_builtin_defaults` would leave a
-                    // keyless provider inactive. Runs after the merge.
-                    activate_stored_credential_providers(&mut fresh);
-                    self.replace_file_backed(fresh, path).await
-                }
-                Err(e) => Err(e.into()),
-            },
-            // Default source: no file to re-read. Rebuild a fresh
-            // zero-config `Config` (which goes through `env_lookup`
-            // too), then apply built-in catalog defaults so every
-            // newly-auto-enabled provider has its `api_base` /
-            // `api_protocol` / `api_key` filled — `replace_config`
-            // calls `discover_models`, which needs `api_base` to talk
-            // to `/models`.
-            ReloadSource::Default => {
-                let mut fresh = bitrouter_providers::zero_config();
-                // Layered on top of the env-var-driven auto-enable: a
-                // signed-in user gets the `bitrouter` provider even when no
-                // `$BITROUTER_API_KEY` is in the daemon's env-override map.
-                crate::cloud::enable_in_zero_config(&mut fresh);
-                bitrouter_providers::apply_builtin_defaults(&mut fresh);
-                // Auto-enable the `claude-code` subscription provider when a
-                // credential is in the OAuth store, before the registry merge
-                // fills its fields — so a sign-in survives a hot-reload.
-                crate::claude_code::enable_if_logged_in(&mut fresh);
-                // Merge the registry so the canonical catalog + every
-                // credentialed BYOK provider is routable after a reload too.
-                crate::assemble::merge_registry_into(&mut fresh).await;
-                // Then re-activate any provider with a stored OAuth / subscription
-                // credential (invisible to the registry's config/env credential
-                // gate), after the merge re-applies builtin defaults.
-                activate_stored_credential_providers(&mut fresh);
-                self.replace_default(fresh).await
-            }
-        };
-        if let Err(e) = routing_outcome {
-            errors.push(format!("routing table: {e}"));
-        }
-        if let Err(e) = self.policy_store.reload().await {
-            errors.push(format!("policy store: {e}"));
-        }
-        if errors.is_empty() {
+        self.reload_with_env(Vec::new()).await
+    }
+
+    async fn reload_with_env(&self, env: Vec<(String, String)>) -> anyhow::Result<()> {
+        let reservation = self
+            .coordinator
+            .reserve_local()
+            .map_err(anyhow::Error::from)?;
+        let report = self
+            .execute_reservation(reservation, ReloadInvocation::Local, env)
+            .await;
+        if report.outcome == ReloadOutcome::Succeeded {
             Ok(())
         } else {
-            Err(anyhow::anyhow!(errors.join("; ")))
+            Err(anyhow::anyhow!(report.safe_summary()))
         }
+    }
+
+    fn reload_state(&self) -> Option<ReloadState> {
+        Some(self.coordinator.state())
+    }
+
+    fn reserve_remote(
+        &self,
+        expected_instance: &str,
+        expected_generation: u64,
+    ) -> Result<ReloadReservation, ReloadAdmissionError> {
+        self.coordinator
+            .reserve_remote(expected_instance, expected_generation)
+    }
+
+    async fn reload_reserved(&self, reservation: ReloadReservation) -> ReloadReport {
+        self.execute_reservation(reservation, ReloadInvocation::Remote, Vec::new())
+            .await
     }
 }
 
@@ -330,6 +1593,166 @@ providers:
             tool_choice: None,
             stream: false,
         }
+    }
+
+    struct FaultFixture {
+        _home: tempfile::TempDir,
+        reloader: Arc<AppReloader>,
+        routing_table: Arc<ConfigRoutingTable>,
+        policy_table: Arc<crate::policy_table_router::PolicyTableRouter>,
+        policy_runtime: Arc<crate::policy_lock::PolicyRuntime>,
+        policy_store: Arc<PolicyStore>,
+        initial_policy_digest: String,
+        candidate_policy_digest: String,
+        config_path: std::path::PathBuf,
+        lock_path: std::path::PathBuf,
+        access_policy_dir: std::path::PathBuf,
+    }
+
+    fn coordinated_config_yaml(model: &str, policy_table_model: &str, read_secs: u64) -> String {
+        format!(
+            r#"inherit_defaults: false
+upstream:
+  timeouts:
+    read_secs: {read_secs}
+providers:
+  alpha:
+    api_base: https://alpha.example.com/v1
+    api_key: alpha-key
+    api_protocol:
+      - "*": chat_completions
+    models:
+      - {{ id: m }}
+  beta:
+    api_base: https://beta.example.com/v1
+    api_key: beta-key
+    api_protocol:
+      - "*": chat_completions
+    models:
+      - {{ id: m }}
+presets:
+  coding:
+    model: {model}
+    policy: coding
+policy_table:
+  tiers:
+    only: {policy_table_model}
+  default_tier: only
+"#
+        )
+    }
+
+    fn coordinated_policy_lock_yaml(model: &str) -> String {
+        format!(
+            r#"lockfileVersion: 1
+policies:
+  coding:
+    key_strategy: agent_trace
+    tiers: {{ strong: {model} }}
+    routes: {{}}
+    default_tier: strong
+    tool_use_tier: strong
+    tool_safe_tiers: [strong]
+"#
+        )
+    }
+
+    async fn fault_fixture(failure: ReloadParticipant) -> anyhow::Result<FaultFixture> {
+        coordinated_fixture(Some(failure), None).await
+    }
+
+    async fn coordinated_fixture(
+        failure: Option<ReloadParticipant>,
+        pause: Option<Arc<TestPreparationPause>>,
+    ) -> anyhow::Result<FaultFixture> {
+        let home = tempfile::tempdir()?;
+        let config_path = home.path().join("bitrouter.yaml");
+        let lock_path = home.path().join("policy-lock.yaml");
+        let access_policy_dir = home.path().join("access-policies");
+        std::fs::create_dir(&access_policy_dir)?;
+        std::fs::write(
+            &config_path,
+            coordinated_config_yaml("alpha:m", "alpha:m", 30),
+        )?;
+        std::fs::write(&lock_path, coordinated_policy_lock_yaml("alpha:m"))?;
+        std::fs::write(
+            access_policy_dir.join("operator.yaml"),
+            "id: operator\nallowed_models: [alpha:m]\n",
+        )?;
+
+        // The running routing table is assembled from the same enriched shape
+        // that a reload later prepares. This keeps the remote classifier from
+        // treating a host-local credential provider as a candidate-only
+        // startup change in this fixture.
+        let mut initial = config::load(&config_path).await?;
+        resolve_reloadable_config(&mut initial).await;
+        let table = crate::policy_table_router::PolicyTable::from_config(&initial.policy_table)
+            .ok_or_else(|| anyhow::anyhow!("initial policy table is unexpectedly inert"))?;
+        let policy_table = Arc::new(crate::policy_table_router::PolicyTableRouter::new(table));
+        let routing_table = Arc::new(ConfigRoutingTable::from_config(initial.clone()));
+        let executor = Arc::new(HttpExecutor::new(HttpTimeouts::default())?);
+        let db = crate::db::connect("sqlite::memory:").await?;
+        crate::db::run_migrations(&db).await?;
+        let policy_runtime = crate::policy_lock::PolicyRuntime::new(
+            &initial,
+            Some(&config_path),
+            db,
+            None,
+            crate::eval::settlement::PendingEvalDecisionStore::default(),
+            None,
+        )
+        .await?;
+        let initial_policy_digest = policy_runtime
+            .administration_snapshot()
+            .digest
+            .ok_or_else(|| anyhow::anyhow!("initial active policy has no digest"))?;
+        let policy_store = Arc::new(PolicyStore::load_dir(&access_policy_dir).await?);
+
+        // Change every participant's input before executing the test-only
+        // boundary fault. The fixture therefore verifies both the participant
+        // report and the live state on either side of every mutation boundary.
+        std::fs::write(&config_path, coordinated_config_yaml("beta:m", "beta:m", 1))?;
+        std::fs::write(&lock_path, coordinated_policy_lock_yaml("beta:m"))?;
+        std::fs::write(
+            access_policy_dir.join("operator.yaml"),
+            "id: operator\nallowed_models: [beta:m]\n",
+        )?;
+        let mut candidate = config::load(&config_path).await?;
+        resolve_reloadable_config(&mut candidate).await;
+        let candidate_policy_digest =
+            crate::policy_lock::load_for_config(&candidate, Some(&config_path))
+                .await?
+                .map(|loaded| loaded.digest)
+                .ok_or_else(|| anyhow::anyhow!("candidate policy has no digest"))?;
+
+        let mut reloader = AppReloader::new(
+            policy_store.clone(),
+            routing_table.clone(),
+            executor,
+            ReloadSource::File(config_path.clone()),
+        )
+        .with_policy_runtime(policy_runtime.clone())
+        .with_policy_table_router(Some(policy_table.clone()));
+        if let Some(failure) = failure {
+            reloader = reloader.with_test_apply_failure(failure);
+        }
+        if let Some(pause) = pause {
+            reloader = reloader.with_test_pause_after_prepare(pause);
+        }
+
+        Ok(FaultFixture {
+            _home: home,
+            reloader: Arc::new(reloader),
+            routing_table,
+            policy_table,
+            policy_runtime,
+            policy_store,
+            initial_policy_digest,
+            candidate_policy_digest,
+            config_path,
+            lock_path,
+            access_policy_dir,
+        })
     }
 
     #[tokio::test]
@@ -560,32 +1983,572 @@ policies:
     }
 
     #[tokio::test]
-    async fn concurrent_reload_waits_for_the_full_transaction_lock() {
-        let (path, dir) = temp_config_path();
-        std::fs::write(&path, "inherit_defaults: false\n").expect("write config");
-        let initial = config::load(&path).await.expect("load config");
-        let routing_table = Arc::new(ConfigRoutingTable::from_config(initial));
-        let executor = Arc::new(HttpExecutor::new(HttpTimeouts::default()).expect("executor"));
-        let reloader = Arc::new(AppReloader::new(
-            Arc::new(PolicyStore::new()),
-            routing_table,
-            executor,
-            ReloadSource::File(path),
-        ));
-        let waiting = reloader.clone();
-        let guard = reloader.reload_lock.lock().await;
-        let mut task = tokio::spawn(async move { waiting.reload().await });
+    async fn fault_boundaries_report_each_participant_and_preserve_active_policy_truth()
+    -> anyhow::Result<()> {
+        for failed_participant in ReloadParticipant::all() {
+            let fixture = fault_fixture(failed_participant).await?;
+            let initial_state = fixture
+                .reloader
+                .reload_state()
+                .ok_or_else(|| anyhow::anyhow!("coordinator state is unavailable"))?;
+            let reservation = fixture
+                .reloader
+                .reserve_remote(&initial_state.server_instance_id, initial_state.generation)?;
+            let report = fixture.reloader.reload_reserved(reservation).await;
 
+            assert_eq!(report.outcome, ReloadOutcome::PartiallyApplied);
+            assert_eq!(
+                report
+                    .participants
+                    .iter()
+                    .filter(|entry| entry.outcome == ReloadParticipantOutcome::Applied)
+                    .count(),
+                4,
+                "every non-failed participant should have made its prepared change"
+            );
+            for entry in &report.participants {
+                if entry.participant == failed_participant {
+                    assert_eq!(entry.outcome, ReloadParticipantOutcome::Failed);
+                    assert_eq!(
+                        entry.error.as_ref().map(|error| error.code.as_str()),
+                        Some("fault_injected")
+                    );
+                } else {
+                    assert_eq!(
+                        entry.outcome,
+                        ReloadParticipantOutcome::Applied,
+                        "{failed_participant:?} must not obscure {participant:?}",
+                        participant = entry.participant
+                    );
+                }
+            }
+
+            let state = fixture
+                .reloader
+                .reload_state()
+                .ok_or_else(|| anyhow::anyhow!("coordinator state disappeared"))?;
+            assert!(!state.running);
+            assert_eq!(state.generation, 1);
+            assert_eq!(state.consistency, ReloadConsistency::Mixed);
+            assert_eq!(state.mixed_state_history.len(), 1);
+            assert_eq!(
+                state.mixed_state_history[0].outcome,
+                ReloadOutcome::PartiallyApplied
+            );
+            assert_eq!(
+                state.mixed_state_history[0].participants, report.participants,
+                "the retained mixed-state record must preserve the actual participant outcomes"
+            );
+
+            let expected_routing_model = if failed_participant == ReloadParticipant::RoutingTable {
+                "alpha:m"
+            } else {
+                "beta:m"
+            };
+            let active_config = fixture.routing_table.snapshot_config();
+            let routed_model = active_config
+                .presets
+                .get("coding")
+                .and_then(|preset| preset.model.as_deref())
+                .ok_or_else(|| anyhow::anyhow!("coding preset is absent after reload"))?;
+            assert_eq!(routed_model, expected_routing_model);
+
+            let expected_table_model = if failed_participant == ReloadParticipant::PolicyTable {
+                "alpha:m"
+            } else {
+                "beta:m"
+            };
+            let mut table_prompt = prompt();
+            fixture.policy_table.apply(&mut table_prompt);
+            assert_eq!(table_prompt.model, expected_table_model);
+
+            let expected_access_model =
+                if failed_participant == ReloadParticipant::AccessPolicyStore {
+                    "alpha:m"
+                } else {
+                    "beta:m"
+                };
+            let access_model = fixture.policy_store.with_policy("operator", |policy| {
+                policy
+                    .and_then(|policy| policy.allowed_models.as_ref())
+                    .and_then(|models| models.first())
+                    .cloned()
+            });
+            assert_eq!(access_model.as_deref(), Some(expected_access_model));
+
+            let expected_policy_digest =
+                if failed_participant == ReloadParticipant::NamedPolicyRuntime {
+                    fixture.initial_policy_digest.as_str()
+                } else {
+                    fixture.candidate_policy_digest.as_str()
+                };
+            assert_eq!(
+                fixture
+                    .policy_runtime
+                    .administration_snapshot()
+                    .digest
+                    .as_deref(),
+                Some(expected_policy_digest),
+                "the active policy report must describe the policy snapshot that actually committed"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prepared_inputs_are_not_re_read_after_source_changes() -> anyhow::Result<()> {
+        let pause = Arc::new(TestPreparationPause::new());
+        let fixture = coordinated_fixture(None, Some(pause.clone())).await?;
+        let state = fixture
+            .reloader
+            .reload_state()
+            .ok_or_else(|| anyhow::anyhow!("coordinator state is unavailable"))?;
+        let reservation = fixture
+            .reloader
+            .reserve_remote(&state.server_instance_id, state.generation)?;
+        let reloader = fixture.reloader.clone();
+        let task = tokio::spawn(async move { reloader.reload_reserved(reservation).await });
+
+        tokio::time::timeout(Duration::from_secs(3), pause.prepared.notified()).await?;
+        // The operation has already captured beta's routing, timeout, policy
+        // table, named-policy, and access-policy inputs. Revert every source
+        // file before allowing mutation; any late source read would install
+        // alpha instead and make this test fail.
+        std::fs::write(
+            &fixture.config_path,
+            coordinated_config_yaml("alpha:m", "alpha:m", 30),
+        )?;
+        std::fs::write(&fixture.lock_path, coordinated_policy_lock_yaml("alpha:m"))?;
+        std::fs::write(
+            fixture.access_policy_dir.join("operator.yaml"),
+            "id: operator\nallowed_models: [alpha:m]\n",
+        )?;
+        pause.resume.notify_one();
+
+        let report = tokio::time::timeout(Duration::from_secs(3), task).await??;
+        assert_eq!(report.outcome, ReloadOutcome::Succeeded);
         assert!(
-            tokio::time::timeout(Duration::from_millis(25), &mut task)
-                .await
-                .is_err(),
-            "a second reload must wait until the first transaction releases"
+            report
+                .participants
+                .iter()
+                .all(|entry| entry.outcome == ReloadParticipantOutcome::Applied)
+        );
+        let active_config = fixture.routing_table.snapshot_config();
+        let routed_model = active_config
+            .presets
+            .get("coding")
+            .and_then(|preset| preset.model.as_deref())
+            .ok_or_else(|| anyhow::anyhow!("coding preset is absent after reload"))?;
+        assert_eq!(routed_model, "beta:m");
+        let mut table_prompt = prompt();
+        fixture.policy_table.apply(&mut table_prompt);
+        assert_eq!(table_prompt.model, "beta:m");
+        let access_model = fixture.policy_store.with_policy("operator", |policy| {
+            policy
+                .and_then(|policy| policy.allowed_models.as_ref())
+                .and_then(|models| models.first())
+                .cloned()
+        });
+        assert_eq!(access_model.as_deref(), Some("beta:m"));
+        assert_eq!(
+            fixture
+                .policy_runtime
+                .administration_snapshot()
+                .digest
+                .as_deref(),
+            Some(fixture.candidate_policy_digest.as_str())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn local_and_sighup_entrypoints_cannot_overtake_remote_reload() -> anyhow::Result<()> {
+        let pause = Arc::new(TestPreparationPause::new());
+        let fixture = coordinated_fixture(None, Some(pause.clone())).await?;
+        let state = fixture
+            .reloader
+            .reload_state()
+            .ok_or_else(|| anyhow::anyhow!("coordinator state is unavailable"))?;
+        let reservation = fixture
+            .reloader
+            .reserve_remote(&state.server_instance_id, state.generation)?;
+        let remote_reloader = fixture.reloader.clone();
+        let remote =
+            tokio::spawn(async move { remote_reloader.reload_reserved(reservation).await });
+
+        tokio::time::timeout(Duration::from_secs(3), pause.prepared.notified()).await?;
+        assert!(
+            fixture
+                .reloader
+                .reload_state()
+                .is_some_and(|state| state.running)
         );
 
-        task.abort();
-        drop(guard);
-        let _ = task.await;
-        std::fs::remove_dir_all(dir).ok();
+        // `DaemonCommand::Reload` calls this entry point. The coordinator must
+        // reject it before `set_env_overrides` can alter process-global state.
+        let override_name = format!(
+            "BITROUTER_RELOAD_CONCURRENCY_{}",
+            uuid::Uuid::new_v4().simple()
+        );
+        assert!(bitrouter_sdk::config::env_lookup(&override_name).is_none());
+        let local = tokio::time::timeout(
+            Duration::from_secs(1),
+            fixture.reloader.reload_with_env(vec![(
+                override_name.clone(),
+                "must-not-be-installed".to_string(),
+            )]),
+        )
+        .await?;
+        let local_error = match local {
+            Ok(()) => return Err(anyhow::anyhow!("local reload overtook remote admission")),
+            Err(error) => error,
+        };
+        assert!(local_error.to_string().contains("reload_in_progress"));
+        assert!(bitrouter_sdk::config::env_lookup(&override_name).is_none());
+
+        // `main.rs` invokes `reload()` from SIGHUP. It must take the exact
+        // same admission path rather than starting a second reload.
+        let hup = tokio::time::timeout(Duration::from_secs(1), fixture.reloader.reload()).await?;
+        let hup_error = match hup {
+            Ok(()) => return Err(anyhow::anyhow!("SIGHUP reload overtook remote admission")),
+            Err(error) => error,
+        };
+        assert!(hup_error.to_string().contains("reload_in_progress"));
+
+        pause.resume.notify_one();
+        let report = tokio::time::timeout(Duration::from_secs(3), remote).await??;
+        assert_eq!(report.outcome, ReloadOutcome::Succeeded);
+        assert_eq!(
+            fixture
+                .reloader
+                .reload_state()
+                .map(|state| state.generation),
+            Some(1)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn remote_rejects_startup_change_applied_by_local_reload() -> anyhow::Result<()> {
+        let (path, dir) = temp_config_path();
+        let initial_yaml = r#"inherit_defaults: false
+server:
+  listen: 127.0.0.1:4356
+presets:
+  coding:
+    model: alpha:m
+"#;
+        let candidate_yaml = r#"inherit_defaults: false
+server:
+  listen: 127.0.0.1:9999
+presets:
+  coding:
+    model: beta:m
+"#;
+        std::fs::write(&path, initial_yaml)?;
+        let mut initial = config::load(&path).await?;
+        resolve_reloadable_config(&mut initial).await;
+        let routing_table = Arc::new(ConfigRoutingTable::from_config(initial));
+        let reloader = AppReloader::new(
+            Arc::new(PolicyStore::new()),
+            routing_table.clone(),
+            Arc::new(HttpExecutor::new(HttpTimeouts::default())?),
+            ReloadSource::File(path.clone()),
+        );
+
+        // Local IPC/SIGHUP retains its existing behavior: it can refresh the
+        // routing snapshot even though the listener itself remains the startup
+        // listener. That cannot make the field remotely reloadable later.
+        std::fs::write(&path, candidate_yaml)?;
+        reloader.reload().await?;
+        assert_eq!(
+            routing_table.snapshot_config().server.listen,
+            "127.0.0.1:9999"
+        );
+
+        let state = reloader
+            .reload_state()
+            .ok_or_else(|| anyhow::anyhow!("coordinator state is unavailable"))?;
+        assert_eq!(state.generation, 1);
+        let reservation = reloader.reserve_remote(&state.server_instance_id, state.generation)?;
+        let report = reloader.reload_reserved(reservation).await;
+
+        assert_eq!(report.outcome, ReloadOutcome::Failed);
+        assert!(
+            report
+                .restart_required_fields
+                .iter()
+                .any(|field| field == "server.listen"),
+            "remote reload must compare startup-only fields with the daemon baseline"
+        );
+        assert_eq!(
+            report
+                .participants
+                .iter()
+                .find(|entry| entry.participant == ReloadParticipant::RoutingTable)
+                .and_then(|entry| entry.error.as_ref())
+                .map(|error| error.code.as_str()),
+            Some("restart_required")
+        );
+        assert_eq!(
+            routing_table.snapshot_config().server.listen,
+            "127.0.0.1:9999"
+        );
+        let state = reloader
+            .reload_state()
+            .ok_or_else(|| anyhow::anyhow!("coordinator state disappeared"))?;
+        assert_eq!(state.generation, 2);
+        assert_eq!(state.consistency, ReloadConsistency::Consistent);
+        let _ = std::fs::remove_dir_all(dir);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn preparation_timeout_finishes_without_live_mutation() -> anyhow::Result<()> {
+        let initial =
+            config::parse("inherit_defaults: false\npresets:\n  coding:\n    model: alpha:m\n")?;
+        let routing_table = Arc::new(ConfigRoutingTable::from_config(initial));
+        let pause = Arc::new(TestPreparationPause::new());
+        let reloader = Arc::new(
+            AppReloader::new(
+                Arc::new(PolicyStore::new()),
+                routing_table.clone(),
+                Arc::new(HttpExecutor::new(HttpTimeouts::default())?),
+                ReloadSource::Default,
+            )
+            .with_test_pause_during_prepare(pause.clone())
+            .with_test_preparation_timeout(Duration::from_millis(10)),
+        );
+        let state = reloader
+            .reload_state()
+            .ok_or_else(|| anyhow::anyhow!("coordinator state is unavailable"))?;
+        let reservation = reloader.reserve_remote(&state.server_instance_id, state.generation)?;
+        let running_reloader = reloader.clone();
+        let task = tokio::spawn(async move { running_reloader.reload_reserved(reservation).await });
+
+        tokio::time::timeout(Duration::from_secs(1), pause.prepared.notified()).await?;
+        let report = tokio::time::timeout(Duration::from_secs(1), task).await??;
+        assert_eq!(report.outcome, ReloadOutcome::Failed);
+        assert!(report.participants.iter().all(|entry| {
+            entry.participant == ReloadParticipant::RoutingTable
+                || entry.outcome == ReloadParticipantOutcome::NotAttempted
+        }));
+        let routing_failure = report
+            .participants
+            .iter()
+            .find(|entry| entry.participant == ReloadParticipant::RoutingTable)
+            .and_then(|entry| entry.error.as_ref())
+            .ok_or_else(|| anyhow::anyhow!("timeout did not identify preparation failure"))?;
+        assert_eq!(routing_failure.code, "preparation_timed_out");
+
+        let state = reloader
+            .reload_state()
+            .ok_or_else(|| anyhow::anyhow!("coordinator state disappeared"))?;
+        assert!(!state.running);
+        assert_eq!(state.generation, 1);
+        assert_eq!(state.consistency, ReloadConsistency::Consistent);
+        assert_eq!(
+            state.last_outcome.as_ref().map(|outcome| outcome.outcome),
+            Some(ReloadOutcome::Failed)
+        );
+        let active_config = routing_table.snapshot_config();
+        assert_eq!(
+            active_config
+                .presets
+                .get("coding")
+                .and_then(|preset| preset.model.as_deref()),
+            Some("alpha:m")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn coordinator_fences_stale_and_concurrent_admission() -> Result<(), ReloadAdmissionError> {
+        let coordinator = ReloadCoordinator::new();
+        let initial = coordinator.state();
+        let first = coordinator.reserve_remote(&initial.server_instance_id, initial.generation)?;
+
+        assert!(matches!(
+            coordinator.reserve_local(),
+            Err(ReloadAdmissionError::ReloadInProgress)
+        ));
+        assert!(coordinator.state().running);
+
+        // An operation-recording failure before execution drops the reservation
+        // and frees admission without advancing the terminal generation.
+        drop(first);
+        let after_abandon = coordinator.state();
+        assert!(!after_abandon.running);
+        assert_eq!(after_abandon.generation, 0);
+
+        let accepted = coordinator
+            .reserve_remote(&after_abandon.server_instance_id, after_abandon.generation)?;
+        let report = ReloadReport::succeeded(
+            accepted.server_instance_id().to_string(),
+            accepted.generation(),
+        );
+        coordinator.complete(&accepted, report);
+        drop(accepted);
+
+        let completed = coordinator.state();
+        assert_eq!(completed.generation, 1);
+        assert!(matches!(
+            coordinator.reserve_remote(&completed.server_instance_id, 0),
+            Err(ReloadAdmissionError::StaleGeneration)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn interrupted_mutation_records_unknown_mixed_state() -> anyhow::Result<()> {
+        let coordinator = ReloadCoordinator::new();
+        let reservation = coordinator.reserve_local()?;
+        let mut progress = ReloadReport::pending(
+            reservation.server_instance_id().to_string(),
+            reservation.generation(),
+        );
+        progress.participant_applied(ReloadParticipant::RoutingTable);
+        reservation.update_progress(&progress);
+        reservation.mark_mutation_started();
+        drop(reservation);
+
+        let state = coordinator.state();
+        let outcome = state
+            .last_outcome
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("interrupted reservation did not record an outcome"))?;
+        assert_eq!(state.generation, 1);
+        assert!(!state.running);
+        assert_eq!(state.consistency, ReloadConsistency::Mixed);
+        assert_eq!(outcome.outcome, ReloadOutcome::Unknown);
+        assert_eq!(
+            outcome
+                .participants
+                .iter()
+                .find(|entry| entry.participant == ReloadParticipant::RoutingTable)
+                .map(|entry| entry.outcome),
+            Some(ReloadParticipantOutcome::Applied),
+            "interruption must retain already-recorded live changes"
+        );
+        assert_eq!(state.mixed_state_history.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn failed_preparation_does_not_clear_prior_mixed_state() -> anyhow::Result<()> {
+        let coordinator = ReloadCoordinator::new();
+        let partial_reservation = coordinator.reserve_local()?;
+        let mut partial = ReloadReport::pending(
+            partial_reservation.server_instance_id().to_string(),
+            partial_reservation.generation(),
+        );
+        partial.participant_applied(ReloadParticipant::RoutingTable);
+        partial.participant_failed(
+            ReloadParticipant::PolicyTable,
+            ReloadFailure::new("fault_injected", "policy table update failed"),
+        );
+        partial.finish(ReloadOutcome::PartiallyApplied);
+        coordinator.complete(&partial_reservation, partial);
+        drop(partial_reservation);
+        assert_eq!(coordinator.state().consistency, ReloadConsistency::Mixed);
+
+        let failed_reservation = coordinator.reserve_local()?;
+        let mut failed = ReloadReport::pending(
+            failed_reservation.server_instance_id().to_string(),
+            failed_reservation.generation(),
+        );
+        failed.participant_failed(
+            ReloadParticipant::RoutingTable,
+            ReloadFailure::new("config_prepare_failed", "reload configuration is invalid"),
+        );
+        failed.finish(ReloadOutcome::Failed);
+        coordinator.complete(&failed_reservation, failed);
+        drop(failed_reservation);
+
+        let state = coordinator.state();
+        assert_eq!(state.generation, 2);
+        assert_eq!(state.consistency, ReloadConsistency::Mixed);
+        assert_eq!(state.mixed_state_history.len(), 1);
+        assert_eq!(
+            state.last_outcome.as_ref().map(|outcome| outcome.outcome),
+            Some(ReloadOutcome::Failed)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn remote_restart_classifier_rejects_startup_and_unknown_fields() -> anyhow::Result<()> {
+        let current = config::parse("inherit_defaults: false\n")?;
+        let candidate = config::parse(
+            "inherit_defaults: false\nserver:\n  listen: 127.0.0.1:9999\nupstream:\n  fallback_backoff_ms: [10]\n",
+        )?;
+        let unclassified_fields = ["future_runtime"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<BTreeSet<_>>();
+
+        let fields = restart_required_fields(&current, &candidate, Some(&unclassified_fields));
+        assert!(fields.contains(&"server.listen".to_string()));
+        assert!(fields.contains(&"upstream.fallback_backoff_ms".to_string()));
+        assert!(fields.contains(&"future_runtime".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn remote_restart_classifier_allows_timeout_client_changes() -> anyhow::Result<()> {
+        let current = config::parse("inherit_defaults: false\n")?;
+        let candidate =
+            config::parse("inherit_defaults: false\nupstream:\n  timeouts:\n    read_secs: 10\n")?;
+        assert!(restart_required_fields(&current, &candidate, Some(&BTreeSet::new())).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn remote_restart_classifier_rejects_unknown_nested_fields() -> anyhow::Result<()> {
+        let raw = r#"inherit_defaults: false
+server:
+  future_field: true
+upstream:
+  future_field: true
+providers:
+  alpha:
+    api_base: https://alpha.example.com/v1
+    api_key: key
+    future_field: true
+"#;
+        let current = config::parse("inherit_defaults: false\n")?;
+        let candidate = config::parse(raw)?;
+        let raw_candidate = serde_saphyr::from_str::<serde_json::Value>(raw)?;
+        let unclassified = unclassified_config_paths(&raw_candidate);
+        assert!(unclassified.contains("server.future_field"));
+        assert!(unclassified.contains("upstream.future_field"));
+        assert!(unclassified.contains("providers.alpha.future_field"));
+
+        let fields = restart_required_fields(&current, &candidate, Some(&unclassified));
+        assert!(fields.contains(&"server.future_field".to_string()));
+        assert!(fields.contains(&"upstream.future_field".to_string()));
+        assert!(fields.contains(&"providers.alpha.future_field".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn remote_restart_classifier_accepts_legacy_policy_writeback_alias() -> anyhow::Result<()> {
+        let current = config::parse("inherit_defaults: false\npolicy:\n  mode: frozen\n")?;
+        let raw = "inherit_defaults: false\npolicy:\n  writeback: locked\n";
+        let candidate = config::parse(raw)?;
+        let raw_candidate = serde_saphyr::from_str::<serde_json::Value>(raw)?;
+        let unclassified = unclassified_config_paths(&raw_candidate);
+        assert!(!unclassified.contains("policy.writeback"));
+        assert!(restart_required_fields(&current, &candidate, Some(&unclassified)).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn remote_restart_classifier_rejects_inherit_defaults_change() -> anyhow::Result<()> {
+        let current = config::parse("inherit_defaults: false\n")?;
+        let candidate = config::parse("inherit_defaults: true\n")?;
+        let fields = restart_required_fields(&current, &candidate, Some(&BTreeSet::new()));
+        assert!(fields.contains(&"inherit_defaults".to_string()));
+        Ok(())
     }
 }

--- a/apps/bitrouter/src/remote_control.rs
+++ b/apps/bitrouter/src/remote_control.rs
@@ -1,9 +1,14 @@
-//! Authenticated, read-only HTTP control plane for remote BitRouter clients.
+//! Authenticated HTTP administration control plane for remote BitRouter clients.
 //!
 //! This is intentionally not the inference API, the local daemon protocol, or
-//! ACP over a network transport. It exposes the existing typed read actions on
+//! ACP over a network transport. It exposes typed inspection and guarded reload on
 //! a dedicated loopback listener so an operator can put a private tunnel or a
 //! TLS reverse proxy in front of it without making local IPC remotely callable.
+
+pub mod auth;
+pub mod inventory;
+pub mod operations;
+mod reads;
 
 use std::future::Future;
 use std::net::SocketAddr;
@@ -12,7 +17,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use axum::extract::{
-    Query, Request, State,
+    DefaultBodyLimit, MatchedPath, Path, Query, Request, State,
     rejection::{JsonRejection, QueryRejection},
 };
 use axum::http::{HeaderMap, StatusCode, header};
@@ -23,19 +28,17 @@ use axum::{Json, Router};
 use bitrouter_mcp::actions::models::ModelsReport;
 use bitrouter_mcp::actions::route::{RouteInput, RouteReport};
 use bitrouter_mcp::actions::status::StatusReport;
-use bitrouter_sdk::config::ControlConfig;
+use bitrouter_sdk::config::{ControlConfig, ControlScope};
 use bitrouter_sdk::error::BitrouterError;
 use futures::StreamExt;
-use hmac::{Hmac, KeyInit, Mac};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
 use url::{Host, Url};
 
-use crate::actions::models::RoutableModels;
-use crate::actions::requests::{MAX_REQUEST_ROWS, RequestsAction};
-use crate::actions::route::RouteAction;
-use crate::actions::status::DaemonStatus;
+use self::auth::{ControlAuth, ControlCaller};
+use self::operations::{OperationError, OperationReport, OperationService, ReloadInput};
+use crate::actions::administration::{Administration, PolicyInput};
+use crate::actions::requests::RequestsAction;
 use crate::output::reports::requests::RequestsReport;
 use crate::paths::ConfigSource;
 
@@ -45,27 +48,118 @@ pub const CONTROL_TOKEN_ENV: &str = "BITROUTER_CONTROL_TOKEN";
 /// Current HTTP control protocol version.
 pub const PROTOCOL_VERSION: u32 = 1;
 
-/// Actions implemented by this protocol version.
-const ACTIONS: [&str; 4] = ["status", "models", "route_preview", "requests"];
-
 /// Minimum token size accepted by the server.
 const MIN_TOKEN_BYTES: usize = 32;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionDescriptor {
+    pub version: u32,
+    pub required_scope: ControlScope,
+    pub input_schema: serde_json::Value,
+    pub output_schema: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapabilitiesReport {
+    #[serde(default)]
+    pub resources: std::collections::BTreeMap<String, ResourceDescriptor>,
+    #[serde(default)]
+    pub limits: std::collections::BTreeMap<String, u64>,
     pub protocol: String,
     pub protocol_version: u32,
     pub server_version: String,
     pub actions: Vec<String>,
+    #[serde(default)]
+    pub action_descriptors: std::collections::BTreeMap<String, ActionDescriptor>,
+    #[serde(default)]
+    pub server_instance_id: Option<String>,
+    #[serde(default)]
+    pub scopes: Vec<ControlScope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceDescriptor {
+    pub version: u32,
+    pub path: String,
+    pub required_scope: ControlScope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct StateReport {
+    #[serde(flatten)]
+    pub reload: crate::reload::ReloadState,
+    pub live_policy_digest: Option<String>,
 }
 
 impl CapabilitiesReport {
-    fn current() -> Self {
+    fn current(state: &ControlState, caller: &ControlCaller) -> Self {
+        let rows = inventory::ACTIONS
+            .iter()
+            .filter(|row| {
+                caller.permits(row.scope)
+                    && (!row.requires_reload || state.operations.is_some())
+                    && (!row.requires_administration || state.administration.is_some())
+            })
+            .collect::<Vec<_>>();
         Self {
-            protocol: "bitrouter-control".to_string(),
+            resources: inventory::RESOURCES
+                .iter()
+                .filter(|row| {
+                    caller.permits(row.scope)
+                        && (!row.requires_reload || state.operations.is_some())
+                })
+                .map(|row| {
+                    (
+                        row.id.into(),
+                        ResourceDescriptor {
+                            version: 1,
+                            path: row.path.into(),
+                            required_scope: row.scope,
+                        },
+                    )
+                })
+                .collect(),
+            limits: std::collections::BTreeMap::from([
+                ("max_operations".into(), operations::MAX_OPERATIONS as u64),
+                (
+                    "preparation_timeout_seconds".into(),
+                    crate::reload::PREPARATION_TIMEOUT_SECONDS,
+                ),
+                (
+                    "operation_retention_seconds".into(),
+                    operations::RETENTION_SECONDS,
+                ),
+                ("max_reload_body_bytes".into(), 16 * 1024),
+                (
+                    "max_request_rows".into(),
+                    crate::actions::requests::MAX_REQUEST_ROWS,
+                ),
+                (
+                    "max_request_window_days".into(),
+                    crate::actions::requests::MAX_REQUEST_WINDOW_DAYS as u64,
+                ),
+                ("max_response_bytes".into(), 8 * 1024 * 1024),
+            ]),
+            protocol: "bitrouter-control".into(),
             protocol_version: PROTOCOL_VERSION,
-            server_version: crate::VERSION.to_string(),
-            actions: ACTIONS.iter().map(ToString::to_string).collect(),
+            server_version: crate::VERSION.into(),
+            actions: rows.iter().map(|row| row.legacy_name.into()).collect(),
+            action_descriptors: rows
+                .iter()
+                .map(|row| {
+                    (
+                        row.id.into(),
+                        ActionDescriptor {
+                            version: row.version,
+                            required_scope: row.scope,
+                            input_schema: (row.input_schema)(),
+                            output_schema: (row.output_schema)(),
+                        },
+                    )
+                })
+                .collect(),
+            server_instance_id: Some(state.instance.clone()),
+            scopes: caller.scopes().to_vec(),
         }
     }
 }
@@ -74,15 +168,35 @@ impl CapabilitiesReport {
 struct ControlState {
     source: ConfigSource,
     socket: PathBuf,
+    administration: Option<Administration>,
+    instance: String,
+    operations: Option<Arc<OperationService>>,
 }
 
-#[derive(Clone)]
-struct ControlToken(Arc<[u8]>);
+impl ControlState {
+    fn reads(&self) -> reads::ReadPorts {
+        reads::ReadPorts {
+            source: self.source.clone(),
+            socket: self.socket.clone(),
+        }
+    }
+
+    fn administration(&self) -> Result<&Administration, ControlError> {
+        self.administration.as_ref().ok_or_else(|| {
+            ControlError::new(
+                StatusCode::NOT_FOUND,
+                "unsupported_action",
+                "live administration ports are unavailable",
+            )
+        })
+    }
+}
 
 /// A validated control listener that is ready to run.
 pub struct ControlServer {
     listen: SocketAddr,
-    router: Router,
+    state: ControlState,
+    auth: ControlAuth,
 }
 
 /// A control listener whose address conflict has already been checked.
@@ -120,23 +234,31 @@ impl ControlServer {
             );
         }
 
-        let token = std::env::var(CONTROL_TOKEN_ENV).with_context(|| {
-            format!(
-                "control.enabled is true but {CONTROL_TOKEN_ENV} is not set; provide a \
-                 dedicated operator token of at least {MIN_TOKEN_BYTES} bytes"
-            )
-        })?;
-        if token.len() < MIN_TOKEN_BYTES {
-            anyhow::bail!(
-                "{CONTROL_TOKEN_ENV} must contain at least {MIN_TOKEN_BYTES} bytes when \
-                 control.enabled is true"
-            );
-        }
-
+        let auth = ControlAuth::from_config(config)?;
         Ok(Some(Self {
             listen,
-            router: control_router(source, socket, token.into_bytes())?,
+            state: ControlState {
+                source,
+                socket,
+                administration: None,
+                operations: None,
+                instance: uuid::Uuid::new_v4().to_string(),
+            },
+            auth,
         }))
+    }
+
+    pub fn with_administration(mut self, administration: Administration) -> Self {
+        self.state.administration = Some(administration);
+        self
+    }
+
+    pub fn with_reloader(mut self, reloader: Arc<dyn crate::daemon::DaemonReloader>) -> Self {
+        if let Some(state) = reloader.reload_state() {
+            self.state.instance = state.server_instance_id;
+            self.state.operations = Some(Arc::new(OperationService::new(reloader)));
+        }
+        self
     }
 
     /// Address the control listener will bind.
@@ -152,7 +274,7 @@ impl ControlServer {
         Ok(BoundControlServer {
             listen: self.listen,
             listener,
-            router: self.router,
+            router: control_router_with(self.state, self.auth),
         })
     }
 }
@@ -175,69 +297,173 @@ impl BoundControlServer {
     }
 }
 
+#[cfg(test)]
 fn control_router(source: ConfigSource, socket: PathBuf, token: Vec<u8>) -> Result<Router> {
-    let mcp_models = Arc::new(RoutableModels::new(source.clone(), Some(socket.clone())));
-    let mcp_status = Arc::new(DaemonStatus::new(socket.clone(), Some(source.clone())));
-    let mcp_routing = Arc::new(RouteAction::new(source.clone(), Some(socket.clone())));
+    let token = String::from_utf8(token).map_err(|_| anyhow::anyhow!("invalid test token"))?;
+    let auth = ControlAuth::from_lookup(&ControlConfig::default(), |_| Some(token.clone()))?;
+    Ok(control_router_with(
+        ControlState {
+            source,
+            socket,
+            administration: None,
+            operations: None,
+            instance: uuid::Uuid::new_v4().to_string(),
+        },
+        auth,
+    ))
+}
+
+fn control_router_with(state: ControlState, expected: ControlAuth) -> Router {
+    let ports = Arc::new(state.reads());
     let mcp = bitrouter_mcp::server::BitrouterMcp::builder()
-        .models(mcp_models)
-        .status(mcp_status)
-        .routing(mcp_routing)
+        .models(ports.clone())
+        .status(ports.clone())
+        .routing(ports)
+        .request_authorizer(Arc::new(reads::McpAuthorization))
         .build();
     let mcp_router = bitrouter_mcp::server::local_http_router(mcp).with_state::<ControlState>(());
-    let state = ControlState { source, socket };
-    let token_digest = digest_token(&token)?;
-    let auth = axum::middleware::from_fn_with_state(
-        ControlToken(Arc::from(token_digest)),
-        require_control_token,
-    );
-
-    Ok(Router::new()
+    let mut router = Router::new()
         .route("/control/v1/capabilities", get(capabilities))
-        .route("/control/v1/status", get(status))
-        .route("/control/v1/models", get(models))
-        .route("/control/v1/route/preview", post(route_preview))
-        .route("/control/v1/requests", get(requests))
+        .route("/control/v1/state", get(control_state))
+        .route("/control/v1/operations/{request_id}", get(operation));
+    let instance = state.instance.clone();
+    let operations = state.operations.clone();
+    for row in inventory::ACTIONS {
+        let handler = match row.action {
+            inventory::Action::Status => get(status),
+            inventory::Action::Models => get(models),
+            inventory::Action::Route => post(route_preview),
+            inventory::Action::Requests => get(requests),
+            inventory::Action::Providers => get(providers),
+            inventory::Action::Observe => get(observe),
+            inventory::Action::PolicyStatus => get(policy_status),
+            inventory::Action::PolicyShow => get(policy_show),
+            inventory::Action::Agents => get(agents),
+            inventory::Action::Reload => post(reload).layer(DefaultBodyLimit::max(16 * 1024)),
+        };
+        router = router.route(row.path, handler);
+    }
+    router
         .merge(mcp_router)
         .method_not_allowed_fallback(method_not_allowed)
         .fallback(not_found)
-        .layer(auth)
-        .with_state(state))
+        .layer(axum::middleware::from_fn_with_state(
+            (expected, instance, operations),
+            require_control_token,
+        ))
+        .with_state(state)
 }
 
 async fn require_control_token(
-    State(expected): State<ControlToken>,
+    State((expected, instance, operations)): State<(
+        ControlAuth,
+        String,
+        Option<Arc<OperationService>>,
+    )>,
     headers: HeaderMap,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Response {
-    let supplied = headers
+    let initial_reload = operations.as_ref().and_then(|service| service.state().ok());
+    let started = std::time::Instant::now();
+    let route_path = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|path| path.as_str())
+        .unwrap_or("unmatched")
+        .to_owned();
+    let bounded_report = request.uri().path().starts_with("/control/v1/");
+    let caller = headers
         .get(header::AUTHORIZATION)
-        .and_then(|value| value.as_bytes().strip_prefix(b"Bearer "));
-    let valid = supplied.is_some_and(|token| {
-        let verifier = Hmac::<Sha256>::new_from_slice(b"bitrouter-control-token-compare-v1");
-        verifier.is_ok_and(|mut verifier| {
-            verifier.update(token);
-            verifier.verify_slice(expected.0.as_ref()).is_ok()
-        })
-    });
-    if !valid {
-        return ControlError::unauthorized().into_response();
-    }
-    if !origin_matches_host(&headers) {
-        return ControlError::new(
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split_once(' '))
+        .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("bearer"))
+        .and_then(|(_, token)| expected.authenticate(token.as_bytes()));
+    let credential_id = caller.as_ref().map(|caller| caller.id().to_owned());
+    let mut response = match caller {
+        None => ControlError::unauthorized().into_response(),
+        Some(_) if !origin_matches_host(&headers) => ControlError::new(
             StatusCode::FORBIDDEN,
             "origin_mismatch",
             "request Origin must match the control endpoint Host",
         )
-        .into_response();
+        .into_response(),
+        Some(caller) => {
+            let path = request
+                .extensions()
+                .get::<MatchedPath>()
+                .map(|path| path.as_str())
+                .unwrap_or(request.uri().path());
+            let scope = inventory::ACTIONS
+                .iter()
+                .find(|row| row.path == path)
+                .map(|row| row.scope)
+                .or_else(|| {
+                    inventory::RESOURCES
+                        .iter()
+                        .find(|row| row.path == path)
+                        .map(|row| row.scope)
+                });
+            if scope.is_some_and(|scope| !caller.permits(scope)) {
+                ControlError::new(
+                    StatusCode::FORBIDDEN,
+                    "scope_denied",
+                    "required control scope is not granted",
+                )
+                .into_response()
+            } else {
+                request.extensions_mut().insert(caller);
+                next.run(request).await
+            }
+        }
+    };
+    if bounded_report {
+        let (parts, body) = response.into_parts();
+        response = match axum::body::to_bytes(body, 8 * 1024 * 1024).await {
+            Ok(bytes) => Response::from_parts(parts, axum::body::Body::from(bytes)),
+            Err(_) => ControlError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "report_too_large",
+                "control report exceeds the response limit",
+            )
+            .into_response(),
+        };
     }
-
-    let mut response = next.run(request).await;
+    tracing::info!(action = %route_path, credential_id = credential_id.as_deref().unwrap_or("unauthenticated"), status = response.status().as_u16(), duration_ms = started.elapsed().as_millis() as u64, "control request completed");
     response.headers_mut().insert(
         header::CACHE_CONTROL,
         header::HeaderValue::from_static("no-store"),
     );
+    if credential_id.is_some()
+        && let Some(state) = operations.as_ref().and_then(|service| service.state().ok())
+    {
+        let spans_versions = initial_reload
+            .as_ref()
+            .is_some_and(|initial| initial.running || initial.generation != state.generation)
+            || state.running;
+        response.headers_mut().insert(
+            "x-bitrouter-control-read-consistency",
+            header::HeaderValue::from_static(if spans_versions {
+                "may_span_versions"
+            } else if state.consistency == crate::reload::ReloadConsistency::Mixed {
+                "mixed"
+            } else {
+                "consistent"
+            }),
+        );
+        if let Ok(value) = header::HeaderValue::from_str(&state.generation.to_string()) {
+            response
+                .headers_mut()
+                .insert("x-bitrouter-control-generation", value);
+        }
+    }
+    if credential_id.is_some()
+        && let Ok(value) = header::HeaderValue::from_str(&instance)
+    {
+        response
+            .headers_mut()
+            .insert("x-bitrouter-control-instance", value);
+    }
     response
 }
 
@@ -265,78 +491,215 @@ fn origin_matches_host(headers: &HeaderMap) -> bool {
         && origin.port_or_known_default() == expected.port_or_known_default()
 }
 
-fn digest_token(token: &[u8]) -> Result<Vec<u8>> {
-    let mut digest = Hmac::<Sha256>::new_from_slice(b"bitrouter-control-token-compare-v1")
-        .map_err(|_| anyhow::anyhow!("initialize control token comparison"))?;
-    digest.update(token);
-    Ok(digest.finalize().into_bytes().to_vec())
+async fn capabilities(
+    State(state): State<ControlState>,
+    axum::Extension(caller): axum::Extension<ControlCaller>,
+) -> Json<CapabilitiesReport> {
+    Json(CapabilitiesReport::current(&state, &caller))
 }
 
-async fn capabilities() -> Json<CapabilitiesReport> {
-    Json(CapabilitiesReport::current())
+fn operation_service(state: &ControlState) -> Result<&Arc<OperationService>, ControlError> {
+    state
+        .operations
+        .as_ref()
+        .ok_or_else(|| OperationError::Unsupported.into())
+}
+
+async fn control_state(
+    State(state): State<ControlState>,
+) -> Result<Json<StateReport>, ControlError> {
+    let reload = operation_service(&state)?.state()?;
+    let live_policy_digest = if let Some(administration) = &state.administration {
+        administration
+            .policy(PolicyInput {
+                view: crate::actions::administration::PolicyView::Active,
+                name: None,
+            })
+            .await
+            .map_err(ControlError::internal)?
+            .digest
+    } else {
+        None
+    };
+    Ok(Json(StateReport {
+        reload,
+        live_policy_digest,
+    }))
+}
+
+async fn reload(
+    State(state): State<ControlState>,
+    axum::Extension(caller): axum::Extension<ControlCaller>,
+    payload: Result<Json<ReloadInput>, JsonRejection>,
+) -> Result<Response, ControlError> {
+    let Json(input) = payload.map_err(|error| {
+        ControlError::new(
+            error.status(),
+            "invalid_request",
+            "reload requires a valid bounded JSON request",
+        )
+    })?;
+    let operation = operation_service(&state)?
+        .submit(caller.id(), input)
+        .await?;
+    let status = if operation.is_running() {
+        StatusCode::ACCEPTED
+    } else {
+        StatusCode::OK
+    };
+    Ok((status, Json(operation)).into_response())
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OperationLookup {
+    instance: String,
+}
+
+async fn operation(
+    State(state): State<ControlState>,
+    axum::Extension(caller): axum::Extension<ControlCaller>,
+    Path(request_id): Path<String>,
+    query: Result<Query<OperationLookup>, QueryRejection>,
+) -> Result<Json<OperationReport>, ControlError> {
+    let Query(query) =
+        query.map_err(|_| ControlError::bad_request("operation lookup requires instance"))?;
+    Ok(Json(
+        operation_service(&state)?
+            .lookup(caller.id(), &request_id, &query.instance)
+            .await?,
+    ))
+}
+
+impl From<OperationError> for ControlError {
+    fn from(error: OperationError) -> Self {
+        let status = match error {
+            OperationError::InvalidRequest => StatusCode::BAD_REQUEST,
+            OperationError::NotFound | OperationError::Unsupported => StatusCode::NOT_FOUND,
+            OperationError::Expired => StatusCode::GONE,
+            OperationError::Capacity | OperationError::GenerationExhausted => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            _ => StatusCode::CONFLICT,
+        };
+        let message = match error {
+            OperationError::NotFound => {
+                "operation outcome is unknown; no retained result exists for this credential"
+            }
+            OperationError::Expired => {
+                "operation outcome is unknown; the retention deadline has passed"
+            }
+            OperationError::ServerInstanceChanged => {
+                "server instance changed; inspect live state before attempting another reload"
+            }
+            _ => error.code(),
+        };
+        Self::new(status, error.code(), message)
+    }
 }
 
 async fn status(State(state): State<ControlState>) -> Result<Json<StatusReport>, ControlError> {
-    let mut report = DaemonStatus::new(&state.socket, Some(state.source))
-        .report()
+    state
+        .reads()
+        .status_report()
         .await
-        .map_err(ControlError::internal)?;
-    // The local IPC path is an implementation detail of the server host. It is
-    // neither actionable remotely nor appropriate to disclose.
-    report.socket = None;
-    Ok(Json(report))
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct ModelsParams {
-    provider: Option<String>,
+        .map(Json)
+        .map_err(ControlError::internal)
 }
 
 async fn models(
     State(state): State<ControlState>,
-    query: Result<Query<ModelsParams>, QueryRejection>,
+    query: Result<Query<inventory::ModelsInput>, QueryRejection>,
 ) -> Result<Json<ModelsReport>, ControlError> {
-    let Query(params) = query.map_err(|error| ControlError::bad_request(error.body_text()))?;
-    let report = RoutableModels::new(state.source, Some(state.socket))
-        .report()
+    let Query(params) = query.map_err(|_| ControlError::bad_request("invalid model filters"))?;
+    if let Some(provider) = &params.provider {
+        crate::actions::administration::validate_identifier(provider)
+            .map_err(ControlError::bad_request)?;
+    }
+    state
+        .reads()
+        .models_report()
         .await
-        .map_err(ControlError::internal)?
-        .filtered(params.provider.as_deref());
-    Ok(Json(report))
+        .map(|report| Json(report.filtered(params.provider.as_deref())))
+        .map_err(ControlError::internal)
 }
 
 async fn route_preview(
     State(state): State<ControlState>,
     payload: Result<Json<RouteInput>, JsonRejection>,
 ) -> Result<Json<RouteReport>, ControlError> {
-    let Json(input) = payload.map_err(|error| ControlError::bad_request(error.body_text()))?;
-    let report = RouteAction::new(state.source, Some(state.socket))
-        .report(input)
+    let Json(input) = payload.map_err(|_| ControlError::bad_request("invalid route input"))?;
+    state
+        .reads()
+        .route_report(input)
         .await
-        .map_err(ControlError::bad_request)?;
-    Ok(Json(report))
-}
-
-#[derive(Debug, Deserialize)]
-struct RequestsParams {
-    #[serde(default = "default_request_limit")]
-    limit: u64,
-}
-
-fn default_request_limit() -> u64 {
-    MAX_REQUEST_ROWS
+        .map(Json)
+        .map_err(ControlError::bad_request)
 }
 
 async fn requests(
     State(state): State<ControlState>,
-    query: Result<Query<RequestsParams>, QueryRejection>,
+    query: Result<Query<crate::actions::requests::RequestFilters>, QueryRejection>,
 ) -> Result<Json<RequestsReport>, ControlError> {
-    let Query(params) = query.map_err(|error| ControlError::bad_request(error.body_text()))?;
-    let report = RequestsAction::new(state.source, state.socket)
-        .report(params.limit)
+    let Query(params) = query.map_err(|_| ControlError::bad_request("invalid request filters"))?;
+    let mut report = RequestsAction::new(state.source, state.socket)
+        .report_filtered(params)
         .await
         .map_err(ControlError::bad_request)?;
+    report.sanitize_for_remote();
     Ok(Json(report))
+}
+
+async fn providers(
+    State(state): State<ControlState>,
+) -> Result<Json<crate::actions::administration::ProvidersReport>, ControlError> {
+    Ok(Json(state.administration()?.providers()))
+}
+
+async fn observe(
+    State(state): State<ControlState>,
+) -> Result<Json<crate::actions::administration::ObserveReport>, ControlError> {
+    Ok(Json(state.administration()?.observe()))
+}
+
+async fn agents(
+    State(state): State<ControlState>,
+) -> Result<Json<crate::actions::administration::AgentsReport>, ControlError> {
+    Ok(Json(state.administration()?.agents()))
+}
+
+async fn policy_status(
+    State(state): State<ControlState>,
+    query: Result<Query<PolicyInput>, QueryRejection>,
+) -> Result<Json<crate::actions::administration::PolicyReport>, ControlError> {
+    let Query(input) = query.map_err(|_| ControlError::bad_request("invalid policy input"))?;
+    if input.name.is_some() {
+        return Err(ControlError::bad_request(
+            "policy status does not accept a name",
+        ));
+    }
+    state
+        .administration()?
+        .policy(input)
+        .await
+        .map(Json)
+        .map_err(ControlError::bad_request)
+}
+
+async fn policy_show(
+    State(state): State<ControlState>,
+    query: Result<Query<PolicyInput>, QueryRejection>,
+) -> Result<Json<crate::actions::administration::PolicyReport>, ControlError> {
+    let Query(input) = query.map_err(|_| ControlError::bad_request("invalid policy input"))?;
+    if input.name.is_none() {
+        return Err(ControlError::bad_request("policy show requires a name"));
+    }
+    state
+        .administration()?
+        .policy(input)
+        .await
+        .map(Json)
+        .map_err(ControlError::bad_request)
 }
 
 async fn not_found() -> ControlError {
@@ -424,18 +787,18 @@ impl IntoResponse for ControlError {
     }
 }
 
-/// HTTP implementation of the read-only control actions.
+/// HTTP implementation of typed inspection and guarded administration.
 ///
 /// Every action performs the capability handshake first. A successful result
-/// is cached for this client instance, so a long-lived TUI checks once while a
-/// one-shot CLI still checks every invocation. A version mismatch or
+/// is cached for at most thirty seconds; boot changes and capability errors
+/// invalidate it immediately. A one-shot CLI checks every invocation. A version mismatch or
 /// unsupported action is more useful than interpreting a coincidental response
 /// shape.
 pub struct HttpControlClient {
     endpoint: Url,
     token: String,
     http: reqwest::Client,
-    capabilities: tokio::sync::OnceCell<CapabilitiesReport>,
+    capabilities: tokio::sync::Mutex<Option<(std::time::Instant, CapabilitiesReport)>>,
 }
 
 impl HttpControlClient {
@@ -473,15 +836,135 @@ impl HttpControlClient {
             endpoint,
             token,
             http,
-            capabilities: tokio::sync::OnceCell::new(),
+            capabilities: tokio::sync::Mutex::new(None),
         })
     }
 
     pub async fn capabilities(&self) -> Result<CapabilitiesReport> {
-        self.capabilities
-            .get_or_try_init(|| self.get("capabilities", None))
+        {
+            let cache = self.capabilities.lock().await;
+            if let Some((fetched, report)) = cache.as_ref()
+                && fetched.elapsed() < std::time::Duration::from_secs(30)
+            {
+                return Ok(report.clone());
+            }
+        }
+        let report = self.get::<CapabilitiesReport>("capabilities", None).await?;
+        *self.capabilities.lock().await = Some((std::time::Instant::now(), report.clone()));
+        Ok(report)
+    }
+
+    async fn require_resource(&self, resource: &str) -> Result<()> {
+        let capabilities = self.capabilities().await?;
+        if capabilities.protocol != "bitrouter-control"
+            || capabilities.protocol_version != PROTOCOL_VERSION
+            || !capabilities.resources.get(resource).is_some_and(|row| {
+                row.version == 1 && capabilities.scopes.contains(&row.required_scope)
+            })
+        {
+            anyhow::bail!("remote server does not support or grant control resource '{resource}'");
+        }
+        Ok(())
+    }
+
+    pub async fn state_report(&self) -> Result<StateReport> {
+        self.require_resource("state").await?;
+        self.get("state", None).await
+    }
+
+    pub async fn state(&self) -> Result<crate::reload::ReloadState> {
+        Ok(self.state_report().await?.reload)
+    }
+
+    pub async fn submit_reload(&self, input: &ReloadInput) -> Result<OperationReport> {
+        self.require_action("reload").await?;
+        self.require_resource("state").await?;
+        let url = self.action_url("reload")?;
+        self.send(self.http.post(url).bearer_auth(&self.token).json(input))
             .await
-            .cloned()
+    }
+
+    pub async fn operation(&self, request_id: &str, instance: &str) -> Result<OperationReport> {
+        self.require_resource("operation").await?;
+        let request_id = uuid::Uuid::parse_str(request_id).context("invalid request UUID")?;
+        uuid::Uuid::parse_str(instance).context("invalid instance UUID")?;
+        self.get(
+            &format!("operations/{request_id}"),
+            Some(&[("instance", instance)]),
+        )
+        .await
+    }
+
+    /// Submit once. A disconnected POST is never retried; identifiers survive in
+    /// the error so an operator can recover the daemon-owned operation.
+    pub async fn reload(&self) -> Result<OperationReport> {
+        self.require_action("reload").await?;
+        let state = self.state().await?;
+        let input = ReloadInput {
+            request_id: uuid::Uuid::new_v4().to_string(),
+            expected_server_instance_id: state.server_instance_id,
+            expected_generation: state.generation,
+        };
+        let recovery = || {
+            format!(
+                "reload outcome may be unknown; inspect operations show {} --instance {}; do not replay with a new request ID",
+                input.request_id, input.expected_server_instance_id
+            )
+        };
+        let mut report = self.submit_reload(&input).await.with_context(recovery)?;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+        while report.is_running() {
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            match tokio::time::timeout_at(
+                deadline,
+                self.operation(&input.request_id, &input.expected_server_instance_id),
+            )
+            .await
+            {
+                Ok(result) => report = result.with_context(recovery)?,
+                Err(_) => break,
+            }
+        }
+        Ok(report)
+    }
+
+    pub async fn providers(&self) -> Result<crate::actions::administration::ProvidersReport> {
+        self.require_action("providers_list").await?;
+        self.get("providers", None).await
+    }
+
+    pub async fn agents(&self) -> Result<crate::actions::administration::AgentsReport> {
+        self.require_action("agents_list").await?;
+        self.get("agents", None).await
+    }
+
+    pub async fn observe(&self) -> Result<crate::actions::administration::ObserveReport> {
+        self.require_action("observe_status").await?;
+        self.get("observe/status", None).await
+    }
+
+    pub async fn policy(
+        &self,
+        input: &PolicyInput,
+    ) -> Result<crate::actions::administration::PolicyReport> {
+        input.validate()?;
+        let (action, path) = if input.name.is_some() {
+            ("policy_show", "policy/show")
+        } else {
+            ("policy_status", "policy/status")
+        };
+        self.require_action(action).await?;
+        let mut query = vec![(
+            "view",
+            match input.view {
+                crate::actions::administration::PolicyView::Active => "active",
+                crate::actions::administration::PolicyView::Disk => "disk",
+            },
+        )];
+        if let Some(name) = &input.name {
+            query.push(("name", name.as_str()));
+        }
+        self.get(path, Some(&query)).await
     }
 
     pub async fn status(&self) -> Result<StatusReport> {
@@ -490,26 +973,52 @@ impl HttpControlClient {
     }
 
     pub async fn models(&self, provider: Option<&str>) -> Result<ModelsReport> {
-        self.require_action("models").await?;
+        self.require_action("list_models").await?;
         let query = provider.map(|provider| vec![("provider", provider)]);
         self.get("models", query.as_deref()).await
     }
 
     pub async fn route(&self, input: &RouteInput) -> Result<RouteReport> {
-        self.require_action("route_preview").await?;
+        self.require_action("route").await?;
         let url = self.action_url("route/preview")?;
         let request = self.http.post(url).bearer_auth(&self.token).json(input);
         self.send(request).await
     }
 
     pub async fn requests(&self, limit: Option<u64>) -> Result<RequestsReport> {
-        self.require_action("requests").await?;
-        let limit = limit.map(|limit| limit.to_string());
-        let query = limit.as_deref().map(|limit| vec![("limit", limit)]);
-        self.get("requests", query.as_deref()).await
+        self.requests_filtered(&crate::actions::requests::RequestFilters::with_limit(
+            limit.unwrap_or(crate::actions::requests::MAX_REQUEST_ROWS),
+        ))
+        .await
     }
 
-    async fn require_action(&self, action: &str) -> Result<()> {
+    pub async fn requests_filtered(
+        &self,
+        filters: &crate::actions::requests::RequestFilters,
+    ) -> Result<RequestsReport> {
+        self.require_action("requests").await?;
+        let has_filters = filters.since.is_some()
+            || filters.until.is_some()
+            || filters.model.is_some()
+            || filters.provider.is_some();
+        if has_filters
+            && !self
+                .capabilities()
+                .await?
+                .action_descriptors
+                .contains_key("requests")
+        {
+            return Err(BitrouterError::bad_request(
+                "remote server does not advertise filtered request inspection",
+            )
+            .into());
+        }
+        let url = self.action_url("requests")?;
+        self.send(self.http.get(url).bearer_auth(&self.token).query(filters))
+            .await
+    }
+
+    pub async fn can_action(&self, action: &str) -> Result<bool> {
         let capabilities = self.capabilities().await?;
         if capabilities.protocol != "bitrouter-control" {
             return Err(BitrouterError::UpstreamInvalidResponse {
@@ -529,13 +1038,35 @@ impl HttpControlClient {
             }
             .into());
         }
-        if !capabilities
-            .actions
-            .iter()
-            .any(|candidate| candidate == action)
-        {
+        let row = inventory::by_id(action)
+            .ok_or_else(|| BitrouterError::bad_request("unknown control action"))?;
+        let available = if capabilities.action_descriptors.is_empty() {
+            row.scope == ControlScope::Read
+                && !row.requires_administration
+                && capabilities
+                    .actions
+                    .iter()
+                    .any(|name| name == row.legacy_name)
+        } else {
+            capabilities
+                .action_descriptors
+                .get(action)
+                .is_some_and(|descriptor| {
+                    descriptor.version == row.version
+                        && descriptor.required_scope == row.scope
+                        && capabilities.scopes.contains(&row.scope)
+                })
+        };
+        Ok(available)
+    }
+
+    async fn require_action(&self, action: &str) -> Result<()> {
+        if !self.can_action(action).await? {
+            *self.capabilities.lock().await = None;
             return Err(BitrouterError::UpstreamInvalidResponse {
-                message: format!("remote BitRouter does not support control action '{action}'"),
+                message: format!(
+                    "remote BitRouter does not support or grant control action '{action}'"
+                ),
             }
             .into());
         }
@@ -572,6 +1103,22 @@ impl HttpControlClient {
             }
         };
         let status = response.status();
+        {
+            let mut cache = self.capabilities.lock().await;
+            let changed = response
+                .headers()
+                .get("x-bitrouter-control-instance")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|instance| {
+                    cache
+                        .as_ref()
+                        .and_then(|(_, report)| report.server_instance_id.as_deref())
+                        .is_some_and(|cached| cached != instance)
+                });
+            if changed || matches!(status.as_u16(), 401 | 403 | 404) {
+                *cache = None;
+            }
+        }
         let mut stream = response.bytes_stream();
         let mut body = Vec::new();
         while let Some(chunk) = stream.next().await {
@@ -721,6 +1268,227 @@ providers:
             .body(Body::empty())?)
     }
 
+    struct ImmediateReloader(Arc<crate::reload::ReloadCoordinator>, bool);
+    #[async_trait::async_trait]
+    impl crate::daemon::DaemonReloader for ImmediateReloader {
+        async fn reload(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn reload_state(&self) -> Option<crate::reload::ReloadState> {
+            Some(self.0.state())
+        }
+        fn reserve_remote(
+            &self,
+            instance: &str,
+            generation: u64,
+        ) -> Result<crate::reload::ReloadReservation, crate::reload::ReloadAdmissionError> {
+            self.0.reserve_remote(instance, generation)
+        }
+        async fn reload_reserved(
+            &self,
+            reservation: crate::reload::ReloadReservation,
+        ) -> crate::reload::ReloadReport {
+            let mut report = crate::reload::ReloadReport::succeeded(
+                reservation.server_instance_id().into(),
+                reservation.generation(),
+            );
+            if self.1 {
+                report.outcome = crate::reload::ReloadOutcome::PartiallyApplied;
+                for participant in &mut report.participants {
+                    if participant.participant == crate::reload::ReloadParticipant::RoutingTable {
+                        participant.outcome = crate::reload::ReloadParticipantOutcome::Applied;
+                    }
+                    if participant.participant == crate::reload::ReloadParticipant::PolicyTable {
+                        participant.outcome = crate::reload::ReloadParticipantOutcome::Failed;
+                        participant.error = Some(crate::reload::ReloadFailure {
+                            code: "fixture_policy_failure".into(),
+                            message: "injected policy table failure".into(),
+                        });
+                    }
+                }
+            }
+            self.0.complete(&reservation, report.clone());
+            report
+        }
+    }
+
+    /// Separate test executable used only by Docker acceptance. This exercises
+    /// real HTTP/CLI/TUI rendering of a fault; AppReloader tests separately
+    /// inject faults at the actual participant boundaries.
+    #[tokio::test]
+    #[ignore = "long-running Docker HTTP fault fixture"]
+    async fn docker_partial_fixture() -> anyhow::Result<()> {
+        use bitrouter_sdk::config::ControlCredentialConfig;
+        let config = ControlConfig {
+            credentials: vec![
+                ControlCredentialConfig {
+                    id: "reader".into(),
+                    token_env: "SERVER_READER_TOKEN".into(),
+                    scopes: vec![ControlScope::Read],
+                },
+                ControlCredentialConfig {
+                    id: "administrator".into(),
+                    token_env: "SERVER_ADMIN_TOKEN".into(),
+                    scopes: vec![ControlScope::Read, ControlScope::Reload],
+                },
+            ],
+            ..ControlConfig::default()
+        };
+        let auth = ControlAuth::from_config(&config)?;
+        let reloader = Arc::new(ImmediateReloader(
+            crate::reload::ReloadCoordinator::new(),
+            true,
+        ));
+        let router = control_router_with(
+            ControlState {
+                source: ConfigSource::Default {
+                    home: PathBuf::from("/nonexistent-fault-fixture"),
+                },
+                socket: PathBuf::from("/nonexistent-fault-fixture/control.sock"),
+                administration: None,
+                instance: reloader.0.state().server_instance_id,
+                operations: Some(Arc::new(OperationService::new(reloader))),
+            },
+            auth,
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:4358").await?;
+        axum::serve(listener, router).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn http_mutations_enforce_scope_shape_owner_and_boot() -> anyhow::Result<()> {
+        use bitrouter_sdk::config::ControlCredentialConfig;
+        let (_directory, source) = default_source()?;
+        let reloader = Arc::new(ImmediateReloader(
+            crate::reload::ReloadCoordinator::new(),
+            false,
+        ));
+        let instance = reloader.0.state().server_instance_id;
+        let config = ControlConfig {
+            credentials: vec![
+                ControlCredentialConfig {
+                    id: "reader".into(),
+                    token_env: "READER".into(),
+                    scopes: vec![ControlScope::Read],
+                },
+                ControlCredentialConfig {
+                    id: "admin".into(),
+                    token_env: "ADMIN".into(),
+                    scopes: vec![ControlScope::Read, ControlScope::Reload],
+                },
+                ControlCredentialConfig {
+                    id: "other".into(),
+                    token_env: "OTHER".into(),
+                    scopes: vec![ControlScope::Read, ControlScope::Reload],
+                },
+            ],
+            ..ControlConfig::default()
+        };
+        let auth = ControlAuth::from_lookup(&config, |name| Some(name.repeat(32)))?;
+        let router = control_router_with(
+            ControlState {
+                source,
+                socket: PathBuf::from("missing.sock"),
+                administration: None,
+                instance: instance.clone(),
+                operations: Some(Arc::new(OperationService::new(reloader))),
+            },
+            auth,
+        );
+        let input = ReloadInput {
+            request_id: uuid::Uuid::new_v4().to_string(),
+            expected_server_instance_id: instance.clone(),
+            expected_generation: 0,
+        };
+        let request = |token: &str,
+                       method: &str,
+                       path: &str,
+                       body: String|
+         -> anyhow::Result<Request<Body>> {
+            Ok(Request::builder()
+                .method(method)
+                .uri(path)
+                .header(
+                    header::AUTHORIZATION,
+                    format!("Bearer {}", token.repeat(32)),
+                )
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))?)
+        };
+        for path in [
+            "/control/v1/reload",
+            "/control/v1/operations/00000000-0000-0000-0000-000000000000?instance=00000000-0000-0000-0000-000000000000",
+        ] {
+            let method = if path.ends_with("reload") {
+                "POST"
+            } else {
+                "GET"
+            };
+            let response = router
+                .clone()
+                .oneshot(request(
+                    "READER",
+                    method,
+                    path,
+                    serde_json::to_string(&input)?,
+                )?)
+                .await?;
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        }
+        for body in [
+            format!("{{\"env\":[],{}", &serde_json::to_string(&input)?[1..]),
+            "x".repeat(16 * 1024 + 1),
+        ] {
+            let response = router
+                .clone()
+                .oneshot(request("ADMIN", "POST", "/control/v1/reload", body)?)
+                .await?;
+            assert!(response.status().is_client_error());
+        }
+        let response = router
+            .clone()
+            .oneshot(request(
+                "ADMIN",
+                "POST",
+                "/control/v1/reload",
+                serde_json::to_string(&input)?,
+            )?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-store")
+        );
+        let path = format!(
+            "/control/v1/operations/{}?instance={instance}",
+            input.request_id
+        );
+        let response = router
+            .clone()
+            .oneshot(request("OTHER", "GET", &path, String::new())?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let response = router
+            .clone()
+            .oneshot(request("ADMIN", "GET", &path, String::new())?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        let changed = format!(
+            "/control/v1/operations/{}?instance={}",
+            input.request_id,
+            uuid::Uuid::new_v4()
+        );
+        let response = router
+            .oneshot(request("ADMIN", "GET", &changed, String::new())?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        Ok(())
+    }
+
     #[tokio::test]
     async fn every_endpoint_requires_the_control_token() -> anyhow::Result<()> {
         let (_directory, source) = default_source()?;
@@ -739,6 +1507,41 @@ providers:
         let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
         let value: serde_json::Value = serde_json::from_slice(&bytes)?;
         assert_eq!(value["error"]["code"], "unauthorized");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn every_inventory_route_authenticates_before_extracting_inputs() -> anyhow::Result<()> {
+        let (_directory, source) = default_source()?;
+        let router = test_router(source, PathBuf::from("missing.sock"))?;
+        let routes = inventory::ACTIONS
+            .iter()
+            .map(|row| (row.method, row.path))
+            .chain(inventory::RESOURCES.iter().map(|row| ("GET", row.path)));
+        for (method, path) in routes {
+            let path = path.replace("{request_id}", "00000000-0000-0000-0000-000000000000");
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(&path)
+                        .body(Body::from("invalid-input"))?,
+                )
+                .await?;
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{method} {path}"
+            );
+            assert_eq!(
+                response
+                    .headers()
+                    .get(header::CACHE_CONTROL)
+                    .and_then(|value| value.to_str().ok()),
+                Some("no-store")
+            );
+        }
         Ok(())
     }
 
@@ -786,6 +1589,196 @@ providers:
     }
 
     #[tokio::test]
+    async fn authenticated_mcp_tool_uses_validated_caller_and_redacted_report() -> anyhow::Result<()>
+    {
+        use rmcp::ServiceExt;
+        use rmcp::transport::StreamableHttpClientTransport;
+        use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+
+        let (_directory, source) = default_source()?;
+        let router = test_router(source, PathBuf::from("/private/secret/control.sock"))?;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move {
+                    let _ = stop_rx.await;
+                })
+                .await
+        });
+        let transport = StreamableHttpClientTransport::with_client(
+            reqwest::Client::new(),
+            StreamableHttpClientTransportConfig::with_uri(format!("http://{address}/mcp-control"))
+                .auth_header(TOKEN),
+        );
+        let client =
+            tokio::time::timeout(std::time::Duration::from_secs(10), ().serve(transport)).await??;
+        let reply = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client.call_tool(rmcp::model::CallToolRequestParams::new("status")),
+        )
+        .await??;
+        let value = serde_json::to_value(&reply)?;
+        assert_eq!(value["structuredContent"]["running"], false);
+        assert!(value["structuredContent"]["socket"].is_null());
+        assert!(!serde_json::to_string(&value)?.contains("/private/secret"));
+        client.cancel().await?;
+        let _ = stop_tx.send(());
+        task.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ambiguous_post_response_retains_ids_without_an_automatic_retry() -> anyhow::Result<()>
+    {
+        use bitrouter_sdk::config::ControlCredentialConfig;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let (_directory, source) = default_source()?;
+        let reloader = Arc::new(ImmediateReloader(
+            crate::reload::ReloadCoordinator::new(),
+            false,
+        ));
+        let instance = reloader.0.state().server_instance_id;
+        let operations = Arc::new(OperationService::new(reloader));
+        let config = ControlConfig {
+            credentials: vec![ControlCredentialConfig {
+                id: "admin".into(),
+                token_env: "TOKEN".into(),
+                scopes: vec![ControlScope::Read, ControlScope::Reload],
+            }],
+            ..ControlConfig::default()
+        };
+        let auth = ControlAuth::from_lookup(&config, |_| Some(TOKEN.into()))?;
+        let posts = Arc::new(AtomicUsize::new(0));
+        let captured = posts.clone();
+        let router = control_router_with(
+            ControlState {
+                source,
+                socket: PathBuf::from("missing.sock"),
+                administration: None,
+                instance: instance.clone(),
+                operations: Some(operations.clone()),
+            },
+            auth,
+        )
+        .layer(axum::middleware::from_fn(
+            move |request: axum::extract::Request, next: Next| {
+                let captured = captured.clone();
+                async move {
+                    let mutate = request.uri().path() == "/control/v1/reload";
+                    let response = next.run(request).await;
+                    if mutate && response.status().is_success() {
+                        captured.fetch_add(1, Ordering::SeqCst);
+                        let (parts, _) = response.into_parts();
+                        Response::from_parts(parts, Body::from("{truncated"))
+                    } else {
+                        response
+                    }
+                }
+            },
+        ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let endpoint = format!("http://{}", listener.local_addr()?);
+        let server = tokio::spawn(async move { axum::serve(listener, router).await });
+        let client = HttpControlClient::from_token(&endpoint, TOKEN.into(), "fixture")?;
+        let result = client.reload().await;
+        assert!(result.is_err());
+        let message = result
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("expected interrupted receipt"))?
+            .to_string();
+        let request_id = message
+            .split_whitespace()
+            .find(|word| uuid::Uuid::parse_str(word).is_ok())
+            .ok_or_else(|| anyhow::anyhow!("recovery error omitted request UUID: {message}"))?;
+        assert!(message.contains(&instance));
+        let operation = client.operation(request_id, &instance).await?;
+        assert!(operation.succeeded());
+        assert_eq!(posts.load(Ordering::SeqCst), 1);
+        assert_eq!(operations.state()?.generation, 1);
+        server.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn redirects_never_forward_control_credentials() -> anyhow::Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let hits = Arc::new(AtomicUsize::new(0));
+        let target_hits = hits.clone();
+        let destination = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let destination_url = format!(
+            "http://{}/control/v1/capabilities",
+            destination.local_addr()?
+        );
+        let destination_task = tokio::spawn(async move {
+            axum::serve(
+                destination,
+                Router::new().fallback(move || {
+                    target_hits.fetch_add(1, Ordering::SeqCst);
+                    async { "credential must never arrive here" }
+                }),
+            )
+            .await
+        });
+        let origin = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let endpoint = format!("http://{}", origin.local_addr()?);
+        let origin_task = tokio::spawn(async move {
+            axum::serve(
+                origin,
+                Router::new().route(
+                    "/control/v1/capabilities",
+                    get(move || {
+                        let destination_url = destination_url.clone();
+                        async move {
+                            (
+                                StatusCode::TEMPORARY_REDIRECT,
+                                [(header::LOCATION, destination_url)],
+                            )
+                        }
+                    }),
+                ),
+            )
+            .await
+        });
+        let client = HttpControlClient::from_token(&endpoint, TOKEN.into(), "fixture")?;
+        assert!(client.capabilities().await.is_err());
+        assert_eq!(hits.load(Ordering::SeqCst), 0);
+        origin_task.abort();
+        destination_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn old_server_capabilities_support_only_legacy_reads() -> anyhow::Result<()> {
+        let router = Router::new()
+            .route("/control/v1/capabilities", get(|| async {
+                Json(serde_json::json!({
+                    "protocol": "bitrouter-control", "protocol_version": 1,
+                    "server_version": "old", "actions": ["status", "models", "route_preview", "requests"]
+                }))
+            }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move {
+                    let _ = stop_rx.await;
+                })
+                .await
+        });
+        let client =
+            HttpControlClient::from_token(&format!("http://{address}"), TOKEN.into(), "test")?;
+        client.require_action("list_models").await?;
+        client.require_action("route").await?;
+        assert!(client.require_action("providers_list").await.is_err());
+        let _ = stop_tx.send(());
+        task.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn browser_origin_must_match_control_host() -> anyhow::Result<()> {
         let (_directory, source) = default_source()?;
         let response = test_router(source, PathBuf::from("missing.sock"))?
@@ -816,7 +1809,14 @@ providers:
         let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
         let report: CapabilitiesReport = serde_json::from_slice(&bytes)?;
         assert_eq!(report.protocol_version, PROTOCOL_VERSION);
-        assert_eq!(report.actions, ACTIONS.map(ToString::to_string));
+        assert_eq!(
+            report.actions,
+            inventory::ACTIONS
+                .iter()
+                .filter(|row| !row.requires_administration && !row.requires_reload)
+                .map(|row| row.legacy_name.to_string())
+                .collect::<Vec<_>>()
+        );
         Ok(())
     }
 
@@ -909,6 +1909,7 @@ providers:
         let config = ControlConfig {
             enabled: true,
             listen: "0.0.0.0:4358".to_string(),
+            ..Default::default()
         };
         let error = ControlServer::from_config(
             &config,

--- a/apps/bitrouter/src/remote_control/auth.rs
+++ b/apps/bitrouter/src/remote_control/auth.rs
@@ -1,0 +1,197 @@
+//! Validated host-control authority. Plaintext credentials never survive setup.
+
+use std::collections::BTreeSet;
+
+use anyhow::{Result, ensure};
+use bitrouter_sdk::config::{ControlConfig, ControlCredentialConfig, ControlScope};
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+
+const COMPARE_KEY: &[u8] = b"bitrouter-control-token-compare-v1";
+pub const MIN_TOKEN_BYTES: usize = 32;
+
+#[derive(Debug, Clone)]
+pub struct ControlCaller {
+    id: String,
+    scopes: Vec<ControlScope>,
+}
+
+impl ControlCaller {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+    pub fn scopes(&self) -> &[ControlScope] {
+        &self.scopes
+    }
+    pub fn permits(&self, scope: ControlScope) -> bool {
+        self.scopes.contains(&scope)
+    }
+}
+
+#[derive(Clone)]
+struct Credential {
+    caller: ControlCaller,
+    digest: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct ControlAuth {
+    credentials: Vec<Credential>,
+}
+
+impl ControlAuth {
+    pub fn from_config(config: &ControlConfig) -> Result<Self> {
+        Self::from_lookup(config, |name| std::env::var(name).ok())
+    }
+
+    pub fn from_lookup(
+        config: &ControlConfig,
+        mut lookup: impl FnMut(&str) -> Option<String>,
+    ) -> Result<Self> {
+        let fallback = vec![ControlCredentialConfig {
+            id: "legacy-operator".into(),
+            token_env: super::CONTROL_TOKEN_ENV.into(),
+            scopes: vec![ControlScope::Read],
+        }];
+        let entries = if config.credentials.is_empty() {
+            &fallback
+        } else {
+            &config.credentials
+        };
+        let mut ids = BTreeSet::new();
+        let mut digests = BTreeSet::new();
+        let mut credentials = Vec::with_capacity(entries.len());
+        for entry in entries {
+            ensure!(valid_name(&entry.id, true), "invalid control credential ID");
+            ensure!(
+                ids.insert(entry.id.clone()),
+                "duplicate control credential ID"
+            );
+            ensure!(
+                valid_name(&entry.token_env, false),
+                "invalid control credential token_env"
+            );
+            ensure!(
+                entry.scopes.contains(&ControlScope::Read),
+                "control credentials require control:read"
+            );
+            let unique_scopes: BTreeSet<_> = entry.scopes.iter().collect();
+            ensure!(
+                unique_scopes.len() == entry.scopes.len(),
+                "duplicate control scope"
+            );
+            let token = lookup(&entry.token_env).ok_or_else(|| {
+                anyhow::anyhow!("control credential environment variable is missing")
+            })?;
+            ensure!(
+                token.len() >= MIN_TOKEN_BYTES,
+                "control token must contain at least 32 bytes"
+            );
+            let digest = token_digest(token.as_bytes())?;
+            ensure!(
+                digests.insert(digest.clone()),
+                "control credentials must have distinct tokens"
+            );
+            credentials.push(Credential {
+                caller: ControlCaller {
+                    id: entry.id.clone(),
+                    scopes: entry.scopes.clone(),
+                },
+                digest,
+            });
+        }
+        Ok(Self { credentials })
+    }
+
+    /// Visit every configured credential, including after a successful match.
+    pub fn authenticate(&self, token: &[u8]) -> Option<ControlCaller> {
+        let mut selected = None;
+        for credential in &self.credentials {
+            let verified = Hmac::<Sha256>::new_from_slice(COMPARE_KEY).is_ok_and(|mut verifier| {
+                verifier.update(token);
+                verifier.verify_slice(&credential.digest).is_ok()
+            });
+            if verified {
+                selected = Some(credential.caller.clone());
+            }
+        }
+        selected
+    }
+}
+
+fn token_digest(token: &[u8]) -> Result<Vec<u8>> {
+    let mut digest = Hmac::<Sha256>::new_from_slice(COMPARE_KEY)
+        .map_err(|_| anyhow::anyhow!("initialize control credential verification"))?;
+    digest.update(token);
+    Ok(digest.finalize().into_bytes().to_vec())
+}
+
+fn valid_name(value: &str, credential_id: bool) -> bool {
+    if value.is_empty() || value.len() > 256 {
+        return false;
+    }
+    value.bytes().enumerate().all(|(index, byte)| {
+        byte.is_ascii_alphabetic()
+            || byte == b'_'
+            || (index > 0 && byte.is_ascii_digit())
+            || (credential_id && index > 0 && matches!(byte, b'-' | b'.'))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> ControlConfig {
+        ControlConfig {
+            credentials: vec![ControlCredentialConfig {
+                id: "admin".into(),
+                token_env: "ADMIN_TOKEN".into(),
+                scopes: vec![ControlScope::Read, ControlScope::Reload],
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn legacy_token_never_gains_write_authority() -> Result<()> {
+        let auth = ControlAuth::from_lookup(&ControlConfig::default(), |_| Some("r".repeat(32)))?;
+        let caller = auth
+            .authenticate("r".repeat(32).as_bytes())
+            .ok_or_else(|| anyhow::anyhow!("reader rejected"))?;
+        assert!(caller.permits(ControlScope::Read));
+        assert!(!caller.permits(ControlScope::Reload));
+        assert!(auth.authenticate(b"wrong").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_credentials_ignore_legacy_env() -> Result<()> {
+        let auth = ControlAuth::from_lookup(&config(), |name| {
+            Some(if name == "ADMIN_TOKEN" { "a" } else { "r" }.repeat(32))
+        })?;
+        assert!(auth.authenticate("r".repeat(32).as_bytes()).is_none());
+        let admin = auth
+            .authenticate("a".repeat(32).as_bytes())
+            .ok_or_else(|| anyhow::anyhow!("admin rejected"))?;
+        assert!(admin.permits(ControlScope::Reload));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_credential_configuration_is_rejected() {
+        let mut duplicate = config();
+        let mut second = duplicate.credentials[0].clone();
+        second.id = "second".into();
+        duplicate.credentials.push(second);
+        assert!(ControlAuth::from_lookup(&duplicate, |_| Some("a".repeat(32))).is_err());
+        let mut no_read = config();
+        no_read.credentials[0].scopes = vec![ControlScope::Reload];
+        assert!(ControlAuth::from_lookup(&no_read, |_| Some("a".repeat(32))).is_err());
+        let mut bad_env = config();
+        bad_env.credentials[0].token_env = "TOKEN=secret".into();
+        assert!(ControlAuth::from_lookup(&bad_env, |_| Some("a".repeat(32))).is_err());
+        assert!(ControlAuth::from_lookup(&config(), |_| Some("short".into())).is_err());
+        assert!(ControlAuth::from_lookup(&config(), |_| None).is_err());
+    }
+}

--- a/apps/bitrouter/src/remote_control/inventory.rs
+++ b/apps/bitrouter/src/remote_control/inventory.rs
@@ -224,36 +224,6 @@ pub fn by_cli(leaf: &str) -> Option<&'static ControlActionSpec> {
     ACTIONS.iter().find(|row| row.cli_leaf == leaf)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::BTreeSet;
-
-    #[test]
-    fn exposure_reuses_shared_identity_and_report_schema() -> anyhow::Result<()> {
-        let mut paths = BTreeSet::new();
-        let mut ids = BTreeSet::new();
-        for row in ACTIONS {
-            assert!(paths.insert((row.method, row.path)));
-            assert!(ids.insert(row.id));
-            assert!((row.input_schema)().is_object());
-            assert!((row.output_schema)().is_object());
-            if let Some(shared_id) = row.shared_id {
-                let shared = bitrouter_mcp::actions::ACTIONS
-                    .iter()
-                    .find(|shared| shared.id == shared_id)
-                    .ok_or_else(|| anyhow::anyhow!("missing shared action"))?;
-                assert_eq!(row.id, shared.id);
-                let schema = shared
-                    .output_schema
-                    .ok_or_else(|| anyhow::anyhow!("missing shared schema"))?;
-                assert_eq!((row.output_schema)(), serde_json::Value::Object(schema()));
-            }
-        }
-        Ok(())
-    }
-}
-
 /// Resources have separate identities from executable actions.
 pub struct ControlResourceSpec {
     pub id: &'static str,
@@ -285,3 +255,33 @@ pub const RESOURCES: &[ControlResourceSpec] = &[
         requires_reload: true,
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn exposure_reuses_shared_identity_and_report_schema() -> anyhow::Result<()> {
+        let mut paths = BTreeSet::new();
+        let mut ids = BTreeSet::new();
+        for row in ACTIONS {
+            assert!(paths.insert((row.method, row.path)));
+            assert!(ids.insert(row.id));
+            assert!((row.input_schema)().is_object());
+            assert!((row.output_schema)().is_object());
+            if let Some(shared_id) = row.shared_id {
+                let shared = bitrouter_mcp::actions::ACTIONS
+                    .iter()
+                    .find(|shared| shared.id == shared_id)
+                    .ok_or_else(|| anyhow::anyhow!("missing shared action"))?;
+                assert_eq!(row.id, shared.id);
+                let schema = shared
+                    .output_schema
+                    .ok_or_else(|| anyhow::anyhow!("missing shared schema"))?;
+                assert_eq!((row.output_schema)(), serde_json::Value::Object(schema()));
+            }
+        }
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/remote_control/inventory.rs
+++ b/apps/bitrouter/src/remote_control/inventory.rs
@@ -1,0 +1,287 @@
+//! Explicit control exposure, independent of the cloud MCP profile.
+
+use bitrouter_sdk::config::ControlScope;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::actions::administration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    Status,
+    Models,
+    Route,
+    Requests,
+    Providers,
+    Observe,
+    PolicyStatus,
+    PolicyShow,
+    Agents,
+    Reload,
+}
+
+pub struct ControlActionSpec {
+    pub action: Action,
+    pub id: &'static str,
+    pub legacy_name: &'static str,
+    pub shared_id: Option<&'static str>,
+    pub version: u32,
+    pub method: &'static str,
+    pub path: &'static str,
+    pub scope: ControlScope,
+    pub cli_leaf: &'static str,
+    pub dashboard: &'static str,
+    pub requires_administration: bool,
+    pub requires_reload: bool,
+    pub input_schema: fn() -> serde_json::Value,
+    pub output_schema: fn() -> serde_json::Value,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EmptyInput {}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ModelsInput {
+    pub provider: Option<String>,
+}
+
+fn input_schema<T: JsonSchema>() -> serde_json::Value {
+    schemars::schema_for!(T).to_value()
+}
+
+fn output_schema<T: JsonSchema + 'static>() -> serde_json::Value {
+    serde_json::Value::Object(
+        rmcp::handler::server::tool::schema_for_output::<T>()
+            .as_ref()
+            .clone(),
+    )
+}
+
+macro_rules! action {
+    ($variant:ident, $id:literal, $legacy:literal, $shared:expr, $method:literal, $path:literal, $cli:literal, $panel:literal, $admin:literal, $input:ty, $output:ty) => {
+        ControlActionSpec {
+            action: Action::$variant,
+            id: $id,
+            legacy_name: $legacy,
+            shared_id: $shared,
+            version: 1,
+            method: $method,
+            path: concat!("/control/v1", $path),
+            scope: ControlScope::Read,
+            cli_leaf: $cli,
+            dashboard: $panel,
+            requires_administration: $admin,
+            requires_reload: false,
+            input_schema: input_schema::<$input>,
+            output_schema: output_schema::<$output>,
+        }
+    };
+}
+
+pub const ACTIONS: &[ControlActionSpec] = &[
+    ControlActionSpec {
+        action: Action::Reload,
+        id: "reload",
+        legacy_name: "reload",
+        shared_id: None,
+        version: 1,
+        method: "POST",
+        path: "/control/v1/reload",
+        scope: ControlScope::Reload,
+        cli_leaf: "reload",
+        dashboard: "reload",
+        requires_administration: false,
+        requires_reload: true,
+        input_schema: input_schema::<super::operations::ReloadInput>,
+        output_schema: output_schema::<super::operations::OperationReport>,
+    },
+    action!(
+        Status,
+        "status",
+        "status",
+        Some("status"),
+        "GET",
+        "/status",
+        "status",
+        "overview",
+        false,
+        EmptyInput,
+        bitrouter_mcp::actions::status::StatusReport
+    ),
+    action!(
+        Models,
+        "list_models",
+        "models",
+        Some("list_models"),
+        "GET",
+        "/models",
+        "models",
+        "models",
+        false,
+        ModelsInput,
+        bitrouter_mcp::actions::models::ModelsReport
+    ),
+    action!(
+        Route,
+        "route",
+        "route_preview",
+        Some("route"),
+        "POST",
+        "/route/preview",
+        "route",
+        "preview",
+        false,
+        bitrouter_mcp::actions::route::RouteInput,
+        bitrouter_mcp::actions::route::RouteReport
+    ),
+    action!(
+        Requests,
+        "requests",
+        "requests",
+        None,
+        "GET",
+        "/requests",
+        "requests",
+        "requests",
+        false,
+        crate::actions::requests::RequestFilters,
+        crate::output::reports::requests::RequestsReport
+    ),
+    action!(
+        Providers,
+        "providers_list",
+        "providers_list",
+        None,
+        "GET",
+        "/providers",
+        "providers list",
+        "providers",
+        true,
+        EmptyInput,
+        administration::ProvidersReport
+    ),
+    action!(
+        Observe,
+        "observe_status",
+        "observe_status",
+        None,
+        "GET",
+        "/observe/status",
+        "observe status",
+        "telemetry",
+        true,
+        EmptyInput,
+        administration::ObserveReport
+    ),
+    action!(
+        PolicyStatus,
+        "policy_status",
+        "policy_status",
+        None,
+        "GET",
+        "/policy/status",
+        "policy status",
+        "policy",
+        true,
+        administration::PolicyInput,
+        administration::PolicyReport
+    ),
+    action!(
+        PolicyShow,
+        "policy_show",
+        "policy_show",
+        None,
+        "GET",
+        "/policy/show",
+        "policy show",
+        "policy",
+        true,
+        administration::PolicyInput,
+        administration::PolicyReport
+    ),
+    action!(
+        Agents,
+        "agents_list",
+        "agents_list",
+        None,
+        "GET",
+        "/agents",
+        "agents list",
+        "agents",
+        true,
+        EmptyInput,
+        administration::AgentsReport
+    ),
+];
+
+pub fn by_id(id: &str) -> Option<&'static ControlActionSpec> {
+    ACTIONS.iter().find(|row| row.id == id)
+}
+
+pub fn by_cli(leaf: &str) -> Option<&'static ControlActionSpec> {
+    ACTIONS.iter().find(|row| row.cli_leaf == leaf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn exposure_reuses_shared_identity_and_report_schema() -> anyhow::Result<()> {
+        let mut paths = BTreeSet::new();
+        let mut ids = BTreeSet::new();
+        for row in ACTIONS {
+            assert!(paths.insert((row.method, row.path)));
+            assert!(ids.insert(row.id));
+            assert!((row.input_schema)().is_object());
+            assert!((row.output_schema)().is_object());
+            if let Some(shared_id) = row.shared_id {
+                let shared = bitrouter_mcp::actions::ACTIONS
+                    .iter()
+                    .find(|shared| shared.id == shared_id)
+                    .ok_or_else(|| anyhow::anyhow!("missing shared action"))?;
+                assert_eq!(row.id, shared.id);
+                let schema = shared
+                    .output_schema
+                    .ok_or_else(|| anyhow::anyhow!("missing shared schema"))?;
+                assert_eq!((row.output_schema)(), serde_json::Value::Object(schema()));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resources have separate identities from executable actions.
+pub struct ControlResourceSpec {
+    pub id: &'static str,
+    pub path: &'static str,
+    pub scope: ControlScope,
+    pub cli_leaf: Option<&'static str>,
+    pub requires_reload: bool,
+}
+pub const RESOURCES: &[ControlResourceSpec] = &[
+    ControlResourceSpec {
+        id: "capabilities",
+        path: "/control/v1/capabilities",
+        scope: ControlScope::Read,
+        cli_leaf: None,
+        requires_reload: false,
+    },
+    ControlResourceSpec {
+        id: "state",
+        path: "/control/v1/state",
+        scope: ControlScope::Read,
+        cli_leaf: None,
+        requires_reload: true,
+    },
+    ControlResourceSpec {
+        id: "operation",
+        path: "/control/v1/operations/{request_id}",
+        scope: ControlScope::Reload,
+        cli_leaf: Some("operations show"),
+        requires_reload: true,
+    },
+];

--- a/apps/bitrouter/src/remote_control/operations.rs
+++ b/apps/bitrouter/src/remote_control/operations.rs
@@ -1,0 +1,484 @@
+//! Bounded, boot-local reload ownership and recovery after HTTP disconnects.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures::FutureExt;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::daemon::DaemonReloader;
+use crate::reload::{ReloadAdmissionError, ReloadOutcome, ReloadReport};
+
+pub const MAX_OPERATIONS: usize = 1_024;
+pub const RETENTION_SECONDS: u64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReloadInput {
+    pub request_id: String,
+    pub expected_server_instance_id: String,
+    pub expected_generation: u64,
+}
+
+impl ReloadInput {
+    fn validate(&mut self) -> Result<(), OperationError> {
+        if self.request_id.len() > 256 || self.expected_server_instance_id.len() > 256 {
+            return Err(OperationError::InvalidRequest);
+        }
+        self.request_id = uuid::Uuid::parse_str(&self.request_id)
+            .map_err(|_| OperationError::InvalidRequest)?
+            .to_string();
+        self.expected_server_instance_id = uuid::Uuid::parse_str(&self.expected_server_instance_id)
+            .map_err(|_| OperationError::InvalidRequest)?
+            .to_string();
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationStatus {
+    Running,
+    Succeeded,
+    Failed,
+    PartiallyApplied,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OperationReport {
+    pub request_id: String,
+    pub server_instance_id: String,
+    pub generation_before: u64,
+    pub status: OperationStatus,
+    pub accepted_at_unix_ms: i64,
+    pub completed_at_unix_ms: Option<i64>,
+    pub retain_until_unix_ms: Option<i64>,
+    pub lookup_url: String,
+    pub result: Option<ReloadReport>,
+}
+
+impl OperationReport {
+    pub fn is_running(&self) -> bool {
+        self.status == OperationStatus::Running
+    }
+    pub fn succeeded(&self) -> bool {
+        self.status == OperationStatus::Succeeded
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationError {
+    InvalidRequest,
+    IdempotencyConflict,
+    ServerInstanceChanged,
+    StaleGeneration,
+    ReloadInProgress,
+    Unsupported,
+    Capacity,
+    GenerationExhausted,
+    NotFound,
+    Expired,
+}
+
+impl OperationError {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::IdempotencyConflict => "idempotency_conflict",
+            Self::ServerInstanceChanged => "server_instance_changed",
+            Self::StaleGeneration => "stale_generation",
+            Self::ReloadInProgress => "reload_in_progress",
+            Self::Unsupported => "unsupported_action",
+            Self::GenerationExhausted => "generation_exhausted",
+            Self::Capacity => "operation_capacity",
+            Self::NotFound => "operation_not_found",
+            Self::Expired => "operation_expired",
+        }
+    }
+}
+
+impl std::fmt::Display for OperationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for OperationError {}
+
+impl From<ReloadAdmissionError> for OperationError {
+    fn from(error: ReloadAdmissionError) -> Self {
+        match error {
+            ReloadAdmissionError::ServerInstanceChanged => Self::ServerInstanceChanged,
+            ReloadAdmissionError::StaleGeneration => Self::StaleGeneration,
+            ReloadAdmissionError::ReloadInProgress => Self::ReloadInProgress,
+            ReloadAdmissionError::GenerationExhausted => Self::GenerationExhausted,
+            ReloadAdmissionError::Unsupported => Self::Unsupported,
+        }
+    }
+}
+
+struct StoredOperation {
+    input: ReloadInput,
+    report: OperationReport,
+    completed: Option<Instant>,
+}
+
+impl StoredOperation {
+    fn expired(&self) -> bool {
+        self.completed
+            .is_some_and(|completed| completed.elapsed() >= Duration::from_secs(RETENTION_SECONDS))
+    }
+}
+
+/// Registry locks precede the coordinator's short admission lock. Execution
+/// never holds the registry lock and never depends on a client connection.
+pub struct OperationService {
+    reloader: Arc<dyn DaemonReloader>,
+    registry: Mutex<BTreeMap<(String, String), StoredOperation>>,
+}
+
+impl OperationService {
+    pub fn new(reloader: Arc<dyn DaemonReloader>) -> Self {
+        Self {
+            reloader,
+            registry: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    pub fn state(&self) -> Result<crate::reload::ReloadState, OperationError> {
+        self.reloader
+            .reload_state()
+            .ok_or(OperationError::Unsupported)
+    }
+
+    pub async fn submit(
+        self: &Arc<Self>,
+        credential_id: &str,
+        mut input: ReloadInput,
+    ) -> Result<OperationReport, OperationError> {
+        input.validate()?;
+        let key = (credential_id.to_owned(), input.request_id.clone());
+        let mut registry = self.registry.lock().await;
+        if let Some(existing) = registry.get(&key) {
+            if existing.expired() {
+                return Err(OperationError::Expired);
+            }
+            return if existing.input == input {
+                Ok(existing.report.clone())
+            } else {
+                Err(OperationError::IdempotencyConflict)
+            };
+        }
+        registry.retain(|_, operation| !operation.expired());
+        if registry.len() >= MAX_OPERATIONS {
+            return Err(OperationError::Capacity);
+        }
+
+        // Admission atomically validates generation and claims exclusive reload
+        // ownership before the HTTP handler can publish a running operation.
+        let reservation = self.reloader.reserve_remote(
+            &input.expected_server_instance_id,
+            input.expected_generation,
+        )?;
+        let report = OperationReport {
+            request_id: input.request_id.clone(),
+            server_instance_id: input.expected_server_instance_id.clone(),
+            generation_before: input.expected_generation,
+            status: OperationStatus::Running,
+            accepted_at_unix_ms: chrono::Utc::now().timestamp_millis(),
+            completed_at_unix_ms: None,
+            retain_until_unix_ms: None,
+            lookup_url: format!(
+                "operations/{}?instance={}",
+                input.request_id, input.expected_server_instance_id
+            ),
+            result: None,
+        };
+        registry.insert(
+            key.clone(),
+            StoredOperation {
+                input,
+                report: report.clone(),
+                completed: None,
+            },
+        );
+        drop(registry);
+        tracing::info!(action = "reload", credential_id, request_id = %report.request_id,
+            instance = %report.server_instance_id, generation = report.generation_before, "control operation admitted");
+        let service = self.clone();
+        tokio::spawn(async move {
+            let instance = reservation.server_instance_id().to_owned();
+            let generation = reservation.generation();
+            let result =
+                std::panic::AssertUnwindSafe(service.reloader.reload_reserved(reservation))
+                    .catch_unwind()
+                    .await
+                    .ok()
+                    .or_else(|| {
+                        service
+                            .reloader
+                            .reload_state()
+                            .and_then(|state| state.last_outcome)
+                            .filter(|report| {
+                                report.server_instance_id == instance
+                                    && report.generation == generation
+                            })
+                    });
+            let status = match result.as_ref().map(|report| report.outcome) {
+                Some(ReloadOutcome::Succeeded) => OperationStatus::Succeeded,
+                Some(ReloadOutcome::Failed) => OperationStatus::Failed,
+                Some(ReloadOutcome::PartiallyApplied) => OperationStatus::PartiallyApplied,
+                Some(ReloadOutcome::Unknown) | None => OperationStatus::Unknown,
+            };
+            let now = chrono::Utc::now().timestamp_millis();
+            let mut registry = service.registry.lock().await;
+            if let Some(operation) = registry.get_mut(&key) {
+                operation.report.status = status;
+                operation.report.completed_at_unix_ms = Some(now);
+                operation.report.retain_until_unix_ms =
+                    Some(now + (RETENTION_SECONDS as i64 * 1_000));
+                operation.report.result = result;
+                operation.completed = Some(Instant::now());
+                tracing::info!(action = "reload", credential_id = %key.0, request_id = %key.1,
+                    instance = %operation.report.server_instance_id, generation,
+                    participants = ?operation.report.result.as_ref().map(|report| &report.participants),
+                    restart_required_fields = ?operation.report.result.as_ref().map(|report| &report.restart_required_fields),
+                    outcome = ?status, duration_ms = now.saturating_sub(operation.report.accepted_at_unix_ms),
+                    "control operation completed");
+            }
+        });
+        Ok(report)
+    }
+
+    pub async fn lookup(
+        &self,
+        credential_id: &str,
+        request_id: &str,
+        instance: &str,
+    ) -> Result<OperationReport, OperationError> {
+        if request_id.len() > 256 || instance.len() > 256 {
+            return Err(OperationError::InvalidRequest);
+        }
+        let instance = uuid::Uuid::parse_str(instance)
+            .map_err(|_| OperationError::InvalidRequest)?
+            .to_string();
+        let request_id = uuid::Uuid::parse_str(request_id)
+            .map_err(|_| OperationError::InvalidRequest)?
+            .to_string();
+        if self.state()?.server_instance_id != instance {
+            return Err(OperationError::ServerInstanceChanged);
+        }
+        let registry = self.registry.lock().await;
+        let operation = registry
+            .get(&(credential_id.to_owned(), request_id))
+            .ok_or(OperationError::NotFound)?;
+        if operation.expired() {
+            return Err(OperationError::Expired);
+        }
+        Ok(operation.report.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reload::{ReloadCoordinator, ReloadReservation, ReloadState};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct TestReloader {
+        coordinator: Arc<ReloadCoordinator>,
+        executions: AtomicUsize,
+        release: tokio::sync::Semaphore,
+    }
+
+    #[async_trait::async_trait]
+    impl DaemonReloader for TestReloader {
+        async fn reload(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn reload_state(&self) -> Option<ReloadState> {
+            Some(self.coordinator.state())
+        }
+        fn reserve_remote(
+            &self,
+            instance: &str,
+            generation: u64,
+        ) -> Result<ReloadReservation, ReloadAdmissionError> {
+            self.coordinator.reserve_remote(instance, generation)
+        }
+        async fn reload_reserved(&self, reservation: ReloadReservation) -> ReloadReport {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            if let Ok(permit) = self.release.acquire().await {
+                permit.forget();
+            }
+            let report = ReloadReport::succeeded(
+                reservation.server_instance_id().into(),
+                reservation.generation(),
+            );
+            self.coordinator.complete(&reservation, report.clone());
+            report
+        }
+    }
+
+    fn fixture() -> (Arc<TestReloader>, Arc<OperationService>, ReloadInput) {
+        let reloader = Arc::new(TestReloader {
+            coordinator: ReloadCoordinator::new(),
+            executions: AtomicUsize::new(0),
+            release: tokio::sync::Semaphore::new(0),
+        });
+        let input = ReloadInput {
+            request_id: uuid::Uuid::new_v4().to_string(),
+            expected_server_instance_id: reloader.coordinator.state().server_instance_id,
+            expected_generation: 0,
+        };
+        let service = Arc::new(OperationService::new(reloader.clone()));
+        (reloader, service, input)
+    }
+
+    async fn completed(
+        service: &OperationService,
+        input: &ReloadInput,
+    ) -> anyhow::Result<OperationReport> {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let report = service
+                    .lookup(
+                        "operator",
+                        &input.request_id,
+                        &input.expected_server_instance_id,
+                    )
+                    .await?;
+                if !report.is_running() {
+                    return Ok(report);
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?
+    }
+
+    #[tokio::test]
+    async fn duplicate_owner_and_disconnect_preserve_one_execution() -> anyhow::Result<()> {
+        let (reloader, service, input) = fixture();
+        let first = service.submit("operator", input.clone()).await?;
+        assert!(first.is_running());
+        let repeated = service.submit("operator", input.clone()).await?;
+        assert_eq!(first.request_id, repeated.request_id);
+        let mut changed = input.clone();
+        changed.expected_generation = 1;
+        assert!(matches!(
+            service.submit("operator", changed).await,
+            Err(OperationError::IdempotencyConflict)
+        ));
+        assert!(matches!(
+            service
+                .lookup(
+                    "reader",
+                    &input.request_id,
+                    &input.expected_server_instance_id
+                )
+                .await,
+            Err(OperationError::NotFound)
+        ));
+        assert!(matches!(
+            service.submit("other", input.clone()).await,
+            Err(OperationError::ReloadInProgress)
+        ));
+        // No HTTP request or response owns this work after submit returns.
+        drop(first);
+        reloader.release.add_permits(1);
+        let result = completed(&service, &input).await?;
+        assert!(result.succeeded());
+        assert_eq!(reloader.executions.load(Ordering::SeqCst), 1);
+        assert_eq!(service.state()?.generation, 1);
+        assert!(result.retain_until_unix_ms > result.completed_at_unix_ms);
+        assert!(service.submit("operator", input.clone()).await?.succeeded());
+        let mut fresh = input.clone();
+        fresh.request_id = uuid::Uuid::new_v4().to_string();
+        assert!(matches!(
+            service.submit("operator", fresh).await,
+            Err(OperationError::StaleGeneration)
+        ));
+        assert!(matches!(
+            service
+                .lookup(
+                    "operator",
+                    &input.request_id,
+                    &uuid::Uuid::new_v4().to_string()
+                )
+                .await,
+            Err(OperationError::ServerInstanceChanged)
+        ));
+        assert!(matches!(
+            service
+                .lookup("operator", &input.request_id, "not-a-uuid")
+                .await,
+            Err(OperationError::InvalidRequest)
+        ));
+        assert!(matches!(
+            service
+                .lookup("operator", &input.request_id, &"x".repeat(257))
+                .await,
+            Err(OperationError::InvalidRequest)
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn capacity_never_evicts_unexpired_and_expiry_never_reexecutes() -> anyhow::Result<()> {
+        let (reloader, service, input) = fixture();
+        service.submit("operator", input.clone()).await?;
+        reloader.release.add_permits(1);
+        let report = completed(&service, &input).await?;
+        {
+            let mut registry = service.registry.lock().await;
+            for index in 1..MAX_OPERATIONS {
+                registry.insert(
+                    ("operator".into(), format!("retained-{index}")),
+                    StoredOperation {
+                        input: input.clone(),
+                        report: report.clone(),
+                        completed: Some(Instant::now()),
+                    },
+                );
+            }
+        }
+        let mut fresh = input.clone();
+        fresh.request_id = uuid::Uuid::new_v4().to_string();
+        fresh.expected_generation = 1;
+        assert!(matches!(
+            service.submit("operator", fresh.clone()).await,
+            Err(OperationError::Capacity)
+        ));
+        assert_eq!(reloader.executions.load(Ordering::SeqCst), 1);
+        {
+            let mut registry = service.registry.lock().await;
+            let stored = registry
+                .get_mut(&("operator".into(), input.request_id.clone()))
+                .ok_or_else(|| anyhow::anyhow!("missing retained operation"))?;
+            stored.completed = Some(Instant::now() - Duration::from_secs(RETENTION_SECONDS + 1));
+        }
+        assert!(matches!(
+            service
+                .lookup(
+                    "operator",
+                    &input.request_id,
+                    &input.expected_server_instance_id
+                )
+                .await,
+            Err(OperationError::Expired)
+        ));
+        assert!(matches!(
+            service.submit("operator", input.clone()).await,
+            Err(OperationError::Expired)
+        ));
+        service.submit("operator", fresh.clone()).await?;
+        reloader.release.add_permits(1);
+        assert!(completed(&service, &fresh).await?.succeeded());
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/remote_control/reads.rs
+++ b/apps/bitrouter/src/remote_control/reads.rs
@@ -1,0 +1,108 @@
+//! One disclosure boundary for REST and daemon MCP inspection.
+
+use std::path::PathBuf;
+
+use bitrouter_mcp::actions::models::{ModelsQuery, ModelsReport};
+use bitrouter_mcp::actions::route::{RouteInput, RouteQuery, RouteReport};
+use bitrouter_mcp::actions::status::{StatusQuery, StatusReport};
+use bitrouter_mcp::backend::CallerAuth;
+use bitrouter_mcp::error::ToolError;
+use bitrouter_sdk::config::ControlScope;
+
+use crate::paths::ConfigSource;
+
+#[derive(Clone)]
+pub(super) struct ReadPorts {
+    pub source: ConfigSource,
+    pub socket: PathBuf,
+}
+
+impl ReadPorts {
+    pub async fn status_report(&self) -> anyhow::Result<StatusReport> {
+        let mut report =
+            crate::actions::status::DaemonStatus::new(&self.socket, Some(self.source.clone()))
+                .report()
+                .await
+                .map_err(|_| anyhow::anyhow!("status_unavailable"))?;
+        report.socket = None;
+        Ok(report)
+    }
+
+    pub async fn models_report(&self) -> anyhow::Result<ModelsReport> {
+        crate::actions::models::RoutableModels::new(self.source.clone(), Some(self.socket.clone()))
+            .report()
+            .await
+            .map_err(|_| anyhow::anyhow!("models_unavailable"))
+    }
+
+    pub async fn route_report(&self, input: RouteInput) -> anyhow::Result<RouteReport> {
+        crate::actions::administration::validate_identifier(&input.model)?;
+        crate::actions::route::RouteAction::new(self.source.clone(), Some(self.socket.clone()))
+            .report(input)
+            .await
+            .map_err(|_| anyhow::anyhow!("route_unavailable"))
+    }
+}
+
+#[async_trait::async_trait]
+impl StatusQuery for ReadPorts {
+    async fn status(&self, _: &CallerAuth) -> Result<StatusReport, ToolError> {
+        self.status_report()
+            .await
+            .map_err(|_| ToolError::new("status_unavailable"))
+    }
+}
+
+#[async_trait::async_trait]
+impl ModelsQuery for ReadPorts {
+    async fn list_models(&self, _: &CallerAuth) -> Result<ModelsReport, ToolError> {
+        self.models_report()
+            .await
+            .map_err(|_| ToolError::new("models_unavailable"))
+    }
+}
+
+#[async_trait::async_trait]
+impl RouteQuery for ReadPorts {
+    async fn route(&self, input: RouteInput) -> Result<RouteReport, ToolError> {
+        self.route_report(input)
+            .await
+            .map_err(|_| ToolError::new("route_unavailable"))
+    }
+}
+
+pub(super) struct McpAuthorization;
+
+impl bitrouter_mcp::server::RequestAuthorizer for McpAuthorization {
+    fn authorize(&self, extensions: &rmcp::model::Extensions) -> Result<(), rmcp::ErrorData> {
+        let caller = extensions
+            .get::<http::request::Parts>()
+            .and_then(|parts| parts.extensions.get::<super::auth::ControlCaller>());
+        if caller.is_some_and(|caller| caller.permits(ControlScope::Read)) {
+            Ok(())
+        } else {
+            Err(rmcp::ErrorData::invalid_request(
+                "validated control:read authority required",
+                None,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitrouter_mcp::server::RequestAuthorizer;
+
+    #[test]
+    fn bearer_presence_is_not_a_scope_grant() {
+        let mut request = http::Request::new(());
+        request.headers_mut().insert(
+            http::header::AUTHORIZATION,
+            http::HeaderValue::from_static("Bearer unvalidated"),
+        );
+        let mut extensions = rmcp::model::Extensions::new();
+        extensions.insert(request.into_parts().0);
+        assert!(McpAuthorization.authorize(&extensions).is_err());
+    }
+}

--- a/crates/bitrouter-mcp/src/server.rs
+++ b/crates/bitrouter-mcp/src/server.rs
@@ -67,6 +67,7 @@ fn parse_bearer(value: &str) -> Option<&str> {
 /// reads it) — a capability is never a pair of parallel field declarations.
 #[derive(Clone, Default)]
 struct Caps {
+    request_authorizer: Option<Arc<dyn RequestAuthorizer>>,
     /// The `status` action's port. Which side fills it depends on the
     /// deployment: a local daemon's liveness comes off the control socket and
     /// its spend off the local metering database (both injected app-side), a
@@ -85,6 +86,12 @@ struct Caps {
     /// JSON-RPC methods and resources — so it stays a plain field rather than
     /// a [`CapSpec`] entry.
     skill_catalog: Option<Arc<dyn SkillCatalog>>,
+}
+
+/// Deployment-owned authorization of a tool request after HTTP authentication.
+/// The MCP crate does not interpret deployment credentials or permissions.
+pub trait RequestAuthorizer: Send + Sync {
+    fn authorize(&self, extensions: &rmcp::model::Extensions) -> Result<(), McpError>;
 }
 
 /// One tool-contributing capability: whether it's wired, the tool router it
@@ -387,6 +394,12 @@ pub struct Builder {
 }
 
 impl Builder {
+    /// Require deployment authorization before dispatching any tool.
+    pub fn request_authorizer(mut self, authorizer: Arc<dyn RequestAuthorizer>) -> Self {
+        self.caps.request_authorizer = Some(authorizer);
+        self
+    }
+
     /// Wire the `status` action's port (the `status` tool).
     pub fn status(mut self, status: Arc<dyn StatusQuery>) -> Self {
         self.caps.status_query = Some(status);
@@ -458,6 +471,18 @@ fn skills_error(e: ToolError) -> McpError {
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for BitrouterMcp {
+    async fn call_tool(
+        &self,
+        request: rmcp::model::CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::CallToolResponse, McpError> {
+        if let Some(authorizer) = &self.caps.request_authorizer {
+            authorizer.authorize(&context.extensions)?;
+        }
+        let context = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        self.tool_router.call(context).await
+    }
+
     fn get_info(&self) -> ServerInfo {
         // Resources and the skills extension are declared only when a catalog
         // is wired. Unlike the gateway — which cannot know its upstreams'

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -167,19 +167,47 @@ impl Default for Config {
     }
 }
 
-/// Read-only operator control API settings.
+/// Scoped operator administration API settings.
 ///
 /// The control API is deliberately separate from the inference listener and
 /// the local control socket. It is disabled by default, may bind only to a
-/// loopback address, and always authenticates with the token held in
-/// `BITROUTER_CONTROL_TOKEN`; [`ServerConfig::skip_auth`] never applies to it.
+/// loopback address, and authenticates named credentials when configured.
+/// Otherwise `BITROUTER_CONTROL_TOKEN` grants read-only access.
+/// [`ServerConfig::skip_auth`] never applies to it.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ControlConfig {
     /// Whether to start the HTTP control listener.
     pub enabled: bool,
     /// Loopback `host:port` to listen on.
     pub listen: String,
+    /// Explicit operator credentials. Empty keeps the legacy read-only token.
+    pub credentials: Vec<ControlCredentialConfig>,
+}
+
+/// Authority granted by a host operator, independently of inference credentials.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, schemars::JsonSchema,
+)]
+pub enum ControlScope {
+    /// Host-wide operational inspection, including usage and policy metadata.
+    #[serde(rename = "control:read")]
+    Read,
+    /// Reload server-owned configuration; requires the read grant as well.
+    #[serde(rename = "control:reload")]
+    Reload,
+}
+
+/// A token reference only; configuration never stores the bearer value.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ControlCredentialConfig {
+    /// Non-secret operator identifier used for ownership and audit events.
+    pub id: String,
+    /// Host environment variable that contains this credential's bearer token.
+    pub token_env: String,
+    /// Explicit management authority, unrelated to inference authentication.
+    pub scopes: Vec<ControlScope>,
 }
 
 impl Default for ControlConfig {
@@ -187,6 +215,7 @@ impl Default for ControlConfig {
         Self {
             enabled: false,
             listen: "127.0.0.1:4358".to_string(),
+            credentials: Vec::new(),
         }
     }
 }

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -119,8 +119,28 @@ impl ConfigRoutingTable {
         let _guard = self.reload_lock.lock().await;
         let mut fresh = fresh;
         crate::config::discover_models(&mut fresh).await;
-        *self.config.write().expect("config lock poisoned") = fresh;
+        self.replace_prepared_config_locked(fresh);
         Ok(())
+    }
+
+    /// Swap a configuration whose model discovery has already completed.
+    ///
+    /// The app reload coordinator prepares provider discovery alongside every
+    /// other reload participant before it mutates live state. This entry point
+    /// preserves that prepared-candidate boundary while retaining the routing
+    /// table's own serialization with callers outside that coordinator.
+    pub async fn replace_prepared_config(&self, fresh: Config) -> Result<()> {
+        let _guard = self.reload_lock.lock().await;
+        self.replace_prepared_config_locked(fresh);
+        Ok(())
+    }
+
+    fn replace_prepared_config_locked(&self, fresh: Config) {
+        let mut current = match self.config.write() {
+            Ok(current) => current,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *current = fresh;
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -698,6 +698,15 @@ struct HttpClientSet {
     provider_clients: HashMap<String, (HttpTimeouts, reqwest::Client)>,
 }
 
+/// A fully constructed upstream-client replacement that has not yet become
+/// visible to requests.
+///
+/// Building a `reqwest::Client` can fail, while installing an already-built
+/// set only swaps a lock-protected value. Keeping those stages separate lets a
+/// caller validate an entire reload candidate before changing another live
+/// subsystem.
+pub struct PreparedProviderTimeouts(HttpClientSet);
+
 /// Immutable inputs reused each time an authenticated upstream request is
 /// rebuilt, including after a provider refreshes an expired credential.
 struct RequestBuildInput<'a> {
@@ -804,13 +813,29 @@ impl HttpExecutor {
         default_timeouts: HttpTimeouts,
         per_provider: HashMap<String, HttpTimeouts>,
     ) -> Result<()> {
+        let prepared = self.prepare_provider_timeouts(default_timeouts, per_provider)?;
+        self.commit_provider_timeouts(prepared);
+        Ok(())
+    }
+
+    /// Build replacement timeout clients without making them live.
+    pub fn prepare_provider_timeouts(
+        &self,
+        default_timeouts: HttpTimeouts,
+        per_provider: HashMap<String, HttpTimeouts>,
+    ) -> Result<PreparedProviderTimeouts> {
         let clients = build_http_client_set(default_timeouts, per_provider)?;
+        Ok(PreparedProviderTimeouts(clients))
+    }
+
+    /// Make a previously prepared timeout-client set visible to new requests.
+    /// Existing requests retain the client they selected before this swap.
+    pub fn commit_provider_timeouts(&self, prepared: PreparedProviderTimeouts) {
         let mut guard = match self.clients.write() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        *guard = clients;
-        Ok(())
+        *guard = prepared.0;
     }
 
     /// Pick the client + timeouts for `target`: a per-provider override when one

--- a/crates/bitrouter-tui/src/dashboard.rs
+++ b/crates/bitrouter-tui/src/dashboard.rs
@@ -25,10 +25,14 @@ pub enum Page {
     Models,
     Requests,
     Route,
+    Providers,
+    Telemetry,
+    Policy,
+    Reload,
 }
 
 impl Page {
-    const ALL: [Self; 7] = [
+    const ALL: [Self; 11] = [
         Self::Home,
         Self::Agents,
         Self::Conversation,
@@ -36,6 +40,10 @@ impl Page {
         Self::Models,
         Self::Requests,
         Self::Route,
+        Self::Providers,
+        Self::Telemetry,
+        Self::Policy,
+        Self::Reload,
     ];
 
     pub fn next(self) -> Self {
@@ -51,6 +59,10 @@ impl Page {
             Self::Models => 4,
             Self::Requests => 5,
             Self::Route => 6,
+            Self::Providers => 7,
+            Self::Telemetry => 8,
+            Self::Policy => 9,
+            Self::Reload => 10,
         }
     }
 }
@@ -66,6 +78,37 @@ pub struct Dashboard {
     pub spend: Option<String>,
     pub models: Vec<ModelLine>,
     pub requests: Vec<RequestLine>,
+    pub provider_inventory: Vec<ProviderLine>,
+    pub telemetry: Option<TelemetryLine>,
+    pub policy: Option<PolicyLine>,
+    pub policy_detail: Option<PolicyDetailLine>,
+    /// The requested source is explicit even before the first policy report
+    /// arrives, so toggling never silently falls back to a different source.
+    pub policy_view: PolicyViewSelection,
+    pub selected_policy: usize,
+    pub policy_scroll: u16,
+    pub reload: Option<ReloadLine>,
+    pub reload_operation: Option<ReloadOperationLine>,
+    /// Each passive read retains its last good data when a later refresh
+    /// fails, together with its own time and diagnostic.
+    pub status_refresh: RefreshState,
+    pub models_refresh: RefreshState,
+    pub requests_refresh: RefreshState,
+    pub providers_refresh: RefreshState,
+    pub agents_refresh: RefreshState,
+    pub telemetry_refresh: RefreshState,
+    pub policy_refresh: RefreshState,
+    pub policy_detail_refresh: RefreshState,
+    pub reload_refresh: RefreshState,
+    /// Cached discovery grants. `false` disables the corresponding control;
+    /// `None` means discovery itself has not answered yet.
+    pub control_read_authorized: Option<bool>,
+    pub control_reload_authorized: Option<bool>,
+    pub authority_refresh: RefreshState,
+    pub reload_action: RefreshState,
+    /// An operator explicitly initiated a reload and its bounded remote poll
+    /// or local socket call has not finished yet.
+    pub reload_in_flight: bool,
     pub route_input: String,
     pub route: Option<RouteLine>,
     /// Action failure retained until that action later succeeds.
@@ -75,8 +118,17 @@ pub struct Dashboard {
     /// Non-fatal action diagnostic, such as an ACP routing fallback.
     pub notice: Option<String>,
     pub agents: Vec<AgentLine>,
+    /// Remote administration exposes the catalog but never agent launch
+    /// controls or ACP sessions.
+    pub can_launch_agents: bool,
     pub selected_agent: usize,
     pub conversation: Conversation,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RefreshState {
+    pub updated_at: Option<String>,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -86,6 +138,124 @@ pub struct AgentLine {
     pub acp: bool,
     pub configured: bool,
     pub description: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProviderLine {
+    pub id: String,
+    pub models: usize,
+    pub active: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct TelemetryLine {
+    pub daemon_reachable: bool,
+    pub compiled_in: bool,
+    pub exporter_wired: bool,
+    pub sampler: Option<String>,
+    pub metrics_enabled: bool,
+    pub header_count: usize,
+    pub resource_attribute_count: usize,
+    pub api_key_count: usize,
+    pub api_key_cap: usize,
+    pub user_id_count: usize,
+    pub user_id_cap: usize,
+    pub active_spans: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyLine {
+    pub view: String,
+    pub availability: String,
+    pub digest: Option<String>,
+    pub mode: String,
+    pub policies: Vec<String>,
+    pub bindings: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PolicyViewSelection {
+    #[default]
+    Active,
+    Disk,
+}
+
+impl PolicyViewSelection {
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::Active => Self::Disk,
+            Self::Disk => Self::Active,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Disk => "disk",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyDetailLine {
+    pub name: String,
+    pub tiers: Vec<PolicyTierLine>,
+    pub routes: Vec<PolicyRouteLine>,
+    pub default_tier: Option<String>,
+    pub tool_use_tier: Option<String>,
+    pub tool_safe_tiers: Vec<String>,
+    pub certificates: Vec<PolicyCertificateLine>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyTierLine {
+    pub tier: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyRouteLine {
+    pub route: String,
+    pub tier: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyCertificateLine {
+    pub name: String,
+    pub selected_tier: String,
+    pub evidence_digest: String,
+    pub compiler_config_digest: String,
+    pub evaluator_config_digest: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReloadLine {
+    pub server_instance_id: String,
+    pub generation: u64,
+    pub running: bool,
+    pub running_generation: Option<u64>,
+    pub consistency: String,
+    pub last_outcome: Option<String>,
+    pub participants: Vec<ReloadParticipantLine>,
+    pub restart_required_fields: Vec<String>,
+    pub mixed_state_history: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReloadParticipantLine {
+    pub participant: String,
+    pub outcome: String,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReloadOperationLine {
+    pub request_id: String,
+    pub server_instance_id: String,
+    pub generation_before: u64,
+    pub status: String,
+    pub lookup: String,
+    pub completed_at_unix_ms: Option<i64>,
 }
 
 /// Presentation state for the one controller/session the Code process owns.
@@ -314,6 +484,10 @@ fn draw(
         "Models",
         "Requests",
         "Route",
+        "Providers",
+        "Telemetry",
+        "Policy",
+        "Reload",
     ]
     .into_iter()
     .map(Line::from);
@@ -342,6 +516,10 @@ fn draw(
         Page::Models => draw_models(frame, content, dashboard),
         Page::Requests => draw_requests(frame, content, dashboard),
         Page::Route => draw_route(frame, content, dashboard),
+        Page::Providers => draw_providers(frame, content, dashboard),
+        Page::Telemetry => draw_telemetry(frame, content, dashboard),
+        Page::Policy => draw_policy(frame, content, dashboard),
+        Page::Reload => draw_reload(frame, content, dashboard),
     }
 
     if let Some(message) = &dashboard.notice {
@@ -366,12 +544,19 @@ fn draw(
     }
 
     let help = match page {
-        Page::Agents => "↑/↓ select · Enter connect · Tab pages · Esc/Ctrl-C quit",
+        Page::Agents if dashboard.can_launch_agents => {
+            "↑/↓ select · Enter connect · Tab pages · Esc/Ctrl-C quit"
+        }
+        Page::Agents => "remote catalog is read-only · Tab pages · Esc/Ctrl-C quit",
         Page::Conversation => {
             "type prompt · Enter send · PgUp/PgDn scroll · Tab views · Ctrl-D quit"
         }
         Page::Route => "Tab pages · type model · Enter preview · Ctrl-U clear · Esc/Ctrl-C quit",
-        _ => "Tab pages · r refresh · 1-7 jump · q/Esc/Ctrl-C quit",
+        Page::Policy => {
+            "↑/↓ select · Enter detail · v active/disk · PgUp/PgDn scroll · r refresh · Tab pages"
+        }
+        Page::Reload => "Enter/Ctrl-R reload · r refresh · Tab pages · q/Esc/Ctrl-C quit",
+        _ => "Tab pages · r refresh · 1-0 jump · q/Esc/Ctrl-C quit",
     };
     frame.render_widget(
         Paragraph::new(help).style(Style::default().fg(Color::DarkGray)),
@@ -435,12 +620,18 @@ fn draw_home(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &Das
         lines.push(field("spend", spend));
     }
     lines.push(Line::from(""));
-    lines.push(Line::from(
-        "Open Agents and press Enter to start an ACP conversation, or inspect operations views.",
-    ));
+    lines.push(Line::from(if dashboard.can_launch_agents {
+        "Open Agents and press Enter to start an ACP conversation, or inspect operations views."
+    } else {
+        "Inspect the remote agent catalog and operations views from this read-only dashboard."
+    }));
     frame.render_widget(
         Paragraph::new(lines)
-            .block(Block::default().borders(Borders::ALL).title(" Status "))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(panel_title("Status", &dashboard.status_refresh)),
+            )
             .wrap(Wrap { trim: false }),
         area,
     );
@@ -487,7 +678,7 @@ fn draw_agents(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &D
     .block(
         Block::default()
             .borders(Borders::ALL)
-            .title(" Available agents "),
+            .title(panel_title("Agent catalog", &dashboard.agents_refresh)),
     );
     frame.render_widget(table, area);
 }
@@ -598,11 +789,10 @@ fn draw_models(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &D
         [Constraint::Percentage(45), Constraint::Percentage(55)],
     )
     .header(Row::new(["MODEL", "PROVIDERS"]).style(Style::default().add_modifier(Modifier::BOLD)))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(format!(" Models · {} ", dashboard.models.len())),
-    );
+    .block(Block::default().borders(Borders::ALL).title(panel_title(
+        &format!("Models · {}", dashboard.models.len()),
+        &dashboard.models_refresh,
+    )));
     frame.render_widget(table, area);
 }
 
@@ -632,11 +822,10 @@ fn draw_requests(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: 
         Row::new(["TIME", "MODEL", "PROVIDER", "TOKENS", "COST", "STATUS"])
             .style(Style::default().add_modifier(Modifier::BOLD)),
     )
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(format!(" Recent requests · {} ", dashboard.requests.len())),
-    );
+    .block(Block::default().borders(Borders::ALL).title(panel_title(
+        &format!("Recent requests · {}", dashboard.requests.len()),
+        &dashboard.requests_refresh,
+    )));
     frame.render_widget(table, area);
 }
 
@@ -665,6 +854,317 @@ fn draw_route(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &Da
             .wrap(Wrap { trim: false }),
         result,
     );
+}
+
+fn draw_providers(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &Dashboard) {
+    let rows = dashboard.provider_inventory.iter().map(|provider| {
+        Row::new(vec![
+            provider.id.clone(),
+            provider.models.to_string(),
+            (if provider.active { "yes" } else { "no" }).to_string(),
+        ])
+    });
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(50),
+            Constraint::Length(12),
+            Constraint::Length(10),
+        ],
+    )
+    .header(
+        Row::new(["PROVIDER", "MODELS", "ACTIVE"])
+            .style(Style::default().add_modifier(Modifier::BOLD)),
+    )
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(panel_title("Providers", &dashboard.providers_refresh)),
+    );
+    frame.render_widget(table, area);
+}
+
+fn draw_telemetry(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &Dashboard) {
+    let lines = match &dashboard.telemetry {
+        Some(telemetry) => {
+            let mut lines = vec![
+                field(
+                    "daemon",
+                    if telemetry.daemon_reachable {
+                        "reachable"
+                    } else {
+                        "stopped"
+                    },
+                ),
+                field("compiled", if telemetry.compiled_in { "yes" } else { "no" }),
+                field(
+                    "wired",
+                    if telemetry.exporter_wired {
+                        "yes"
+                    } else {
+                        "no"
+                    },
+                ),
+                field(
+                    "metrics",
+                    if telemetry.metrics_enabled {
+                        "on"
+                    } else {
+                        "off"
+                    },
+                ),
+                field("headers", &telemetry.header_count.to_string()),
+                field("res-attrs", &telemetry.resource_attribute_count.to_string()),
+                field(
+                    "api keys",
+                    &format!("{} / {}", telemetry.api_key_count, telemetry.api_key_cap),
+                ),
+                field(
+                    "users",
+                    &format!("{} / {}", telemetry.user_id_count, telemetry.user_id_cap),
+                ),
+                field("in-flight", &telemetry.active_spans.to_string()),
+            ];
+            if let Some(sampler) = &telemetry.sampler {
+                lines.insert(3, field("sampler", sampler));
+            }
+            lines
+        }
+        None => vec![Line::from("Telemetry has not returned a snapshot yet.")],
+    };
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(panel_title("Telemetry", &dashboard.telemetry_refresh)),
+            )
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_policy(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &Dashboard) {
+    let mut lines = match &dashboard.policy {
+        Some(policy) => {
+            let mut lines = vec![
+                field("view", &policy.view),
+                field("availability", &policy.availability),
+                field("mode", &policy.mode),
+            ];
+            if let Some(digest) = &policy.digest {
+                lines.push(field("digest", digest));
+            }
+            if !policy.policies.is_empty() {
+                lines.push(Line::from(""));
+                lines.push(Line::from("Policies (Up/Down, Enter for typed detail):"));
+                for (index, name) in policy.policies.iter().enumerate() {
+                    let marker = if index == dashboard.selected_policy {
+                        ">"
+                    } else {
+                        " "
+                    };
+                    lines.push(Line::from(format!(" {marker} {name}")));
+                }
+            }
+            for (preset, policy) in &policy.bindings {
+                lines.push(Line::from(format!("  @{preset} -> {policy}")));
+            }
+            lines
+        }
+        None => vec![Line::from(format!(
+            "{} policy has not returned a snapshot yet.",
+            dashboard.policy_view.label()
+        ))],
+    };
+    if let Some(detail) = &dashboard.policy_detail {
+        lines.push(Line::from(""));
+        lines.push(Line::from(format!("Detail: {}", detail.name)));
+        if let Some(tier) = &detail.default_tier {
+            lines.push(field("default tier", tier));
+        }
+        if let Some(tier) = &detail.tool_use_tier {
+            lines.push(field("tool tier", tier));
+        }
+        if !detail.tool_safe_tiers.is_empty() {
+            lines.push(field("tool safe", &detail.tool_safe_tiers.join(", ")));
+        }
+        if !detail.tiers.is_empty() {
+            lines.push(Line::from("  Tiers:"));
+            for tier in &detail.tiers {
+                lines.push(Line::from(format!("    {} -> {}", tier.tier, tier.target)));
+            }
+        }
+        if !detail.routes.is_empty() {
+            lines.push(Line::from("  Routes:"));
+            for route in &detail.routes {
+                lines.push(Line::from(format!("    {} -> {}", route.route, route.tier)));
+            }
+        }
+        if !detail.certificates.is_empty() {
+            lines.push(Line::from("  Certificates:"));
+            for certificate in &detail.certificates {
+                lines.push(Line::from(format!(
+                    "    {}: tier={}",
+                    certificate.name, certificate.selected_tier
+                )));
+                lines.push(Line::from(format!(
+                    "      evidence={} compiler={}",
+                    certificate.evidence_digest, certificate.compiler_config_digest
+                )));
+                if let Some(evaluator) = &certificate.evaluator_config_digest {
+                    lines.push(Line::from(format!("      evaluator={evaluator}")));
+                }
+            }
+        }
+    }
+    if let Some(error) = &dashboard.policy_detail_refresh.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(format!("Policy detail: {error}")));
+    } else if let Some(updated) = &dashboard.policy_detail_refresh.updated_at {
+        lines.push(Line::from(format!("Policy detail updated {updated}")));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(format!(
+        "Source: {} · press v to switch active/disk · PgUp/PgDn scroll detail",
+        dashboard.policy_view.label()
+    )));
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(panel_title("Policy", &dashboard.policy_refresh)),
+            )
+            .wrap(Wrap { trim: false })
+            .scroll((dashboard.policy_scroll, 0)),
+        area,
+    );
+}
+
+fn draw_reload(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &Dashboard) {
+    let mut lines = match &dashboard.reload {
+        Some(reload) => {
+            let mut lines = vec![
+                field("instance", &reload.server_instance_id),
+                field("generation", &reload.generation.to_string()),
+                field("running", if reload.running { "yes" } else { "no" }),
+                field("consistency", &reload.consistency),
+                field(
+                    "read scope",
+                    authority_text(dashboard.control_read_authorized),
+                ),
+                field(
+                    "reload scope",
+                    authority_text(dashboard.control_reload_authorized),
+                ),
+            ];
+            if let Some(generation) = reload.running_generation {
+                lines.push(field("running-gen", &generation.to_string()));
+            }
+            if let Some(outcome) = &reload.last_outcome {
+                lines.push(field("last outcome", outcome));
+            }
+            if !reload.restart_required_fields.is_empty() {
+                lines.push(field("restart", &reload.restart_required_fields.join(", ")));
+            }
+            if reload.mixed_state_history > 0 {
+                lines.push(field(
+                    "mixed history",
+                    &reload.mixed_state_history.to_string(),
+                ));
+            }
+            for participant in &reload.participants {
+                let detail = participant
+                    .detail
+                    .as_ref()
+                    .map_or_else(String::new, |detail| format!(" · {detail}"));
+                lines.push(Line::from(format!(
+                    "  {}: {}{detail}",
+                    participant.participant, participant.outcome
+                )));
+            }
+            lines
+        }
+        None => vec![
+            Line::from("Reload state has not returned a snapshot yet."),
+            field(
+                "read scope",
+                authority_text(dashboard.control_read_authorized),
+            ),
+            field(
+                "reload scope",
+                authority_text(dashboard.control_reload_authorized),
+            ),
+        ],
+    };
+    if let Some(operation) = &dashboard.reload_operation {
+        lines.push(Line::from(""));
+        lines.push(field("request", &operation.request_id));
+        lines.push(field("op status", &operation.status));
+        lines.push(field("op instance", &operation.server_instance_id));
+        lines.push(field(
+            "op generation",
+            &operation.generation_before.to_string(),
+        ));
+        if let Some(completed) = operation.completed_at_unix_ms {
+            lines.push(field("op completed", &completed.to_string()));
+        }
+        lines.push(field("lookup", &operation.lookup));
+    }
+    if dashboard.reload_in_flight {
+        lines.push(Line::from(
+            "Reload action: submitting or polling the retained operation…",
+        ));
+    } else if let Some(error) = &dashboard.reload_action.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(format!("Reload action: {error}")));
+    } else if let Some(updated) = &dashboard.reload_action.updated_at {
+        lines.push(Line::from(format!("Reload action updated {updated}")));
+    }
+    if let Some(error) = &dashboard.authority_refresh.error {
+        lines.push(Line::from(format!("Capability discovery: {error}")));
+    } else if let Some(updated) = &dashboard.authority_refresh.updated_at {
+        lines.push(Line::from(format!(
+            "Capability discovery updated {updated}"
+        )));
+    }
+    if dashboard.control_reload_authorized == Some(false) {
+        lines.push(Line::from(
+            "Reload action is unavailable for this credential; refresh after a scope change.",
+        ));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(
+        "Press Enter or Ctrl-R to reload. Inspect failed, mixed, or unknown results before retrying.",
+    ));
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(panel_title("Reload", &dashboard.reload_refresh)),
+            )
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn authority_text(authorized: Option<bool>) -> &'static str {
+    match authorized {
+        Some(true) => "granted",
+        Some(false) => "not granted",
+        None => "unknown",
+    }
+}
+
+fn panel_title(name: &str, state: &RefreshState) -> String {
+    match (&state.updated_at, &state.error) {
+        (Some(updated), Some(error)) => format!(" {name} · stale since {updated} · {error} "),
+        (None, Some(error)) => format!(" {name} · unavailable · {error} "),
+        (Some(updated), None) => format!(" {name} · updated {updated} "),
+        (None, None) => format!(" {name} "),
+    }
 }
 
 fn field(name: &str, value: &str) -> Line<'static> {
@@ -747,6 +1247,74 @@ mod tests {
     }
 
     #[test]
+    fn policy_page_renders_a_selected_typed_detail_and_source() -> io::Result<()> {
+        let backend = TestBackend::new(160, 60);
+        let mut terminal = Terminal::new(backend)?;
+        let dashboard = Dashboard {
+            target: "remote:workstation".to_string(),
+            policy_view: PolicyViewSelection::Disk,
+            policy: Some(PolicyLine {
+                view: "disk".to_string(),
+                availability: "available".to_string(),
+                digest: Some("policy-digest".to_string()),
+                mode: "frozen".to_string(),
+                policies: vec!["default".to_string()],
+                bindings: Vec::new(),
+            }),
+            policy_detail: Some(PolicyDetailLine {
+                name: "default".to_string(),
+                tiers: vec![PolicyTierLine {
+                    tier: "fast".to_string(),
+                    target: "openai/gpt-5".to_string(),
+                }],
+                routes: vec![PolicyRouteLine {
+                    route: "code".to_string(),
+                    tier: "fast".to_string(),
+                }],
+                default_tier: Some("fast".to_string()),
+                tool_use_tier: None,
+                tool_safe_tiers: Vec::new(),
+                certificates: vec![PolicyCertificateLine {
+                    name: "proof".to_string(),
+                    selected_tier: "fast".to_string(),
+                    evidence_digest: "evidence".to_string(),
+                    compiler_config_digest: "compiler".to_string(),
+                    evaluator_config_digest: Some("evaluator".to_string()),
+                }],
+            }),
+            ..Dashboard::default()
+        };
+
+        terminal.draw(|frame| draw(frame, Page::Policy, &dashboard, None))?;
+        let rendered = rendered_text(&terminal);
+        assert!(rendered.contains("Detail: default"));
+        assert!(rendered.contains("fast -> openai/gpt-5"));
+        assert!(rendered.contains("code -> fast"));
+        assert!(rendered.contains("proof: tier=fast"));
+        assert!(rendered.contains("Source: disk"));
+        Ok(())
+    }
+
+    #[test]
+    fn reload_page_marks_a_missing_reload_scope_unavailable() -> io::Result<()> {
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend)?;
+        let dashboard = Dashboard {
+            target: "remote:reader".to_string(),
+            control_read_authorized: Some(true),
+            control_reload_authorized: Some(false),
+            ..Dashboard::default()
+        };
+
+        terminal.draw(|frame| draw(frame, Page::Reload, &dashboard, None))?;
+        let rendered = rendered_text(&terminal);
+        assert!(rendered.contains("reload scope"));
+        assert!(rendered.contains("not granted"));
+        assert!(rendered.contains("Reload action is unavailable"));
+        Ok(())
+    }
+
+    #[test]
     fn reducer_preserves_draft_while_agents_and_scroll_change() {
         let mut dashboard = Dashboard {
             agents: vec![
@@ -822,6 +1390,10 @@ mod tests {
             Page::Models,
             Page::Requests,
             Page::Route,
+            Page::Providers,
+            Page::Telemetry,
+            Page::Policy,
+            Page::Reload,
             Page::Home,
         ] {
             page = page.next();

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -338,8 +338,16 @@
       "type": "object"
     },
     "ControlConfig": {
-      "description": "Read-only operator control API settings.\n\nThe control API is deliberately separate from the inference listener and\nthe local control socket. It is disabled by default, may bind only to a\nloopback address, and always authenticates with the token held in\n`BITROUTER_CONTROL_TOKEN`; [`ServerConfig::skip_auth`] never applies to it.",
+      "additionalProperties": false,
+      "description": "Scoped operator administration API settings.\n\nThe control API is deliberately separate from the inference listener and\nthe local control socket. It is disabled by default, may bind only to a\nloopback address, and authenticates named credentials when configured.\nOtherwise `BITROUTER_CONTROL_TOKEN` grants read-only access.\n[`ServerConfig::skip_auth`] never applies to it.",
       "properties": {
+        "credentials": {
+          "description": "Explicit operator credentials. Empty keeps the legacy read-only token.",
+          "items": {
+            "$ref": "#/$defs/ControlCredentialConfig"
+          },
+          "type": "array"
+        },
         "enabled": {
           "default": false,
           "description": "Whether to start the HTTP control listener.",
@@ -352,6 +360,48 @@
         }
       },
       "type": "object"
+    },
+    "ControlCredentialConfig": {
+      "additionalProperties": false,
+      "description": "A token reference only; configuration never stores the bearer value.",
+      "properties": {
+        "id": {
+          "description": "Non-secret operator identifier used for ownership and audit events.",
+          "type": "string"
+        },
+        "scopes": {
+          "description": "Explicit management authority, unrelated to inference authentication.",
+          "items": {
+            "$ref": "#/$defs/ControlScope"
+          },
+          "type": "array"
+        },
+        "token_env": {
+          "description": "Host environment variable that contains this credential's bearer token.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "token_env",
+        "scopes"
+      ],
+      "type": "object"
+    },
+    "ControlScope": {
+      "description": "Authority granted by a host operator, independently of inference credentials.",
+      "oneOf": [
+        {
+          "const": "control:read",
+          "description": "Host-wide operational inspection, including usage and policy metadata.",
+          "type": "string"
+        },
+        {
+          "const": "control:reload",
+          "description": "Reload server-owned configuration; requires the read grant as well.",
+          "type": "string"
+        }
+      ]
     },
     "DatabaseConfig": {
       "description": "Database connection settings.",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -99,7 +99,7 @@ Local router subcommands that load a config accept an optional `-c / --config <p
 
 Daemon-control subcommands (`stop`, `reload`, `status`) also accept `--socket <path>` to override the control socket path derived from the config.
 
-## Remote contexts (HTTP-only MVP)
+## Remote contexts
 
 ```console
 bitrouter context add workstation \
@@ -111,6 +111,12 @@ bitrouter --context workstation status
 bitrouter --context workstation requests
 bitrouter --context workstation models --provider openai
 bitrouter --context workstation route openai/gpt-5
+bitrouter --context workstation providers list
+bitrouter --context workstation observe status
+bitrouter --context workstation policy status       # active by default
+bitrouter --context workstation policy show default --view disk
+bitrouter --context workstation agents list
+bitrouter --context workstation reload
 bitrouter context remove workstation
 ```
 
@@ -121,13 +127,28 @@ plain HTTP is accepted only for `localhost`/loopback, including an SSH-forwarded
 port. The client performs the `/control/v1/capabilities` handshake before its
 first action (and caches it for a long-lived TUI), follows no redirects, and
 never falls back to this computer's config, socket, or database after a remote
-error.
+error. A named context is the complete target: supported remote commands reject
+local `--config` and `--socket` flags before opening local configuration,
+environment, or metering state.
 
-The MVP supports `status`, `requests`, `models`, `route`, and the operations
-`code` UI. Daemon mutations, configuration/provider/key administration,
-agent lifecycle, ACP sessions, native harness launch, and `code <agent>` remain
-local and reject a remote context before doing anything. Use SSH for an agent
-TUI on the server until remote ACP is implemented.
+Remote read actions are `status`, `requests`, `models`, `route`, `providers
+list`, `observe status`, `policy status`, `policy show`, and `agents list`, as
+well as the operations `code` dashboard. A remote policy command defaults to
+`--view active`; local policy reads default to `--view disk`. The dashboard
+always requests the active policy explicitly; its Policy page can switch sources
+with `v` and request a selected policy's typed detail with `Enter`.
+
+`agents list` is a catalog read only. `agents list --remote`, agent checks and
+launches, ACP sessions, native harness UIs, and `code <agent>` stay local. The
+only remote mutation is the explicit `reload` action; it reloads server-owned
+files and never uploads config or forwards the client's environment. Provider,
+key, configuration, policy-publication, and service lifecycle administration
+remain local.
+
+Local CLI compatibility adapters retain the established `providers list`
+`api_base` field and `observe status` socket, endpoint, and service fields.
+Those host details are omitted from remote administration and dashboard
+reports, which use the redacted typed read contracts.
 
 ---
 
@@ -143,23 +164,34 @@ bitrouter serve [-c <path>]
 
 Starts the proxy on the configured listen address (default `127.0.0.1:4356`) and opens a Unix domain control socket. Logs to stdout.
 
-An opt-in, read-only remote-control listener can expose the existing typed
-status/models/route/requests actions to a trusted operator through a private tunnel or
-TLS reverse proxy:
+An opt-in remote-control listener exposes typed administration reads and a
+separately authorized reload action to a trusted operator through a private
+tunnel or TLS reverse proxy:
 
 ```yaml
 control:
   enabled: true
   listen: 127.0.0.1:4358
+  credentials:
+    - id: workstation-admin
+      token_env: WORKSTATION_ADMIN_CONTROL_TOKEN
+      scopes: [control:read, control:reload]
 ```
 
-Set a dedicated bearer token of at least 32 bytes in
-`BITROUTER_CONTROL_TOKEN` before starting the daemon. This listener is disabled
-by default, accepts loopback addresses only, and is never affected by inference
-`server.skip_auth`. Its typed HTTP actions live under `/control/v1`, and the
-BitRouter origin MCP service is mounted at `/mcp-control` with the same bearer
-and browser-Origin checks. Remote ACP sessions are not part of this HTTP-only MVP. Changes under `control:` are
-restart-only because they govern listener creation and binding.
+`ControlConfig.credentials` is optional. When it is absent or empty, the legacy
+`BITROUTER_CONTROL_TOKEN` remains valid with `control:read` only. When explicit
+credentials are configured, only their `id`, `token_env`, and `scopes` entries
+are accepted; the legacy token is not an additional credential. Each token must
+be at least 32 bytes. `control:read` grants the host-wide operational reports;
+`control:reload` permits the guarded reload operation and requires the read
+scope alongside it.
+
+This listener is disabled by default, accepts loopback addresses only, and is
+never affected by inference `server.skip_auth`. Its typed HTTP actions live
+under `/control/v1`, and the BitRouter origin MCP service is mounted at
+`/mcp-control` with the same bearer and browser-Origin checks. Remote ACP
+sessions are not exposed. Changes under `control:` are restart-only because
+they govern listener creation and binding.
 
 ### `bitrouter start`
 
@@ -191,17 +223,24 @@ Stops the running daemon (waiting up to 30s for in-flight requests to drain), th
 
 ```
 bitrouter reload [-c <path>] [--socket <path>]
+bitrouter --context <name> reload
 ```
 
 Hot-reloads the running daemon's config and routing table without dropping connections. Also triggered by `SIGHUP`.
 
 Any provider API keys present in the current environment are forwarded to the daemon so `export OPENAI_API_KEY=…; bitrouter reload` takes effect immediately.
 
+With `--context`, reload submits a guarded operation against the server's own
+current configuration. It does not forward client environment variables. The
+report includes a request id, server instance, generation, and per-subsystem
+result. A running, failed, partially applied, or unknown operation exits
+non-zero; use its operation lookup details and the target's state before retrying.
+
 ### `bitrouter status`
 
 ```
 bitrouter status [-c <path>] [--socket <path>]
-bitrouter requests [--limit N]       # what the router has actually done
+bitrouter requests [--limit N] [--since RFC3339 --until RFC3339] [--model ID] [--provider ID]
 bitrouter requests --human           # the same, as a table
 ```
 
@@ -224,7 +263,14 @@ The figure is **machine-wide**, not per-caller: it rolls up every caller of this
 
 `bitrouter status --json` gained `spend` additively; every pre-existing key is unchanged.
 
-`bitrouter requests [--limit N]` reports what the router has actually done: newest-first settled requests — time, model, the provider that **actually** served, tokens in/out, cost, latency, status — plus daemon state and the window's spend and trailing-minute rate. It reads the metering store directly, so it also works with **no daemon running**. `status --requests` remains a hidden compatibility spelling.
+`bitrouter requests` reports what the router has actually done: newest-first
+settled requests — time, model, the provider that **actually** served, tokens
+in/out, cost, latency, status — plus daemon state and the window's spend and
+trailing-minute rate. It reads the metering store directly, so it also works
+with **no daemon running**. `--since` and `--until` are an RFC3339 pair with a
+maximum seven-day interval; absent both, the server selects today from UTC
+midnight. `--model` and `--provider` filter the same report before the limit.
+`status --requests` remains a hidden compatibility spelling.
 
 Like every other report it uses JSON by default and `--human` for the table. Repeat it with `watch -n1 bitrouter requests --human` for a live view.
 
@@ -381,10 +427,14 @@ Same report type as the origin MCP server's `list_models` tool, so
 ### `bitrouter providers list`
 
 ```
-bitrouter providers list [-c <path>]
+bitrouter providers list [-c <path>] [--socket <path>]
 ```
 
-Prints each configured provider's id, model count, active state, and API base URL.
+Local compatibility output prints each provider's id, model count,
+routing-active state, and `api_base`. Named remote contexts and the dashboard
+use the redacted accepted catalog, which omits API bases and credentials.
+`active` means the accepted routing configuration includes the provider, not
+that a connectivity probe succeeded.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,10 @@ workspace architecture guide, and design specs. It is *not* published anywhere.
 - [`REMOTE_CONTROL_MVP_SPEC.md`](REMOTE_CONTROL_MVP_SPEC.md) — **implemented.**
   Read-only remote status/models/route/requests and dashboard views over an
   authenticated, loopback-only HTTP control listener; ACP stays local.
+- [`REMOTE_ADMINISTRATION_SPEC.md`](REMOTE_ADMINISTRATION_SPEC.md) — **implemented.**
+  Expands remote inspection and adds explicitly authorized reload,
+  with shared action metadata, live/disk policy views, partial-failure reporting,
+  and recovery after a client disconnect. Remote agent execution stays deferred.
 - [`REMOTE_CLI_TUI_SUPPORT_SPEC.md`](REMOTE_CLI_TUI_SUPPORT_SPEC.md) — **Phase 2
   RFD, deferred.** Remote ACP sessions over a versioned WebSocket transport,
   constrained execution, and reconnect behavior.

--- a/docs/REMOTE_ADMINISTRATION_PROGRESS.md
+++ b/docs/REMOTE_ADMINISTRATION_PROGRESS.md
@@ -1,0 +1,145 @@
+# Remote administration implementation ledger
+
+Objective: implement the whole [remote administration spec](REMOTE_ADMINISTRATION_SPEC.md)
+and verify its acceptance criteria. Authorized 2026-09-08. Baseline `b657cb62`.
+
+Requested workers: `gpt-5.3-codex-spark`, `xhigh`; launch requests were accepted,
+but all three workers terminated at the Spark usage limit before making changes.
+The maintainer selected `gpt-5.6-terra` at `max`; replacement workers completed the implementation.
+Status: **implementation and prior spec acceptance are complete, but the
+expanded live external-host MCP acceptance is currently blocked on 2026-09-08.**
+The default Docker command reaches the real TLS sidecar and receives HTTP 403
+at MCP `initialize` because rmcp rejects `Host: server:8443`; `tools/list` and
+the advertised MCP tool calls therefore cannot execute. The historical notes
+below remain evidence for the prior specification acceptance. A separately
+labeled selected run passes the independent CLI, HTTP, reload, and dashboard
+journeys with MCP intentionally skipped; it is not complete remote acceptance.
+
+| Requirement | State | Evidence |
+| --- | --- | --- |
+| A: canonical remote inventory and schema/profile guards | Complete | Canonical action/resource rows and schema identity tests pass; existing MCP profile guards remain intact. |
+| A: shared CLI/dashboard target ports, no local fallback | Complete | InspectionTarget is shared; real subprocess traps prove denied/failed remote actions do not access local config, metering or sockets. |
+| A: additive discovery and old/new compatibility | Complete | Legacy names, old-server read compatibility, scope discovery and no-redirect HTTP tests pass. |
+| A: REST/MCP caller validation and shared disclosure | Partial | Loopback HTTP MCP validation uses the same redacted read ports. Expanded Docker TLS `initialize` is rejected before runtime inventory or tool calls by rmcp's Host allowlist. |
+| B: providers, telemetry, passive agent reads | Complete | Live typed ports and redaction tests pass; all advertised reads exercised over Docker HTTP and CLI. |
+| B: active/disk policy status/detail | Complete | Snapshot mode, bindings and digest tests pass; Docker observes disk/live divergence and convergence after reload. |
+| B: bounded request filters, summaries, availability | Complete | Storage and report tests plus Docker CLI/HTTP filters, truncation, validation and redaction pass. |
+| B: CLI and dashboard all read actions | Complete | Selected Docker run exercises all nine CLI leaves and semantic dashboard Home, Models, Requests, Route, Providers, Telemetry, Agents, active/disk policy overview/detail, and excluded remote ACP views. |
+| C: unified reload ownership and local env serialization | Complete | HTTP/local IPC/SIGHUP admission race and reservation tests pass. |
+| C: prepared inputs and restart-required classification | Complete | All five participants prepare before mutation; immutable startup baseline, nested unknown fields and 60-second preparation deadline are tested. |
+| C: per-participant failure and mixed runtime state | Complete | Fault matrix, immutable prepared inputs, active digest, mixed-history and interruption-truth tests pass. |
+| D: explicit scoped credentials, legacy read token | Complete | Named read/reload credentials, owner isolation and legacy read-only fallback pass unit/HTTP/Docker tests. |
+| D: guarded reload admission and retained operations | Complete | Generation/boot guards, deduplication, ownership, 1024-entry capacity and 24-hour retention tests pass. |
+| D: CLI/dashboard reload and operation recovery | Complete | Selected Docker run verifies a successful production CLI reload plus `operations show` recovery, receipt-body loss recovery, boot mismatch, and successful/partial PTY outcomes. |
+| D: limits, audit events, HTTP errors | Complete | 16 KiB input, 8 MiB report bound, advertised limits, structured audit and safe error tests pass. |
+| E: inventory/HTTP/auth/version/redaction tests | Complete | Final all-feature suite includes HTTP scope/shape/owner, ambiguity, redirect, legacy and inventory-route guards. |
+| E: target isolation and read divergence tests | Complete | Linux inotify, synthetic provider/config/metering inputs and two Unix-socket traps pass wrong-token and unreachable-context checks. |
+| E: reload faults/concurrency/disconnect/boot tests | Complete | Core fault/admission tests plus actual Docker lost receipt-body, same-ID lookup, deduplication and restart acceptance pass. |
+| E: dashboard and real terminal verification | Complete | Inventory-to-page guard and stale/scope tests pass; selected Docker PTY covers semantic read panels, route Backspace/Ctrl-U, policy Up/Down, typed detail, PageDown/PageUp and active/disk before reload; both outcomes restore terminal modes and subsequent shell output. |
+| E: isolated Docker client/server TLS acceptance | Partial | Linux/ARM64 selected CLI/dashboard run passes and cleans up. Default full harness fails at external-host MCP `initialize` with HTTP 403; this is container, not physical-host, evidence. |
+| E: CLI, shipped skill, config schemas and distribution | Complete | CLI and skill references updated; schema/dist, relative links and all eight extracted package builds pass. |
+| E: all-feature tests, doc tests, clippy, fmt | Complete | Final suite: 3169 passed, 12 skipped; one existing ACP test had a non-failing leak annotation and passed cleanly on focused rerun. Doc tests, strict rustdoc, clippy and fmt pass. |
+
+## Progress
+
+- 2026-09-08: reread current worktree/spec/AGENTS.md; source tree initially
+  unchanged except the authored design and docs index. Split bounded request,
+  credential, and reload-core work among the requested model/effort workers.
+- No requirement is marked complete without integration and verification.
+- Spark workers all returned usage-limit errors before edits. Parent added the
+  initial administration DTOs and policy-runtime inspection snapshot; compilation
+  and transport integration are still in progress.
+- Maintainer selected `gpt-5.6-terra` at `max`; three workers now own requests,
+  reload coordination, and CLI/dashboard reads. Read-side all-target compilation
+  passed before the next integration edits. Focused real HTTP MCP test passed;
+  the complete focused suite is still being integrated.
+- Maintainer selected Docker for final network-boundary acceptance. Docker
+  Desktop 4.81.0 is running with a Linux arm64 engine. No physical-host deployment claim will be made from container evidence.
+- Focused nextest run `e81c6cbc-3f37-41d8-9b2c-eff585c6ff5a`: 32 tests passed across administration reads, request filters, remote auth/MCP/schema/legacy compatibility, operation deduplication/retention/ownership, and reload core. This predates the final HTTP mutation and dashboard integration edits.
+- Expanded focused suite: 35 passed, including HTTP reload body/scope guards, operation ownership and boot mismatch responses, and local target rejection.
+- Shared live consistency headers now identify reads that may span reload generations, without claiming a single atomic runtime configuration.
+- First workspace-wide `cargo nextest run --all-features --no-fail-fast` passed: 3,149 tests, 11 skipped, test execution 19.788 seconds. This successful build precedes the final asynchronous dashboard reload and Docker fault-fixture edits, which still require final verification.
+- Reload preparation now has a 60-second deadline; commit has no cancellation deadline. New tests cover all five participant failure boundaries, immutable prepared inputs, mixed-history preservation, nested unknown configuration, and local IPC/SIGHUP entry methods racing a held remote reservation.
+- Docker harness uses separate TLS client/server containers and a separate lib-test HTTP partial-failure fixture. The shipped server has no fault flags. A standard-library PTY harness checks explicit reload, visible partial state, quit, terminal modes, and subsequent shell output. Execution is pending the final integrated build; these assets are not yet acceptance evidence.
+- Final integrated workspace run after reload fixes: `cargo nextest run
+  --all-features --no-fail-fast` passed 3,168 tests, with 12 skipped, in
+  30.156 seconds of test execution. This includes all five participant fault
+  boundaries, local/remote/SIGHUP admission races, immutable startup-setting
+  classification, prepared-input stability, and interrupted-outcome truth.
+- `cargo test --doc --all-features` passed five documentation tests (one ignored);
+  `cargo clippy --all-features`, `cargo fmt --all -- --check`, and
+  `cargo run -p dist-helper -- check` passed. Distribution verification confirms
+  the generated configuration schema and registry artifacts are current.
+- Docker production acceptance passed remote reads and request filters, active
+  versus disk policy divergence, explicit reload, lost receipt-body recovery,
+  operation ownership and boot mismatch, legacy read-only authentication, and
+  a real PTY successful reload with terminal restoration. The test-only partial
+  fixture phase is still being debugged; full container acceptance remains open.
+
+- The complete Docker flow subsequently passed, including the test-only HTTP
+  partial fixture and both successful and partially applied dashboard PTY
+  journeys. Partial CLI output preserves the operation report plus the CLI's
+  existing JSON error envelope, exits nonzero, and identifies applied/failed
+  participants. A separate synthetic-local-input trap phase is being added to
+  close acceptance criterion 3 before the final container rerun.
+- CI-equivalent `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features
+  --no-deps` passed. All 35 relative links in the spec, ledger, docs index and
+  shipped remote-administration guidance resolve.
+
+- `cargo package --workspace --allow-dirty` passed: all eight packages were
+  produced and their extracted sources compiled successfully (4m 33s). No
+  publication or repository commit was performed.
+
+- Final Docker acceptance after adding every CLI read and target isolation passed
+  in 19.4 seconds. The rebuilt Linux/ARM64 image contains the wrong-token reload
+  trap case. HTTP/CLI reads, filtered requests, staged policy divergence, scoped
+  reload, receipt-body loss, same-ID recovery, boot changes, legacy credentials,
+  and both PTY outcomes passed. Harness Bash syntax, Python compile, ShellCheck
+  and diff checks passed; no temporary test containers or networks remain.
+- Final `cargo nextest run --all-features --no-fail-fast`, including the added
+  inventory-to-dashboard-page guard: **3,169 passed, 12 skipped**, 22.679 seconds.
+  The unchanged SDK test `callbacks_and_unknown_extensions_are_bidirectional`
+  received a non-failing nextest subprocess-leak annotation in that run; its
+  focused rerun passed cleanly (run ID `447177c1-2869-4d14-b8a7-b414fd4dc199`).
+  Formatting was rechecked after the test-only addition. This records the
+  earlier specified acceptance scope; the expanded external-host MCP result
+  below supersedes its former blanket Docker-acceptance status.
+- Expanded live-interface verification added a standard-library MCP client that
+  initializes the TLS `/mcp-control` endpoint, obtains runtime `tools/list`,
+  requires the exact discovered control set, and semantically calls each tool.
+  The default `tests/remote-administration/run.sh` now reaches that client after
+  all CLI reads, then fails at `initialize` with `MCP HTTP 403: Forbidden: Host
+  header is not allowed`. The production container logs record rmcp rejecting
+  `NormalizedAuthority { host: "server", port: Some(8443) }`. Since the
+  initialization handshake never completes, `tools/list` and calls to the
+  expected `list_models`, `route_preview`, and `status` tools were not executed
+  through the external TLS deployment. No Host rewrite or permissive bypass was
+  used.
+- The narrowly labeled diagnostic run
+  `BITROUTER_REMOTE_ADMIN_SKIP_MCP=1 tests/remote-administration/run.sh` passed
+  the independent Docker journeys. It executed an actual successful
+  administrator CLI reload and retained `operations show` recovery, then both
+  successful and partial PTY reload outcomes with terminal restoration and a
+  usable subsequent shell. It is explicitly not a complete acceptance result.
+- The successful production PTY journey rendered semantic Home, Models,
+  Requests, Route, Providers, Telemetry, Agents, policy active/disk overview
+  and named detail. It exercised route Backspace and Ctrl-U; policy Down then
+  Up with typed-detail reset, PageDown then PageUp restoring the visible top,
+  and the active/disk toggle. Agent Enter showed `Remote agent catalogs are
+  read-only; start ACP sessions on the local host.` Conversation and Sessions
+  remained remote-excluded with their existing generic unavailable messages;
+  this is a copy/UX finding, not a claim of remote ACP execution.
+- The request-filter harness now uses microsecond RFC3339 UTC bounds rather
+  than a rounded current second. The passing selected run recorded CLI bounds
+  `2026-09-08T07:52:02.640492+00:00` to
+  `2026-09-08T08:02:02.645285+00:00`, with newest row
+  `2026-09-08T08:02:01.963642884+00:00`; its HTTP bounds were
+  `2026-09-08T07:52:07.129770+00:00` to
+  `2026-09-08T08:02:07.134657+00:00` for the same newest row. This removes the
+  prior same-second cutoff error without widening the assertion.
+- Minor dashboard wording findings remain: Home calls the remote dashboard
+  read-only even for an administrator with reload authority, and the inactive
+  Conversation/Sessions views suggest choosing an agent despite remote ACP
+  being unavailable. The live agent-launch attempt was correctly denied.
+  This follow-up changed test assets and evidence only; production fixes remain
+  separate from the live-testing results.

--- a/docs/REMOTE_ADMINISTRATION_PROGRESS.md
+++ b/docs/REMOTE_ADMINISTRATION_PROGRESS.md
@@ -143,3 +143,34 @@ journeys with MCP intentionally skipped; it is not complete remote acceptance.
   being unavailable. The live agent-launch attempt was correctly denied.
   This follow-up changed test assets and evidence only; production fixes remain
   separate from the live-testing results.
+
+
+### Integration with main for PR review (2026-09-08)
+
+- Merged `main` at `a59bd6b3` into the remote-administration branch. Preserved
+  native transcript scrollback, the multiline composer, and docked controls.
+  All eleven pages remain available; Policy and Reload use the available
+  terminal height so typed details and retained operation receipts stay visible.
+  Rendering tests exercise the actual dock height for policy and reload.
+- Updated the PTY emulator for the main-screen writer's cursor-position query,
+  bottom-row line-feed scrolling, erase ranges, and synchronized frames.
+  PageDown/PageUp compares the complete policy body independently of automatic
+  refresh timestamps, retaining the semantic scroll-and-restore assertion.
+- Post-merge `cargo nextest run --all-features --no-fail-fast`: **3,195 passed,
+  12 skipped**. An earlier run hit the existing timeout-sensitive
+  `local_cli::tests::probes_compatible_old_failed_and_hung_workers` test; the
+  complete final rerun passed, including that test. Documentation tests passed
+  (five passed, one ignored), as did all-feature Clippy, formatting, strict
+  workspace rustdoc, and distribution/schema checks.
+- Rebuilt Linux/ARM64 selected Docker acceptance passed again: every remote
+  CLI/REST read, target isolation, retained-operation recovery, policy controls,
+  and both successful and partially applied real-PTY reload journeys. Both PTY
+  runs restored terminal state and verified a subsequent shell write. This
+  remains the explicitly MCP-skipped diagnostic selection; it does not close
+  the external-host MCP limitation recorded above.
+- Post-merge evidence: `/tmp/bitrouter-remote-merge-tests-final.log`,
+  `/tmp/bitrouter-remote-merge-doctests.log`,
+  `/tmp/bitrouter-remote-merge-clippy.log`,
+  `/tmp/bitrouter-remote-merge-rustdoc.log`,
+  `/tmp/bitrouter-remote-merge-dist.log`, and
+  `/tmp/bitrouter-remote-merge-docker-verified.log`.

--- a/docs/REMOTE_ADMINISTRATION_SPEC.md
+++ b/docs/REMOTE_ADMINISTRATION_SPEC.md
@@ -1,0 +1,476 @@
+# Spec: remote router administration
+
+Status: **implemented; expanded live verification found a remote MCP issue.**
+The original acceptance run completed on 2026-09-08 in the maintainer-approved
+Docker environment. A subsequent live MCP test found that the transport rejects
+the external Host header through a TLS proxy that preserves it. See the
+[acceptance evidence and current findings](REMOTE_ADMINISTRATION_PROGRESS.md).
+Date: 2026-09-08.
+Verified source baseline: `b657cb62` (`v1.0.0-alpha.30`).
+
+## 1. Decision to review
+
+Expand the existing named-context HTTP client into a router administration
+surface. The first release adds operational reads and one write: reloading the
+server's existing configuration. The CLI and Code dashboard use the same typed
+actions, target resolution, authorization, and reports.
+
+An operator can inspect the running router, distinguish its active policy from
+files waiting on disk, diagnose telemetry, inspect its configured agent catalog,
+and reload changes prepared on the server. They can determine whether a reload
+succeeded, failed before applying changes, or partially applied changes even if
+the initiating HTTP connection was lost.
+
+This release continues the trusted-operator deployment model. It introduces
+separate read and reload authority, not tenant isolation or remote code
+execution. Provider credentials and configuration files stay on the host.
+
+### Review decisions
+
+| ID | Recommended decision | Consequence / alternative |
+| --- | --- | --- |
+| D1 | Ship inspection plus guarded reload as the first administration release. | Policy publication, remote config editing, and service supervision need later contracts. Reads can land first, but do not constitute the full release. |
+| D2 | Preserve the existing token as a read-only operator credential; add explicit named credentials with scopes. | Existing deployments gain no write authority merely by upgrading. A single all-powerful token would be smaller but would silently expand existing authority. |
+| D3 | Report reload's actual per-subsystem outcome; do not promise transactional rollback. | Strengthen preparation before mutation, but a partial commit remains an explicit terminal result. An all-or-nothing runtime swap is a separate, larger refactor. |
+| D4 | Keep remote exposure in one app-owned inventory joined to existing shared action IDs. | Reuse shared types; avoid forcing administration operations into MCP's reversible session-action model. |
+| D5 | Add the new reads to CLI and dashboard; preserve the current three-tool daemon MCP profile for this release. | Share its authorization and redaction machinery now. Wider MCP tool exposure remains an explicit later decision. |
+| D6 | Exclude active agent/MCP diagnostics. | `agents check` launches an agent; MCP checks can launch configured subprocesses. These are not passive reads. |
+
+The maintainer authorized implementation of this spec, including D1–D6, on
+2026-09-08. Flags, paths, scopes, and configuration below remain implementation
+requirements, not proof of delivered behavior. Track evidence in the
+[implementation ledger](REMOTE_ADMINISTRATION_PROGRESS.md).
+
+## 2. Verified starting point
+
+| Source | Current behavior and implication |
+| --- | --- |
+| [`remote_control.rs`](../apps/bitrouter/src/remote_control.rs) | `/control/v1` exposes capabilities, status, models, route preview, and requests. The dedicated listener is disabled by default, loopback-only, and validates `BITROUTER_CONTROL_TOKEN`. |
+| [`contexts.rs`](../apps/bitrouter/src/contexts.rs), [`main.rs`](../apps/bitrouter/src/main.rs) | Contexts store endpoint and token environment-variable references. Remote command eligibility is a manual match; supported commands reject local config/socket overrides. |
+| [`dashboard.rs`](../apps/bitrouter/src/dashboard.rs) | Local/remote dispatch is repeated in the app driver. Snapshot refresh uses `try_join!` across status/models/requests, so one error prevents the full snapshot from updating. Remote agent lists are empty. |
+| [`actions/mod.rs`](../crates/bitrouter-mcp/src/actions/mod.rs) | Shared CLI/MCP/TUI actions already have IDs, schemas, reach, and effects. `Effect::Write` requires a real inverse; reload does not fit that promise. |
+| [`actions/requests.rs`](../apps/bitrouter/src/actions/requests.rs) | Requests are host-wide, limited to 1–500 rows and today's window. Metering failures become empty/default data, so absence of data and failure are not fully distinguishable. |
+| [`server.rs`](../crates/bitrouter-mcp/src/server.rs) | `local_http_router` mounts the caller-assembled MCP profile at `/mcp-control`. The daemon wires status, models, and route preview into it under control authentication. This is distinct from the crate's restricted cloud HTTP profile. |
+| [`actions/status.rs`](../apps/bitrouter/src/actions/status.rs) | Status includes host-wide spend and the local socket path. REST removes the path; the daemon MCP profile receives the unfiltered status port. Redaction currently depends on transport wiring. |
+| [`main.rs`](../apps/bitrouter/src/main.rs), [`policy_lock.rs`](../apps/bitrouter/src/policy_lock.rs) | CLI policy status/show load files. The running policy runtime has its own snapshot/digest. A file report must not be presented as proof of the live policy. |
+| [`reload.rs`](../apps/bitrouter/src/reload.rs) | Reload has a mutex and prepares policy-runtime state, but swaps policy-table, routing, timeout, and policy-runtime state sequentially, then reloads access policies. Errors can follow successful changes. |
+| [`daemon.rs`](../apps/bitrouter/src/daemon.rs) | Local reload accepts environment overrides and installs them before calling the reloader. This owner-trusted command is not a public remote request type. |
+| [`agents.rs`](../apps/bitrouter/src/agents.rs) | Agent listing is passive, but custom descriptions contain command arguments. Agent checking spawns processes and initializes ACP. |
+
+The [remote-control MVP](REMOTE_CONTROL_MVP_SPEC.md) remains the historical
+baseline. This proposal supersedes its read-only limit only for the explicitly
+authorized reload action. The [remote ACP RFD](REMOTE_CLI_TUI_SUPPORT_SPEC.md)
+remains deferred; its administration exclusions and older command names must
+not be mistaken for this proposal's action matrix.
+
+## 3. Release scope and action matrix
+
+All subjects below are the selected server host. No request selects an arbitrary
+filesystem path, workspace, shell command, environment value, or API principal.
+
+| Canonical action | CLI with `--context <name>` | HTTP under `/control/v1` | Scope | Dashboard |
+| --- | --- | --- | --- | --- |
+| `status` | `status` | `GET /status` | `control:read` | Overview |
+| `list_models` | `models [--provider ...]` | `GET /models` | `control:read` | Models |
+| `providers_list` | `providers list` | `GET /providers` | `control:read` | Provider inventory |
+| `route` | `route <model> [--prompt ...]` | `POST /route/preview` | `control:read` | Route preview |
+| `requests` | `requests [filters]` | `GET /requests` | `control:read` | Requests |
+| `observe_status` | `observe status` | `GET /observe/status` | `control:read` | Telemetry |
+| `policy_status` | `policy status [--view active\|disk]` | `GET /policy/status?view=...` | `control:read` | Policy overview |
+| `policy_show` | `policy show <name> [--view active\|disk]` | `GET /policy/show?name=...&view=...` | `control:read` | Named policy detail |
+| `agents_list` | `agents list` | `GET /agents` | `control:read` | Catalog, without launch controls |
+| `reload` | `reload` | `POST /reload` | `control:reload` | Explicit reload action |
+
+Supporting resources are `GET /capabilities`, `GET /state`, and
+`GET /operations/{request_id}?instance=...`. State requires `control:read`; operation lookup
+requires `control:reload` and ownership by the same credential. Capability
+discovery requires any valid control credential and discloses only its grants.
+
+`status --requests` remains a compatibility form. Remote `policy reload`
+remains unavailable in this release: its current local implementation is a full
+daemon reload, and the remote client should name that operation explicitly.
+`agents list --remote` continues to mean fetching the external ACP registry in
+local CLI usage; reject its combination with a remote context before fetching.
+
+### Explicit exclusions
+
+- Agent sessions, ACP/WebSocket transport, launching/checking/installing agents,
+  native harness UIs, and MCP connection diagnostics.
+- Start, stop, restart, upgrade, and service-manager integration. The control
+  listener dies with the daemon and cannot restart it itself.
+- Config uploads/edits, provider login/logout, key management, environment
+  propagation, arbitrary config reads, and remote credential administration.
+- Policy compile/publish/rollback, eval submission, optimization runs, and
+  changes to policy-lock files. These need artifact lineage and publication
+  contracts beyond reloading an already prepared host configuration.
+- Skills/workspace browsing, arbitrary log tails, request bodies, file sync,
+  durable jobs, Cloud tenancy, and new MCP tools.
+
+The useful first workflow is: prepare host files using the operator's existing
+deployment workflow, inspect disk policy remotely, then explicitly reload them.
+Remote editing is not implied by remote administration.
+
+## 4. Typed actions and target resolution
+
+Create one app-owned `ControlActionSpec` inventory. Each row contains its
+canonical ID, action version, typed input/output schema functions, explicit
+HTTP method/path, scope, CLI binding, and dashboard availability. Existing
+shared actions reference the IDs and schemas in `bitrouter-mcp::actions::ACTIONS`;
+the build/test guard rejects disagreement or dangling references. New actions
+need not acquire an MCP tool solely to enter this inventory.
+
+The inventory replaces the separate remote action-name array and centralizes
+eligibility, discovery, and authorization metadata. Typed handlers and clients
+remain ordinary Rust; do not introduce runtime schema execution, arbitrary
+`execute(command)` RPC, shell forwarding, or generic JSON business logic.
+Resource endpoints have a small explicit route inventory with their own guards.
+
+Resolve the execution target once, before execution config, provider env, DB,
+or filesystem access. The resulting local/HTTP action ports serve both CLI and
+dashboard. Reading the client's context store and its selected control token is
+expected; loading the client's router configuration is not. Validate
+command-specific flag combinations centrally before invoking a port.
+
+Existing MCP-shared contracts stay in `bitrouter-mcp`; new administration-only
+contracts live app-side beside their action ports. Human rendering stays in
+`output/reports`. Do not extract a new crate for this release. The renderer
+continues to contain no network client, daemon IPC, or database access.
+
+Preserve the three existing daemon MCP tools, but inject the same authorized,
+redacted read ports used by HTTP. Control authentication must attach a validated
+control caller; do not interpret `CallerAuth::default()` or a raw supplied bearer
+as a remote scope grant. Keep the separate cloud backend and its profile guards
+unchanged. MCP tool schemas alone do not grant access to an action.
+
+## 5. Authentication and compatibility
+
+Keep loopback binding, HTTPS for non-loopback client URLs, disabled redirects,
+same-origin checks, bearer authentication, and `Cache-Control: no-store`.
+Inference authentication and `server.skip_auth` remain unrelated.
+
+Proposed optional configuration:
+
+```yaml
+control:
+  enabled: true
+  listen: 127.0.0.1:4358
+  credentials:
+    - id: workstation-admin
+      token_env: WORKSTATION_ADMIN_CONTROL_TOKEN
+      scopes: [control:read, control:reload]
+```
+
+When `credentials` is absent or empty, require the existing
+`BITROUTER_CONTROL_TOKEN` and grant it `control:read`. When explicit credentials
+are configured, accept only those entries; the legacy variable is not an extra
+implicit credential. Require `control:read` alongside `control:reload` so an
+administrator can inspect the target before and after a mutation.
+
+Validate unique IDs, distinct token values, valid environment-variable names,
+known scopes, and token length of at least 32 bytes at startup. Store only
+digests in the server auth state, compare without token-dependent early exits,
+and never serialize credential values. Unknown or duplicate configuration is a
+startup error. Token issuance, rotation, and revocation use host-local config/env
+changes plus service restart; no credential database or remote token CRUD here.
+
+`control:read` explicitly grants host-wide operational data, including spend,
+request metadata, and policy rules. It is not a personal usage scope. A narrower
+usage permission can be designed later without pretending the current reports
+are tenant-filtered. Existing reader tokens remain read-only but can access the
+new inspection actions after upgrade; document that scope expansion.
+
+Preserve protocol version 1 and the existing `actions: [string]` field and its
+legacy names (`models`, `route_preview`). Add `action_descriptors` keyed by
+canonical IDs with per-action versions and required scopes, plus
+`server_instance_id`, effective grants, and advertised limits. Generate both
+representations from the one inventory, with explicit legacy-name mappings.
+Existing route paths and report fields retain their meanings.
+
+New clients accept old servers for existing reads, mapping legacy action names.
+They require the new descriptors and state resource before invoking reload.
+Never infer write support from binary version or probe it by sending a mutation.
+Cache discovery for at most 30 seconds in a long-lived dashboard; invalidate on
+instance change or capability errors. Every handler still checks authorization.
+Breaking report semantics require an action-version change and client gating.
+
+## 6. Read reports and disclosure
+
+Use additive fields or explicitly versioned reports, with source and availability
+expressed as data. Existing local CLI defaults and JSON fields remain compatible;
+new `--view` flags opt into the explicit policy views locally. Remote policy
+commands default to `active`; local legacy policy commands without `--view`
+continue to report disk state and identify that source in an additive field.
+The new dashboard always requests an explicit view.
+
+### Policy and runtime state
+
+`active` is read from live runtime snapshots; `disk` parses the server's configured
+files without activating them. Both return named policy IDs, digest, mode,
+bindings, and a typed policy view. Omit raw paths. If no active policy exists,
+report `not_configured`; do not substitute the disk policy. Invalid disk data
+returns safe validation diagnostics while the active view remains available.
+Capture active mode, bindings, and policy detail with the relevant runtime
+snapshot; do not combine a live digest with startup config or freshly read disk
+bindings. An active snapshot may legitimately differ from disk after a failure.
+
+Do not use the existing arbitrary `PolicyReport.policy: Value` serialization as
+an automatic remote allowlist. Define the policy detail fields that operators
+need: tier targets, efforts, variants, route rules, and certificate/evidence
+identifiers. Omit embedded raw evidence, paths, and extension payloads unless
+explicitly included in the versioned schema.
+
+`GET /state` reports the boot instance ID, reload generation, whether a reload
+is running, last reload outcome, and live policy digest if present. A generation
+identifies a reload attempt boundary, not an atomic snapshot of every subsystem.
+Report `mixed` after partial application; do not label the whole router with one
+successful configuration digest. Reads during a reload indicate that they may
+span subsystem versions. Disk reports never change that live-state claim.
+
+### Requests, telemetry, and agents
+
+- Requests add `--since`, `--until` (RFC3339), `--model`, and `--provider` with
+  equivalent query fields. Preserve the existing default of today since UTC
+  midnight, using the server's clock;
+  explicit ranges use absolute instants and include resolved bounds in the
+  report. Maximum explicit window: seven days; maximum rows: 500. Both time
+  bounds are required together with `since < until`, using `[since, until)`.
+  Apply filters before the limit and to spend
+  summaries; label any host-wide rate separately. Return `truncated` when a
+  further row exists. Cursor pagination/export is deferred.
+- Add a metering availability field so a failed store/query cannot look like
+  successfully observed zero usage. Preserve successful fields on partial query
+  failure and label unavailable components. Do not fabricate zero-cost evidence.
+- Telemetry reads the daemon's observation provider. Report compile/wiring
+  state, sampling and counters. Omit the socket; omit raw endpoint strings and
+  header values. A feature-off server reports that state, not a client-side
+  compile-time guess.
+- Provider listing returns IDs, model counts, and activation state from the
+  daemon's accepted config/catalog view. Activation means routing configuration,
+  not a successful connectivity probe. Omit raw API bases and credential details.
+- Agent listing returns IDs, catalog descriptions, and configured flags from the
+  server's accepted config/catalog view. Custom entries use a neutral description, never the
+  configured command/args/env. Do not claim readiness without a check, inspect
+  binaries by running them, or fetch an external registry on this path.
+- Preserve route-preview provenance and current limitations. The live daemon's
+  route-chain answer does not become a full prompt-dependent inference
+  simulation merely because the HTTP input accepts `prompt`.
+
+Apply one remote disclosure policy before REST or MCP rendering: allowlisted
+fields, no credential/env/config dumps, no socket/filesystem paths, and no raw
+upstream error bodies. Request errors become bounded categorized summaries;
+validation errors expose field identifiers and safe codes, not interpolated
+secret-bearing source text. Test malicious token-bearing URLs, command args,
+and upstream errors against this boundary. No general file or log read endpoint.
+
+## 7. Reload contract
+
+### Invocation and admission
+
+`bitrouter --context workstation reload` means: reload the server-owned source
+as it exists when the server prepares the operation. It neither uploads files
+nor forwards the client's environment. It does not claim to apply a previously
+reviewed immutable candidate. Policy publication and a frozen dry-run/apply
+workflow remain deferred.
+
+The client fetches `/state`, generates a UUID request ID, and submits:
+
+```json
+{
+  "request_id": "<uuid>",
+  "expected_server_instance_id": "<boot-id>",
+  "expected_generation": 12
+}
+```
+
+Accept no additional fields. Under the daemon's reload coordinator: authenticate,
+resolve any existing request ID, verify instance/generation, reserve bounded
+operation capacity, and accept the operation. Return `202` with an operation
+report and relative same-origin lookup URL. A repeated identical request from
+the same credential returns the existing operation without another reload;
+reuse with different input returns `409 idempotency_conflict`.
+
+An instance mismatch or stale generation returns `409` without mutation.
+Concurrent reload admission returns `409 reload_in_progress`; do not queue
+unbounded work or silently refresh the generation and retry. These checks fence
+other reloads, not edits made to disk by external tools.
+
+### Execution and actual consistency guarantee
+
+Move all reload entry points—remote HTTP, local IPC, policy reload, and SIGHUP—
+through the same coordinator. Environment overrides from local IPC must be
+serialized inside it, not installed before taking the reload lock. Preserve the
+local feature, but exclude that input from remote requests.
+
+Prepare and validate the candidate and its policy inputs before any live swap.
+Capture the inputs used during preparation; subsequent stages must consume the
+prepared objects rather than silently re-read changed files. Provider discovery
+may contact configured upstreams and must have bounded timeouts. No client can
+supply an upstream address through this action.
+
+Classify changed config fields explicitly as reloadable or restart-required.
+Listener/auth/control credentials, database connection configuration, process
+wiring, and other startup-only settings are restart-required. Reject such a
+candidate before mutation and return safe field names. Unknown changed fields
+default to restart-required until their live consumer is inventoried. The
+implementation must pin this classification to actual startup/reload consumers.
+
+The coordinator covers preparation, mutation, result recording, and generation
+advancement. Advance the generation once for every accepted terminal attempt,
+including failed attempts; leave it unchanged for admission rejections.
+
+Do not promise cross-subsystem atomicity. Return a result for each of the actual
+reload participants: routing table, upstream timeout clients, policy table,
+named policy runtime, and access-policy store. Each reports `applied`,
+`unchanged`, `failed`, or `not_attempted`. Overall terminal state is:
+
+- `succeeded`: all intended participants completed successfully.
+- `failed`: preparation failed or failure occurred with no live change.
+- `partially_applied`: at least one live change occurred and completion failed.
+
+Audit each underlying mutator's own failure behavior; an `Err` after an internal
+change must not be mislabeled as no change. Refactor it to report the change or
+prepare it safely. In-flight inference is not drained; requests may observe
+different subsystem versions during application. Do not automatically roll back
+or retry a partially applied reload. The report identifies what changed and
+what the operator must inspect before another explicit attempt.
+
+### Disconnects, limits, and operation lookup
+
+An admitted reload is owned by the daemon and continues when HTTP disconnects.
+CLI/dashboard poll its operation, not repeat the POST with a new ID. Default
+client wait is 30 seconds; on expiry emit `running` plus the request/instance IDs
+and exit nonzero. A proposed recovery command is:
+
+```console
+bitrouter --context workstation operations show <request-id> --instance <boot-id>
+```
+
+This resource command requires an explicit remote context and queries the
+operation resource with the supplied instance ID. Register its CLI mapping in
+the resource inventory; it never performs the write again. Context metadata
+commands remain client-local.
+
+Keep results in bounded memory for the current boot: at most 1,024 admitted
+remote operations, retained for at least 24 hours after completion. Do not evict
+unexpired entries to admit a mutation; return `503 operation_capacity` before
+starting work. Advertise limits and timestamps. Clients must not replay a POST
+after the reported retention deadline or against another boot instance.
+
+Daemon restart loses operation results. A boot mismatch or expired/unknown ID
+returns an explicit unknown-outcome error; it is never evidence that a reload
+did not occur. The operator inspects live state before issuing a new operation.
+Do not advertise durable jobs or exactly-once execution across process restarts.
+
+The HTTP request timeout is not an execution cancellation deadline. Bound
+preparation/network waits; avoid interrupting a live commit midway to satisfy a
+transport timeout. Fatal daemon failure leaves an unknown outcome. No operation
+cancellation endpoint in this release.
+
+Record structured operational audit events for admission and outcome with
+credential ID, action, request/instance IDs, generation, safe subsystem results,
+and duration. Log rejected attempts without credentials or raw request bodies.
+These events use the existing logging infrastructure; they are not a durable
+operation database or compliance-grade audit ledger.
+
+## 8. Error and client behavior
+
+Keep the existing `{ "error": { "code", "message" } }` envelope; add safe
+structured details only where defined. Use `401 unauthorized`, `403 scope_denied`,
+`400 invalid_request`, `404 unsupported_action` / `operation_not_found`,
+`409 stale_generation` / `server_instance_changed` / `reload_in_progress` /
+`idempotency_conflict`, `410 operation_expired` when known, and
+`503 operation_capacity`. Unknown operation IDs do not reveal another caller's
+activity. Partial application is a terminal operation report, not a generic
+HTTP 500 that invites retry.
+
+New JSON inputs reject unknown fields, unsupported content types, and bodies
+over 16 KiB; retain the existing route-preview input limit separately. Limit
+operator-supplied identifiers to 256 bytes and reject invalid filter values
+before querying storage. Enforce bounded report sizes and publish limits in
+capabilities; never silently truncate a policy into a misleading valid report.
+
+CLI output remains JSON by default with the existing human rendering mode. Any
+failed/partial/unknown reload outcome exits nonzero. An explicit CLI reload
+command authorizes the mutation; do not add an interactive prompt that breaks
+automation. The dashboard presents host identity and reload scope before the
+user activates its explicit reload control, then shows operation progress and
+results. It must never launch a mutation from a refresh timer.
+
+Refresh dashboard panels independently. Preserve the last successful data with
+its timestamp and mark it stale after an error; distinguish unavailable,
+unauthorized, failed, and loading states. A server lacking requests or telemetry
+must still provide useful overview/models panels. Disable unsupported writes
+with an explanation. Network/auth errors never become local data or a false
+claim that the remote daemon is stopped.
+
+## 9. Implementation sequence and ownership
+
+| Phase | Deliverable | Exit condition |
+| --- | --- | --- |
+| A: contract and parity foundation | App-owned remote inventory, typed target ports, additive discovery, shared remote disclosure, independent panel refresh. | Existing remote commands/MCP reports remain compatible; socket/error disclosure and capability mismatch cases have regression coverage. |
+| B: administration reads | Providers, telemetry, active/disk policy reports, passive agents, bounded request filters; CLI and dashboard consumers. | Same target/input/authority yields matching typed data; disk/live divergence and unavailable metering are visible. |
+| C: reload ownership | Unified reload coordinator, input preparation, field classification, truthful participant results, boot/generation state. | Local IPC/SIGHUP concurrency and partial failure tests pass before enabling remote writes. |
+| D: authorized remote reload | Named scoped credentials, reload endpoint, bounded operation retention/lookup, CLI and dashboard progress/recovery. | Disconnects and repeated requests cannot initiate a second attempt within the advertised window; no implicit write upgrade. |
+| E: release acceptance | Real HTTP and isolated Docker client/server tests, CLI/skill/config docs, packaging checks. | The full read-and-reload workflow passes; exclusions remain rejected before side effects. |
+
+Expected ownership:
+
+- Split `remote_control.rs` into a `remote_control/` module as needed for
+  contracts, inventory, authentication, HTTP server/client, and operation state;
+  keep public module paths explicit and do not add re-exports.
+- Keep new action implementations beside `apps/bitrouter/src/actions/` and
+  renderers in `output/reports/`. Add only the ports needed by these consumers.
+- `reload.rs` owns coordinated reload semantics; `daemon.rs` adapts local IPC.
+  The composition root injects live policy/observation/reload ports into the
+  control listener instead of treating local IPC as a remotely serializable API.
+- `main.rs` handles command parsing and output; `dashboard.rs` handles effects;
+  `bitrouter-tui` renders supplied state. Config schema changes belong in the SDK,
+  but operator authorization and lifecycle logic remain app-owned.
+- Update `docs/CLI.md` and `skills/bitrouter/` in each implementation change
+  introducing flags/config/env behavior. Check agent-plugin manifests if their
+  CLI wiring changes. Coordinate published prose separately in `bitrouter-docs`.
+
+## 10. Verification and acceptance
+
+Required automated coverage:
+
+1. Inventory guards join canonical IDs/schemas, HTTP routes, required scopes,
+   supported CLI leaves, and dashboard availability. Existing MCP/cloud profile
+   guards stay intact. Legacy capability names are deliberate mappings.
+2. Real HTTP tests cover missing/wrong/read-only/admin tokens; redirects and
+   origin rejection; unsupported actions; old/new client-server combinations;
+   bounds/content types; and secrets in every report/error channel.
+3. Remote target tests arrange tempting local config, metering, sockets, and
+   provider env, then prove denied/failed remote commands never consult them or
+   perform local effects. Remote operation lookup is tested separately from
+   client-local context metadata management.
+4. Read tests exercise active/disk policy disagreement, invalid disk policy,
+   unconfigured runtime, feature-off telemetry, filtered/truncated requests,
+   missing versus empty metering, and custom agent command redaction.
+5. Reload fault injection covers each participant before and after a live
+   change; mixed state is reported correctly. Restart-only changes fail before
+   mutation. Local overrides cannot race remote preparation.
+6. Reload admission tests race HTTP, IPC, and SIGHUP; verify generation checks,
+   same-ID deduplication, different-body conflict, capacity exhaustion, owner
+   isolation, disconnect-after-admission, deadline expiry, and boot changes.
+   Unknown outcomes must never cause an automatic fresh mutation.
+7. Dashboard tests cover independent panel errors, stale-data labels, scope
+   changes, unsupported features, explicit reload initiation, and partial results.
+
+The maintainer selected Docker for network-boundary acceptance on 2026-09-08.
+Use separate client and server containers: the client has no server configuration
+or provider credentials, and the server exposes its loopback control listener
+through a TLS proxy. This replaces the original physical two-machine test
+environment, not the action, authorization, or failure requirements; record it
+as container acceptance rather than physical-host deployment verification. Verify
+every advertised read, stage a host-side policy change and observe disk/live
+divergence, reload with write authority, and verify the live policy afterward.
+Drop the client connection after admission and recover the same operation.
+Inject a partial reload failure and verify that both clients show it accurately.
+Repeat with the legacy read token and prove reload is rejected. Restart the host
+and verify that old operation IDs produce an unknown outcome, not a retry.
+
+Before code submission run the repository-required all-feature tests, clippy,
+and formatting checks; run distribution checks when schemas or shipped skills
+change. A documentation-only proposal needs link/diff review, not a Rust build.
+Keep test evidence separate from this proposal's planned acceptance criteria.

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -155,29 +155,16 @@ and the rollup reads `unreported` rather than `$0.00` when none does. Canonical
 ids use slashes and a pin uses a colon (`openrouter:openai/gpt-4o`);
 `references/diagnose.md` has the full spelling rules.
 
-For read-only control from another computer, add a named context and select it
-explicitly:
-
-```bash
-bitrouter context add workstation \
-  --endpoint https://router.example/control/v1 \
-  --token-env WORKSTATION_BITROUTER_TOKEN
-bitrouter --context workstation status
-bitrouter --context workstation requests
-bitrouter --context workstation models
-bitrouter --context workstation route openai/gpt-5
-bitrouter --context workstation code
-```
-
-The context stores only the environment-variable name. Remote errors never
-fall back to this machine. The HTTP-only MVP supports those reads; agent
-sessions and lifecycle commands remain local (use SSH for a remote native TUI).
+For administration from another computer, use a named `--context`; see
+`references/remote-administration.md` for token scopes, tunnel setup, and host
+boundaries. Remote errors never fall back to this machine's configuration.
 
 ## References — read on demand, not upfront
 
 | File | When to read |
 |---|---|
 | `references/cli.md` | Full subcommand reference — the primary reference |
+| `references/remote-administration.md` | Remote contexts, operator credentials, and host boundaries |
 | `references/providers.md` | Add / configure providers, multi-account, custom endpoints, model-id spelling |
 | `references/cloud-setup.md` | Cloud signup, key mint, billing, wallet path |
 | `references/diagnose.md` | Install issues, daemon won't start, connection refused, model ids |
@@ -194,11 +181,11 @@ sessions and lifecycle commands remain local (use SSH for a remote native TUI).
 - **Hosted sign-in is `cloud login` or `providers login bitrouter`** (same flow),
   everything else `providers login <id>`; there is no top-level `login`.
 - **Remote control is separate from inference and ACP.** `control.enabled: true`
-  starts a read-only API on `127.0.0.1:4358` and requires a dedicated
-  `BITROUTER_CONTROL_TOKEN` of at least 32 bytes. Keep it loopback-only behind a
+  starts a control API on `127.0.0.1:4358` with dedicated operator credentials
+  (legacy `BITROUTER_CONTROL_TOKEN` grants reads only). Keep it loopback-only behind a
   private tunnel or TLS reverse proxy. `server.skip_auth` never disables this
   authentication, changes under `control:` require a daemon restart, and the
-  HTTP-only MVP does not run remote ACP sessions.
+  control API does not run remote ACP sessions.
 - **`init --harness` only accepts `claude` and `codex`**; `launch <agent>`
   accepts the native facets listed by `launch --help`.
 - **`providers add/remove/use/test/stats` and `bitrouter doctor` do not exist.**

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -16,27 +16,33 @@ the ACP registry; the headless `--harness` aliases remain `codex` and `claude`.
 
 
 
-Global `--context NAME` selects a named remote-control target for the read-only
-`status` (including `--requests`), `models`, and `route` commands; `local`
-forces normal local behavior.
+Global `--context NAME` selects a named remote-control target for `status`
+(including `--requests`), `requests`, `models`, `route`, `providers list`,
+`observe status`, `policy status|show`, `agents list`, and the `code`
+operations dashboard; `local` forces normal local behavior. `reload` is the
+one remote mutation, and `operations show <request-id> --instance <boot-id>`
+looks up its retained receipt.
 Manage targets with `bitrouter context add NAME --endpoint URL --token-env
 ENV`, `context list`, `context show NAME`, and `context remove NAME`. The store
 contains the token environment-variable name, never its value. HTTPS is
 required except for loopback/SSH-forwarded HTTP. The client handshakes first,
 follows no redirects, never falls back to local state on a remote error, and
-rejects every lifecycle/ACP/agent command under a remote context.
+rejects local `--config`/`--socket` before reading local config, environment, or
+metering data. Remote `agents list` is catalog-only: external-registry fetches,
+checks, launches, and ACP sessions remain local. Remote policy defaults to
+`--view active`; local policy defaults to `--view disk`.
 
 ## Daemon lifecycle
 
 | Command | Effect |
 |---|---|
-| `bitrouter serve [--config PATH]` | Run the inference HTTP server + local control socket **in the foreground**. Optional `control.enabled: true` also starts the authenticated HTTP control listener at `control.listen` (default `127.0.0.1:4358`), including Streamable HTTP MCP at `/mcp-control`. It requires a dedicated `BITROUTER_CONTROL_TOKEN` of at least 32 bytes, validates browser origins, stays loopback-only for a private tunnel/TLS reverse proxy, and ignores inference `server.skip_auth`. It does not expose ACP sessions. |
+| `bitrouter serve [--config PATH]` | Run the inference HTTP server + local control socket **in the foreground**. Optional `control.enabled: true` also starts the authenticated HTTP control listener at `control.listen` (default `127.0.0.1:4358`), including Streamable HTTP MCP at `/mcp-control`. `control.credentials` may name `{id, token_env, scopes}` credentials using `control:read` and `control:reload`; absent/empty credentials preserve `BITROUTER_CONTROL_TOKEN` as read-only. Explicit credentials exclude that legacy token. Tokens are at least 32 bytes, browser origins are checked, the listener stays loopback-only for a private tunnel/TLS reverse proxy, and inference `server.skip_auth` does not affect it. It does not expose ACP sessions. |
 | `bitrouter start [--config PATH] [--log PATH]` | Spawn `serve` as a detached background process. Stdout/stderr go to `~/.bitrouter/bitrouter.log` unless `--log` overrides. Refuses to start over a live daemon. |
 | `bitrouter stop [--config PATH] [--socket PATH]` | Graceful shutdown via the control socket. |
 | `bitrouter restart [--config PATH] [--log PATH] [--socket PATH]` | Stop, wait up to 30s for in-flight requests to drain, then start. Escalates to SIGKILL on timeout. |
-| `bitrouter reload [--config PATH] [--socket PATH]` | Hot-reload the running daemon's config + routing table. **Also re-pushes provider env vars** from the current shell into the daemon, so `export OPENAI_API_KEY=new...; bitrouter reload` rotates the key without a restart. SIGHUP reloads daemon-side config but cannot forward newly exported shell variables. |
+| `bitrouter reload [--config PATH] [--socket PATH]` | Hot-reload the running daemon's config + routing table. **Also re-pushes provider env vars** from the current shell into the daemon, so `export OPENAI_API_KEY=new...; bitrouter reload` rotates the key without a restart. `bitrouter --context NAME reload` instead reloads server-owned files without client env forwarding; non-success, running, partial, or unknown results exit non-zero and include a retained operation lookup. SIGHUP reloads daemon-side config but cannot forward newly exported shell variables. |
 | `bitrouter status [--config PATH] [--socket PATH]` | `systemctl status`-style block: pid / listen / model count / the distinct providers behind them / socket, plus `spend`. Reports `stopped` (exit 0) when no daemon is reachable — and still reports spend, which is on disk and outlives the daemon. Same report type as the origin MCP server's `status` tool, so `--json` here and that tool's structured content are the same bytes. **`spend` is two independent facts**: `spend.spent` (money already gone — `estimated_micro_usd` over `window`, `requests`, `unpriced`) comes from the local metering database on *any* deployment; `spend.limit` (money left — `balance_micro_usd`, `pending_micro_usd`, `remaining_micro_usd`) appears only where a cap exists, today a metered cloud account's prepaid credit. `spent` is an **estimate and a floor**: requests with no charge evidence are excluded rather than summed as zero, and `unpriced` counts them — non-zero means the figure understates by an unknown amount, so never read it as a total. A `limit` is the opposite, an authoritative ledger. No `spend` key at all means no metering database was readable, which is *not* the same as `estimated_micro_usd: 0`. Machine-wide, not per-caller. |
-| `bitrouter requests [--limit N]` | Newest-first settled requests (time, model, provider actually used, tokens, cost, latency, status) + the window's spend and trailing-minute rate. **JSON by default**; `--human` renders the table. Reads the metering store directly and works with no daemon (`mode: history_only`). Portable to named remote contexts. `status --requests` is a hidden compatibility spelling. |
+| `bitrouter requests [--limit N] [--since RFC3339 --until RFC3339] [--model ID] [--provider ID]` | Newest-first settled requests (time, model, provider actually used, tokens, cost, latency, status) + the filtered-window spend and host-wide trailing-minute rate. **JSON by default**; `--human` renders the table. The time pair is required together and spans at most seven days; `limit` is 1–500. Reads the metering store directly and works with no daemon (`mode: history_only`). Portable to named remote contexts. `status --requests` is a hidden compatibility spelling. |
 
 ## Inspection
 
@@ -44,15 +50,15 @@ rejects every lifecycle/ACP/agent command under a remote context.
 |---|---|
 | `bitrouter route <model> [--prompt TEXT] [--config PATH]` | Resolve a model name through the routing table. Tries the running daemon first (live table; its `route` verb resolves the model as given — the daemon's policy table runs on real requests, not on this preview), falls back to standalone config resolution — **policy table included**, so the answer there is what would actually run. `--prompt` supplies the request text the policy table keys on (it routes by agent-loop step, so the selected model can differ with the prompt); config path only. JSON keys: `requested_model` (what you asked for) and `effective_model` (what would run — **read this one**; equals `requested_model` on `live`), `effective_effort`, `resolved_via` (`live` \| `config` \| `zero_config` — the same words `bitrouter models` uses), `policy_decision` (absent on `live`: the daemon's `route` verb does not replay policy), `provider_chain[]` of `{provider, service_id, api_protocol}`, and `estimated_cost` (the first hop's per-token rates plus any steeper long-context brackets — rates, not a total). Same report type as the MCP `route_preview` tool. Read-only: nothing is sent upstream, and no credential is surfaced. |
 | `bitrouter models [--config PATH] [--provider ID]` | List every routable model selector, each with **all** the providers that can serve it (the fallback chain, in order). Subscription providers are explicit-route-only and therefore appear as pinned `provider:canonical-model` selectors; every displayed selector can be passed unchanged to `bitrouter route`. Tries the running daemon first, falls back to a standalone config parse — same order as `bitrouter route`. The parse is resolved the way the daemon resolves its own config at start-up (built-in defaults, then subscription providers such as `claude-code` / `google-ai` re-activated from the OAuth credential store), so a subscription-backed provider is listed with no daemon running; the live table additionally reflects `reload`s and whatever the daemon resolved at start-up. `--json` reports `resolved_via: "live" \| "config"`. Filter with `--provider`. Same report type as the MCP `list_models` tool. |
-| `bitrouter providers list [--config PATH]` | Tab-aligned: `ID  MODELS  ACTIVE  API_BASE`. |
+| `bitrouter providers list [--config PATH] [--socket PATH]` | Local compatibility output retains `ID  MODELS  ACTIVE  API_BASE`; a named remote context and the dashboard use the redacted accepted catalog without API bases or credentials. Active means configured for routing rather than connectivity-probed. |
 | `bitrouter mcp serve` | Run BitRouter's local origin MCP server over protocol-pure stdio for a host or plugin. Network-capable hosts connect directly to the daemon's authenticated `/mcp-control` Streamable HTTP endpoint. The old standalone HTTP/cloud flags are hidden compatibility inputs and no longer start a second listener. |
 | `bitrouter mcp check [server] [--config PATH]` | Connect to one configured upstream MCP server, or all of them, and report transport, reachability, latency, negotiated tools capability, and advertised tool names. |
-| `bitrouter agents list [--remote] [--config PATH]` | Show bundled ACP catalog + which are configured. `--remote` also fetches the official ACP agent registry (cdn.agentclientprotocol.com) and lists its agents with version + install support (`npx`/`uvx` stub-able; `manual` for binary-only). |
+| `bitrouter agents list [--remote] [--config PATH] [--socket PATH]` | Show the accepted ACP catalog + which are configured. A named BitRouter context exposes this catalog only. Local `--remote` also fetches the official ACP agent registry (cdn.agentclientprotocol.com) and lists its agents with version + install support (`npx`/`uvx` stub-able; `manual` for binary-only). |
 | `bitrouter agents inspect <agent> [--config PATH]` | Open a fresh ACP session, wait briefly for advertised slash commands, and report which source answers each command. |
 | `bitrouter agents check [agent] [--config PATH]` | Preflight one friendly/catalog agent or spawn each configured ACP agent and verify `initialize`. |
 | `bitrouter agents conformance <id>` | Run the `acp_compat_1` ACP-compatibility suite against a catalog agent and print the `conformance:` block to record in `registry/runtimes/<runtime>.yaml`. `<id>` is `<runtime>/<harness>` or a bare harness id (`local/` is the default runtime and may be elided). Two tiers: **handshake** (the agent answers `initialize` and settles on the ACP version its registry entry declares) and **routability** (the agent's LLM traffic reaches BitRouter when its routing block is applied). Needs **no provider credentials** — the agent is launched with its own routing pointed at an ephemeral loopback gateway that records what arrived; it does spawn the agent, so the package or binary must be installed. Exits non-zero when a tier fails, and prints no record in that case. |
 | `bitrouter agents scaffold <id>` | Print a paste-ready YAML stub for `<id>` — resolved from the bundled catalog first, then the ACP registry (`npx`/`uvx` distributions, version-pinned, `env` included). `agents install` is a hidden compatibility spelling. |
-| `bitrouter observe status [--json] [--config PATH] [--socket PATH]` | OTel exporter snapshot: wired / endpoint / sampler / cardinality usage / in-flight spans. JSON output for tooling. |
+| `bitrouter observe status [--json] [--config PATH] [--socket PATH]` | OTel exporter snapshot: compiled/wired state, sampler, metric/cardinality counters, and in-flight spans. Local compatibility output retains socket, endpoint, and service fields; named remote contexts and the dashboard use the redacted report, which omits those host details and header values. |
 
 ## Durable trajectory operations
 
@@ -204,9 +210,12 @@ See `references/sessions.md` for the controller/native-session boundary and what
 ## Interactive interface (`bitrouter code`)
 
 Bare `bitrouter code` opens the full-screen unified shell on Home with Agents,
-Conversation, Sessions, Models, Requests, and Route views. It refreshes read
-views every two seconds. `bitrouter code <agent>` enters Conversation in that
-same alternate-screen app, backed by the same ACP session host as `run`.
+Conversation, Sessions, Models, Requests, Route, Providers, Telemetry, Policy,
+and Reload views. Each read panel refreshes independently every two seconds and
+keeps its last successful data and its own stale/error time. `bitrouter code
+<agent>` enters Conversation in that same alternate-screen app, backed by the
+same ACP session host as `run`. Under `--context`, the Agents view is catalog
+only and has no launch controls.
 
 | Command | What it does |
 |---|---|
@@ -227,6 +236,7 @@ normal terminal state is restored when the shell exits or unwinds.
 | `Esc` | Deny the open permission request |
 | `Ctrl-C` | Cancel a running turn; otherwise exit |
 | `Ctrl-D` | Exit from Conversation |
+| `Enter` or `Ctrl-R` on Reload | Explicitly submit a reload; ordinary timer refreshes never reload. The view keeps the request id, server instance, status, and lookup after an interrupted response. |
 
 Cancelling a turn with a permission outstanding **denies it** — a cancel is never read as consent.
 
@@ -244,8 +254,9 @@ snapshot; BitRouter owns no transcript store or second session catalog.
 | `bitrouter skills init <NAME> [--output PATH] [--json\|--human]` | Scaffold a spec-valid skill directory — writes `<NAME>/SKILL.md` unless `--output` names a path. `<NAME>` is written into the generated frontmatter. |
 | `bitrouter policy create <id> [--dir DIR]` | Write a starter access-control policy file under `--dir` (default `./policies`). Bind to a key with `bitrouter key sign --user <id> --policy <id>`. |
 | `bitrouter policy init <name> --preset <preset> --economy <model> [--economy-effort <level>] [--strong <model>] [--strong-effort <level>] [--config PATH]` | Create or extend deterministic `policy-lock.yaml`, bind the named policy to a preset, and set the process configuration to `policy.mode: adaptive`. Model-only targets retain scalar compatibility; an explicit supported effort makes `(model, effort)` the target identity, so the same model can occupy strong and economy at different levels. The strong model is inferred from an existing preset when omitted; `--strong-effort` therefore requires explicit `--strong`. Presets use `@preset[:variant]`; `templates/auto-router` binds the `auto` preset, published as `bitrouter/auto` and `bitrouter/auto:cost`. |
-| `bitrouter policy check|status [--config PATH]` | Cross-validate the main config and lock, or report the resolved path, semantic digest, runtime mode, policies, and preset bindings. |
-| `bitrouter policy show <name> [--config PATH]` | Print one validated effective policy. |
+| `bitrouter policy check [--config PATH]` | Cross-validate the local main config and lock. |
+| `bitrouter policy status [--view active\|disk] [--config PATH] [--socket PATH]` | Report an explicit policy source, digest, mode, policies, and preset bindings. Local default is `disk`; named remote context default is `active`. |
+| `bitrouter policy show <name> [--view active\|disk] [--config PATH] [--socket PATH]` | Print one named policy from the explicit source; the same local/remote defaults apply. |
 | `bitrouter policy compile --output FILE [--eval-snapshot SHA256] [--snapshot-time UNIX_MS] [--config PATH]` | Compile legacy migration evidence and an optional frozen generic-eval snapshot into a deterministic v3 candidate. Never changes the active lock. |
 | `bitrouter policy diff <ACTIVE> <CANDIDATE>` | Compare explicit route selections. |
 | `bitrouter policy publish <CANDIDATE> [--config PATH] [--socket PATH]` | Publish that exact compiled v3 candidate under adaptive mode using its parent digest as a compare-and-swap token. |

--- a/skills/bitrouter/references/remote-administration.md
+++ b/skills/bitrouter/references/remote-administration.md
@@ -1,0 +1,107 @@
+# Remote router administration
+
+Use `--context NAME` to select the router host before choosing an action.
+Inference endpoints (`--base-url`) do not select a control host or move agents.
+The client needs only a named endpoint and its control-token environment variable.
+Provider credentials, router config, and metering stay on the server.
+
+## Host credentials
+
+Keep the listener on loopback behind an existing private tunnel or TLS proxy:
+
+```yaml
+control:
+  enabled: true
+  listen: 127.0.0.1:4358
+  credentials:
+    - id: observer
+      token_env: ROUTER_OBSERVER_TOKEN
+      scopes: [control:read]
+    - id: operator
+      token_env: ROUTER_OPERATOR_TOKEN
+      scopes: [control:read, control:reload]
+```
+
+Set distinct bearer tokens of at least 32 bytes in the host environment before
+starting the service. Config stores variable names, never token values. Changing
+control credentials or listener configuration requires a daemon restart.
+
+With no explicit credentials, `BITROUTER_CONTROL_TOKEN` remains the required
+legacy credential and receives only `control:read`. With explicit entries,
+only those entries authenticate; the legacy variable is not an extra credential.
+Read authority includes host-wide spend, request metadata, and policy rules.
+It is not a personal usage scope. Inference `server.skip_auth` has no effect.
+
+## Client context
+
+Set the selected token in the client's environment, then save its variable name:
+
+```console
+bitrouter context add workstation \
+  --endpoint https://router.example/control/v1 \
+  --token-env WORKSTATION_CONTROL_TOKEN
+bitrouter --context workstation status
+bitrouter --context workstation models
+bitrouter --context workstation code
+```
+
+Plain HTTP is accepted only for a loopback URL, such as an SSH port-forward.
+Redirects are rejected. Do not combine a remote context with local `--config`
+or `--socket`. Authentication, capability, and transport errors never fall back
+to the client's router configuration or database.
+
+Capabilities determine what the selected server can answer. Older servers can
+still provide their existing reads; upgrading a client does not enable actions
+the server does not advertise. Remote ACP and native harness execution remain
+unavailable. Agent checks, MCP diagnostics, login, config editing, and service
+start/stop/restart continue to require host-local execution.
+
+## Inspect the host
+
+```console
+bitrouter --context workstation providers list
+bitrouter --context workstation observe status
+bitrouter --context workstation agents list
+bitrouter --context workstation policy status
+bitrouter --context workstation policy show production --view active
+bitrouter --context workstation policy status --view disk
+bitrouter --context workstation requests --limit 50 --provider openai \
+  --since 2026-09-07T00:00:00Z --until 2026-09-08T00:00:00Z
+```
+
+Remote policy reads default to `active`; local policy reads retain their disk
+view unless `--view active` is explicit. The disk view shows host files waiting
+to be applied. Agent listing is passive and never starts an agent. Remote
+`agents list --remote` is rejected because that flag selects an external registry.
+
+Request intervals require both RFC3339 bounds, span at most seven days, and use
+an inclusive start and exclusive end. Limits are 1–500 rows. Summary filters
+apply before the row limit; `truncated` describes omitted matching rows. Metering
+availability distinguishes missing storage from an available empty report.
+Rate counters remain host-wide and report that scope explicitly.
+
+## Reload and recover
+
+Prepare configuration using the host's existing deployment workflow, inspect
+its disk policy, then use a credential with `control:reload`:
+
+```console
+bitrouter --context workstation reload
+bitrouter --context workstation operations show REQUEST_UUID --instance BOOT_UUID
+```
+
+Reload reads only server-owned files and does not forward client environment
+values. Preparation has a 60-second deadline; a live commit is never interrupted
+to meet a client timeout. Listener, credentials, and other startup-only changes return explicit
+restart-required fields before applying any change. Each result identifies the
+participants that applied, failed, remained unchanged, or were not attempted.
+A partially applied result is not a rollback; inspect the active policy and
+runtime state before deciding the next host-side change.
+
+The client submits one operation and waits up to 30 seconds for its result. If
+it reports `running` or loses the connection, retain the request and boot IDs
+and query `operations show`; never blindly issue another reload. The daemon
+continues an admitted operation after HTTP disconnect. Lookup requires the same
+credential, and results remain in memory for at least 24 hours after completion,
+with a maximum of 1,024 retained operations. A restart or expired/missing result
+means the outcome is unknown, not that the earlier reload did not happen.

--- a/tests/remote-administration/Dockerfile
+++ b/tests/remote-administration/Dockerfile
@@ -1,0 +1,59 @@
+# Container acceptance image for docs/REMOTE_ADMINISTRATION_SPEC.md.
+#
+# The image deliberately contains the server binary and only generic client
+# tooling. Each run mounts server state into the server container and gives the
+# client an empty home, so no host configuration or provider credential crosses
+# the network-boundary test.
+FROM rust:1.93-bookworm AS build
+
+WORKDIR /src
+COPY . .
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends python3 \
+    && rm -rf /var/lib/apt/lists/*
+ENV CARGO_INCREMENTAL=false \
+    CARGO_PROFILE_DEV_DEBUG=0
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/src/target \
+    cargo build --locked --package bitrouter \
+    && install -D -m 0755 /src/target/debug/bitrouter /out/bitrouter \
+    && /bin/bash -o pipefail -c 'cargo test --locked --package bitrouter --lib --no-run --message-format=json | python3 tests/remote-administration/select-test-binary.py /out/bitrouter-lib-tests'
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        jq \
+        openssl \
+        python3 \
+        socat \
+    && rm -rf /var/lib/apt/lists/*
+RUN install -d -m 0755 /tls
+
+COPY --from=build /out/bitrouter /usr/local/bin/bitrouter
+COPY --from=build /out/bitrouter-lib-tests /usr/local/bin/bitrouter-lib-tests
+COPY tests/remote-administration/mock-openai.py /usr/local/libexec/mock-openai.py
+COPY tests/remote-administration/server-entrypoint.sh /usr/local/bin/remote-admin-server
+COPY tests/remote-administration/tls-proxy-entrypoint.sh /usr/local/bin/remote-admin-tls-proxy
+COPY tests/remote-administration/client-entrypoint.sh /usr/local/bin/remote-admin-client
+COPY tests/remote-administration/pty-entrypoint.sh /usr/local/bin/remote-admin-pty
+COPY tests/remote-administration/client-checks.sh /usr/local/bin/remote-admin-checks
+COPY tests/remote-administration/disconnect-submit.py /usr/local/libexec/disconnect-submit.py
+COPY tests/remote-administration/mcp-check.py /usr/local/libexec/mcp-check.py
+COPY tests/remote-administration/target-isolation.py /usr/local/libexec/target-isolation.py
+COPY tests/remote-administration/pty-check.py /usr/local/libexec/pty-check.py
+
+RUN chmod 0755 \
+        /usr/local/bin/remote-admin-server \
+        /usr/local/bin/remote-admin-tls-proxy \
+        /usr/local/bin/remote-admin-client \
+        /usr/local/bin/remote-admin-pty \
+        /usr/local/bin/remote-admin-checks \
+        /usr/local/libexec/mock-openai.py \
+        /usr/local/libexec/disconnect-submit.py
+
+CMD ["bash"]

--- a/tests/remote-administration/Dockerfile.dockerignore
+++ b/tests/remote-administration/Dockerfile.dockerignore
@@ -1,0 +1,19 @@
+# Keep Docker's build context free of local work products and credentials.
+.git
+.git/**
+target
+target/**
+**/target
+**/target/**
+.env
+.env.*
+**/.env
+**/.env.*
+.credentials
+.credentials/**
+**/.credentials
+**/.credentials/**
+*.pem
+*.key
+*.p12
+*.pfx

--- a/tests/remote-administration/README.md
+++ b/tests/remote-administration/README.md
@@ -1,0 +1,78 @@
+# Remote-administration container acceptance
+
+Run this from the repository root on a Linux/ARM64-capable Docker daemon:
+
+```console
+tests/remote-administration/run.sh
+```
+
+The default command is the complete acceptance gate. It includes a TLS MCP
+client that initializes `/mcp-control`, obtains the runtime `tools/list`
+inventory, and calls every discovered control tool with semantic assertions.
+At the current workspace state, that default command correctly fails at MCP
+initialization: the server rejects the sidecar's `Host: server:8443` header
+with HTTP 403 before JSON-RPC begins. This is a live deployment finding, so the
+MCP inventory and calls are not claimed as passed.
+
+For diagnostics after that known MCP failure, the following selector runs the
+independent CLI, HTTP, reload, and dashboard journeys:
+
+```console
+BITROUTER_REMOTE_ADMIN_SKIP_MCP=1 tests/remote-administration/run.sh
+```
+
+It prints `selected CLI/dashboard acceptance passed (MCP skipped)` on success.
+It is not a substitute for the default acceptance gate.
+
+The script builds `bitrouter-remote-administration:local` from the current
+workspace unless `BITROUTER_REMOTE_ADMIN_SKIP_BUILD=1` is set. It removes every
+container, network, certificate, and server-state directory it creates.
+
+The topology deliberately has three network roles:
+
+- The server container owns `bitrouter.yaml`, its policy lock, metering data,
+  and a synthetic upstream credential. Its control API binds only to
+  `127.0.0.1:4358`.
+- A TLS-proxy sidecar shares the server network namespace and forwards TLS on
+  `server:8443` to that loopback listener. The client cannot reach port 4358
+  directly.
+- Each client phase starts with an empty tmpfs home and `BITROUTER_HOME`. It
+  receives only the test CA and the control-token environment variable it
+  needs; it receives no server configuration or provider credentials.
+
+The server’s loopback mock OpenAI endpoint makes actual inference requests so
+the request inspection checks query the daemon’s own metering database. The
+normal read phase invokes all nine advertised CLI leaves as well as their HTTP
+routes. Once MCP initialization is accepted, it dynamically verifies the
+advertised MCP control-tool inventory and invokes every tool through the same
+TLS sidecar. It also runs a standalone synthetic local-trap subprocess: poisoned
+config, metering, control-socket, and provider-environment inputs are watched
+with Linux inotify and socket listeners while wrong-token and unreachable remote
+reads run. The synthetic subprocess intentionally sets a fake `OPENAI_API_KEY`;
+the normal client and actual server boundary still expose no server config or
+provider credentials to the client. The fixture covers every advertised
+`control:read` action, the `state` resource,
+filtered and truncated request inspection, the TLS CLI path, reader denial of
+reload, disk-versus-active policy divergence, an administrator reload after a
+client connection closes, same-ID recovery, boot-instance change behavior, and
+the legacy `BITROUTER_CONTROL_TOKEN` fallback after explicit credentials are
+removed. That fallback remains read-only; the former named administrator token
+is rejected after the restart. The recovery client reads the reload receipt's
+`202` headers and closes before the operation body, then resolves that same
+operation ID through the lookup endpoint.
+
+The image also carries a separately compiled, ignored Rust test executable.
+Its `docker_partial_fixture` is a test-only HTTP server that uses the real
+control authentication, operation registry, and reload coordinator while
+simulating a partial participant result. A second client phase confirms that
+the CLI emits the `partially_applied` operation report and exits nonzero. Real
+PTY checks drive the remote dashboard through every remote read panel and its
+available controls before a successful production reload, then through the
+partial fixture. They verify semantic Home, Models, Requests, Route,
+Providers, Telemetry, Agents and policy output; route Backspace/Ctrl-U;
+active/disk policy selection, typed detail, PageDown/PageUp; explicit refresh,
+outcome rendering, generation changes, terminal restoration, and a subsequent
+shell write. The
+participant-level fault matrix remains in the Rust reload tests; the production
+server container has no fault-injection switch. This is container acceptance,
+not physical-host deployment verification.

--- a/tests/remote-administration/client-checks.sh
+++ b/tests/remote-administration/client-checks.sh
@@ -1,0 +1,714 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly control_endpoint="https://server:8443/control/v1"
+readonly ca_file="/tls/ca.crt"
+
+fail() {
+    printf 'remote-administration acceptance failed: %s\n' "$*" >&2
+    exit 1
+}
+
+assert_json() {
+    local value=$1
+    local expression=$2
+    jq --exit-status "$expression" <<<"$value" >/dev/null \
+        || fail "JSON assertion failed: $expression"
+}
+
+utc_timestamp() {
+    python3 - "${1:-0}" <<'PYTHON'
+from datetime import datetime, timedelta, timezone
+import sys
+
+value = datetime.now(timezone.utc) + timedelta(seconds=int(sys.argv[1]))
+print(value.isoformat(timespec="microseconds").replace("+00:00", "Z"))
+PYTHON
+}
+
+assert_client_boundary() {
+    [[ ! -e "$HOME/bitrouter.yaml" ]] || fail 'client home unexpectedly contains a router config'
+    [[ ! -e "$BITROUTER_HOME/bitrouter.yaml" ]] \
+        || fail 'client BitRouter home unexpectedly contains a router config'
+    [[ ! -e /tls/server.key && ! -e /tls/server.crt ]] \
+        || fail 'client unexpectedly received TLS private-key material'
+    for name in \
+        ANTHROPIC_API_KEY \
+        GEMINI_API_KEY \
+        OPENAI_API_KEY \
+        BITROUTER_API_KEY \
+        SERVER_UPSTREAM_TOKEN \
+        TEST_UPSTREAM_TOKEN; do
+        if printenv "$name" >/dev/null; then
+            fail "client unexpectedly received provider credential variable $name"
+        fi
+    done
+}
+
+control_get() {
+    local token=$1
+    local path=$2
+    shift 2
+    local -a args=(
+        --silent
+        --show-error
+        --fail-with-body
+        --cacert "$ca_file"
+        --header "Authorization: Bearer $token"
+        --header 'Accept: application/json'
+        --get
+    )
+    local query
+    for query in "$@"; do
+        args+=(--data-urlencode "$query")
+    done
+    curl "${args[@]}" "$control_endpoint$path"
+}
+
+control_post() {
+    local token=$1
+    local path=$2
+    local body=$3
+    curl \
+        --silent \
+        --show-error \
+        --fail-with-body \
+        --cacert "$ca_file" \
+        --header "Authorization: Bearer $token" \
+        --header 'Content-Type: application/json' \
+        --data "$body" \
+        "$control_endpoint$path"
+}
+
+control_status() {
+    local token=$1
+    local method=$2
+    local path=$3
+    local expected_status=$4
+    local body=${5-}
+    local output
+    output=$(mktemp)
+    local code
+    local -a args=(
+        --silent
+        --show-error
+        --cacert "$ca_file"
+        --header "Authorization: Bearer $token"
+        --request "$method"
+        --output "$output"
+        --write-out '%{http_code}'
+    )
+    if [[ -n "$body" ]]; then
+        args+=(--header 'Content-Type: application/json' --data "$body")
+    fi
+    code=$(curl "${args[@]}" "$control_endpoint$path")
+    if [[ "$code" != "$expected_status" ]]; then
+        local response
+        response=$(<"$output")
+        rm -f "$output"
+        fail "expected HTTP $expected_status from $method $path, got $code: $response"
+    fi
+    local response
+    response=$(<"$output")
+    rm -f "$output"
+    printf '%s' "$response"
+}
+
+add_reader_context() {
+    bitrouter context add reader \
+        --endpoint "$control_endpoint" \
+        --token-env CLIENT_READ_TOKEN >/tmp/context-reader.json
+}
+
+assert_cli_reaches_tls_proxy() {
+    add_reader_context
+    bitrouter --context reader status >/tmp/status.json
+    bitrouter --context reader models >/tmp/models.json
+    jq --exit-status 'has("running")' /tmp/status.json >/dev/null \
+        || fail 'remote status CLI response is not a status report'
+    jq --exit-status 'has("models")' /tmp/models.json >/dev/null \
+        || fail 'remote models CLI response is not a models report'
+}
+
+assert_cli_read_actions() {
+    local since
+    since=$(utc_timestamp -600)
+    local until
+    until=$(utc_timestamp)
+
+    bitrouter --context reader status >/tmp/cli-status.json
+    bitrouter --context reader status --requests >/tmp/cli-status-requests.json
+    bitrouter --context reader models --provider fixture >/tmp/cli-models.json
+    bitrouter --context reader requests \
+        --limit 1 \
+        --model fixture-a \
+        --provider fixture \
+        --since "$since" \
+        --until "$until" >/tmp/cli-requests.json
+    bitrouter --context reader route fixture-a \
+        --prompt 'container acceptance' >/tmp/cli-route.json
+    bitrouter --context reader providers list >/tmp/cli-providers.json
+    bitrouter --context reader observe status >/tmp/cli-observe.json
+    bitrouter --context reader policy status --view active >/tmp/cli-policy-status.json
+    bitrouter --context reader policy show fixture \
+        --view active >/tmp/cli-policy-show.json
+    bitrouter --context reader agents list >/tmp/cli-agents.json
+
+    jq --exit-status 'has("running")' /tmp/cli-status.json >/dev/null \
+        || fail 'remote status CLI did not return a status report'
+    jq --exit-status '.rows | type == "array"' /tmp/cli-status-requests.json >/dev/null \
+        || fail 'remote status --requests CLI did not return a requests report'
+    jq --exit-status '.models | type == "array"' /tmp/cli-models.json >/dev/null \
+        || fail 'remote models CLI did not return a models report'
+    jq --exit-status '
+        .filters.model == "fixture-a"
+        and .filters.provider == "fixture"
+        and (.rows | length) == 1
+        and .truncated == true
+    ' /tmp/cli-requests.json >/dev/null \
+        || fail 'remote requests CLI did not preserve request filters'
+    local expected_since=${since/Z/+00:00}
+    local expected_until=${until/Z/+00:00}
+    [[ "$(jq -r '.filters.since' /tmp/cli-requests.json)" == "$expected_since" ]] \
+        || fail 'remote requests CLI did not preserve the inclusive request bound'
+    [[ "$(jq -r '.filters.until' /tmp/cli-requests.json)" == "$expected_until" ]] \
+        || fail 'remote requests CLI did not preserve the exclusive request bound'
+    printf 'REMOTE_ADMIN_CLI_REQUEST_FILTER_BOUNDS since=%s until=%s newest_row=%s\n' \
+        "$expected_since" \
+        "$expected_until" \
+        "$(jq -r '.rows[0].created_at' /tmp/cli-requests.json)"
+    jq --exit-status '.requested_model == "fixture-a"' /tmp/cli-route.json >/dev/null \
+        || fail 'remote route CLI did not return a route report'
+    jq --exit-status '.providers | type == "array"' /tmp/cli-providers.json >/dev/null \
+        || fail 'remote providers CLI did not return a providers report'
+    jq --exit-status 'has("daemon_reachable")' /tmp/cli-observe.json >/dev/null \
+        || fail 'remote observe CLI did not return an observation report'
+    jq --exit-status '.view == "active" and .availability == "available"' \
+        /tmp/cli-policy-status.json >/dev/null \
+        || fail 'remote policy status CLI did not use the active view'
+    jq --exit-status '.view == "active" and .definitions.fixture != null' \
+        /tmp/cli-policy-show.json >/dev/null \
+        || fail 'remote policy show CLI did not use the active view'
+    jq --exit-status '.agents | type == "array"' /tmp/cli-agents.json >/dev/null \
+        || fail 'remote agents CLI did not return an agents report'
+}
+
+assert_mcp_control_tools() {
+    local report
+    report=$(python3 /usr/local/libexec/mcp-check.py \
+        --endpoint 'https://server:8443/mcp-control' \
+        --ca "$ca_file" \
+        --token-env CLIENT_READ_TOKEN)
+    assert_json "$report" '
+        .mcp == "passed"
+        and .tools == ["list_models", "route_preview", "status"]
+    '
+}
+
+assert_remote_target_isolation() {
+    local report
+    report=$(python3 /usr/local/libexec/target-isolation.py \
+        --binary bitrouter \
+        --endpoint "$control_endpoint" \
+        --ca "$ca_file")
+    assert_json "$report" '
+        .target_isolation == "passed"
+        and .read_actions == 9
+        and .failure_modes == 2
+    '
+}
+
+assert_control_is_loopback_only() {
+    if curl \
+        --silent \
+        --show-error \
+        --connect-timeout 1 \
+        --max-time 1 \
+        http://server:4358/control/v1/capabilities >/dev/null 2>&1; then
+        fail 'client reached the control listener without the TLS proxy'
+    fi
+}
+
+seed_requests() {
+    local model
+    for model in fixture-a fixture-a fixture-a fixture-b; do
+        curl \
+            --silent \
+            --show-error \
+            --fail-with-body \
+            --header 'Content-Type: application/json' \
+            --data "{\"model\":\"$model\",\"messages\":[{\"role\":\"user\",\"content\":\"container acceptance\"}]}" \
+            http://server:4356/v1/chat/completions >/dev/null
+    done
+
+    if curl \
+        --silent \
+        --show-error \
+        --fail-with-body \
+        --header 'Content-Type: application/json' \
+        --data '{"model":"fixture-a","messages":[{"role":"user","content":"force-rate-limit"}]}' \
+        http://server:4356/v1/chat/completions >/dev/null; then
+        fail 'fixture upstream was expected to reject the synthetic rate-limited request'
+    fi
+}
+
+wait_for_metering() {
+    local report
+    local count
+    for _ in $(seq 1 80); do
+        report=$(control_get "$CLIENT_READ_TOKEN" '/requests' 'limit=500')
+        count=$(jq -r '.rows | length' <<<"$report")
+        if [[ "$count" -ge 5 ]]; then
+            return
+        fi
+        sleep 0.25
+    done
+    fail 'daemon did not persist synthetic requests to metering'
+}
+
+assert_advertised_read_actions() {
+    local capabilities=$1
+    local advertised
+    advertised=$(jq -r '
+        .action_descriptors
+        | to_entries[]
+        | select(.value.required_scope == "control:read")
+        | .key
+    ' <<<"$capabilities" | LC_ALL=C sort)
+    local expected
+    expected=$(printf '%s\n' \
+        agents_list \
+        list_models \
+        observe_status \
+        policy_show \
+        policy_status \
+        providers_list \
+        requests \
+        route \
+        status | LC_ALL=C sort)
+    [[ "$advertised" == "$expected" ]] \
+        || fail "an advertised read action lacks an endpoint assertion: $advertised"
+}
+
+assert_read_actions() {
+    local capabilities
+    capabilities=$(control_get "$CLIENT_READ_TOKEN" '/capabilities')
+    assert_json "$capabilities" '.protocol == "bitrouter-control" and .protocol_version == 1'
+    assert_json "$capabilities" '.scopes == ["control:read"]'
+    assert_json "$capabilities" '.resources.capabilities != null and .resources.state != null'
+    assert_json "$capabilities" '.action_descriptors.reload == null'
+    assert_advertised_read_actions "$capabilities"
+
+    local status
+    status=$(control_get "$CLIENT_READ_TOKEN" '/status')
+    assert_json "$status" 'has("running")'
+
+    local models
+    models=$(control_get "$CLIENT_READ_TOKEN" '/models' 'provider=fixture')
+    assert_json "$models" '.models | type == "array"'
+
+    local route
+    route=$(control_post "$CLIENT_READ_TOKEN" '/route/preview' \
+        '{"model":"fixture-a","prompt":"container acceptance"}')
+    assert_json "$route" '.requested_model == "fixture-a" and (.provider_chain | length) > 0'
+
+    local providers
+    providers=$(control_get "$CLIENT_READ_TOKEN" '/providers')
+    assert_json "$providers" '.resolved_via == "live" and (.providers | type == "array")'
+
+    local observe
+    observe=$(control_get "$CLIENT_READ_TOKEN" '/observe/status')
+    assert_json "$observe" 'has("daemon_reachable") and has("metrics_enabled")'
+
+    local policy_status
+    policy_status=$(control_get "$CLIENT_READ_TOKEN" '/policy/status' 'view=active')
+    assert_json "$policy_status" '.view == "active" and .availability == "available"'
+
+    local policy_show
+    policy_show=$(control_get "$CLIENT_READ_TOKEN" '/policy/show' 'view=active' 'name=fixture')
+    assert_json "$policy_show" '.definitions.fixture.tiers.chosen == "fixture:fixture-a"'
+
+    local agents
+    agents=$(control_get "$CLIENT_READ_TOKEN" '/agents')
+    assert_json "$agents" '.resolved_via == "live" and (.agents | type == "array")'
+
+    local state
+    state=$(control_get "$CLIENT_READ_TOKEN" '/state')
+    assert_json "$state" '(.server_instance_id | type == "string") and (.generation | type == "number")'
+}
+
+assert_request_filters() {
+    local since
+    since=$(utc_timestamp -600)
+    local until
+    until=$(utc_timestamp)
+    local report
+    report=$(control_get \
+        "$CLIENT_READ_TOKEN" \
+        '/requests' \
+        'limit=1' \
+        'model=fixture-a' \
+        'provider=fixture' \
+        "since=$since" \
+        "until=$until")
+    local expected_since=${since/Z/+00:00}
+    local expected_until=${until/Z/+00:00}
+    assert_json "$report" '
+        .filters.model == "fixture-a"
+        and .filters.provider == "fixture"
+        and (.filters.since | type == "string")
+        and (.filters.until | type == "string")
+        and .rate_scope == "all callers, trailing minute"
+        and .metering.summary == "available"
+        and .metering.rate == "available"
+        and .metering.rows == "available"
+        and (.rows | length) == 1
+        and .truncated == true
+        and .requests >= 3
+        and .rows[0].model == "fixture-a"
+        and .rows[0].provider == "fixture"
+    '
+    [[ "$(jq -r '.filters.since' <<<"$report")" == "$expected_since" ]] \
+        || fail 'server did not return the resolved inclusive request bound'
+    [[ "$(jq -r '.filters.until' <<<"$report")" == "$expected_until" ]] \
+        || fail 'server did not return the resolved exclusive request bound'
+    printf 'REMOTE_ADMIN_HTTP_REQUEST_FILTER_BOUNDS since=%s until=%s newest_row=%s\n' \
+        "$expected_since" \
+        "$expected_until" \
+        "$(jq -r '.rows[0].created_at' <<<"$report")"
+    assert_json "$report" '
+        .scope == "all callers"
+        and .requests >= 4
+        and all(.rows[]; ((.error // "") | contains("fixture-upstream-secret") | not))
+    '
+
+    local sanitized
+    sanitized=$(control_get \
+        "$CLIENT_READ_TOKEN" \
+        '/requests' \
+        'limit=500' \
+        'model=fixture-a' \
+        'provider=fixture' \
+        "since=$since" \
+        "until=$until")
+    assert_json "$sanitized" '
+        any(.rows[]; .error != null)
+        and all(.rows[]; ((.error // "") | contains("fixture-upstream-secret") | not))
+    '
+}
+
+assert_request_filter_validation() {
+    local response
+    response=$(control_status "$CLIENT_READ_TOKEN" GET '/requests?limit=0' 400)
+    assert_json "$response" '.error.code == "bad_request"'
+
+    response=$(control_status "$CLIENT_READ_TOKEN" GET '/requests?limit=501' 400)
+    assert_json "$response" '.error.code == "bad_request"'
+
+    response=$(control_status \
+        "$CLIENT_READ_TOKEN" \
+        GET \
+        '/requests?limit=1&since=2026-01-01T00:00:00Z' \
+        400)
+    assert_json "$response" '.error.code == "bad_request"'
+
+    response=$(control_status \
+        "$CLIENT_READ_TOKEN" \
+        GET \
+        '/requests?limit=1&since=2026-01-01T00:00:00Z&until=2026-01-09T00:00:01Z' \
+        400)
+    assert_json "$response" '.error.code == "bad_request"'
+}
+
+assert_policy_divergence() {
+    local active
+    active=$(control_get "$CLIENT_READ_TOKEN" '/policy/status' 'view=active')
+    local disk
+    disk=$(control_get "$CLIENT_READ_TOKEN" '/policy/status' 'view=disk')
+    local active_digest
+    active_digest=$(jq -r '.digest' <<<"$active")
+    local disk_digest
+    disk_digest=$(jq -r '.digest' <<<"$disk")
+    [[ "$active_digest" != 'null' && "$disk_digest" != 'null' && "$active_digest" != "$disk_digest" ]] \
+        || fail 'staged disk policy did not diverge from the live policy'
+
+    local active_policy
+    active_policy=$(control_get "$CLIENT_READ_TOKEN" '/policy/show' 'view=active' 'name=fixture')
+    local disk_policy
+    disk_policy=$(control_get "$CLIENT_READ_TOKEN" '/policy/show' 'view=disk' 'name=fixture')
+    assert_json "$active_policy" '.definitions.fixture.tiers.chosen == "fixture:fixture-a"'
+    assert_json "$disk_policy" '.definitions.fixture.tiers.chosen == "fixture:fixture-b"'
+}
+
+wait_for_disconnected_admission() {
+    local request_id=$1
+    local instance=$2
+    local report
+    for _ in $(seq 1 120); do
+        if report=$(control_get \
+            "$CLIENT_ADMIN_TOKEN" \
+            "/operations/$request_id?instance=$instance" 2>/dev/null); then
+            jq --exit-status --arg request_id "$request_id" \
+                '.request_id == $request_id' <<<"$report" >/dev/null \
+                || fail 'disconnected request returned the wrong operation identity'
+            printf '%s' "$report"
+            return
+        fi
+        sleep 0.25
+    done
+    fail "disconnected reload $request_id was not admitted before recovery"
+}
+
+poll_operation() {
+    local request_id=$1
+    local instance=$2
+    local report
+    local status
+    for _ in $(seq 1 120); do
+        report=$(control_get "$CLIENT_ADMIN_TOKEN" "/operations/$request_id?instance=$instance")
+        status=$(jq -r '.status' <<<"$report")
+        if [[ "$status" != 'running' ]]; then
+            printf '%s' "$report"
+            return
+        fi
+        sleep 0.25
+    done
+    fail "reload operation $request_id did not finish"
+}
+
+assert_disconnected_reload_recovery() {
+    local state
+    state=$(control_get "$CLIENT_ADMIN_TOKEN" '/state')
+    local instance
+    instance=$(jq -r '.server_instance_id' <<<"$state")
+    local generation
+    generation=$(jq -r '.generation' <<<"$state")
+    local request_id
+    request_id=$(python3 -c 'import uuid; print(uuid.uuid4())')
+    local body
+    body=$(jq --null-input \
+        --arg request_id "$request_id" \
+        --arg instance "$instance" \
+        --argjson generation "$generation" \
+        '{request_id: $request_id, expected_server_instance_id: $instance, expected_generation: $generation}')
+
+    local denied
+    denied=$(control_status "$CLIENT_READ_TOKEN" POST '/reload' 403 "$body")
+    assert_json "$denied" '.error.code == "scope_denied"'
+
+    /usr/local/libexec/disconnect-submit.py "$body"
+    local admitted
+    admitted=$(wait_for_disconnected_admission "$request_id" "$instance")
+    assert_json "$admitted" '.status == "running" or .status == "succeeded"'
+
+    local duplicate
+    duplicate=$(control_post "$CLIENT_ADMIN_TOKEN" '/reload' "$body")
+    jq --exit-status --arg request_id "$request_id" '.request_id == $request_id' <<<"$duplicate" >/dev/null \
+        || fail 'duplicate reload submission did not return the admitted operation'
+
+    local completed
+    completed=$(poll_operation "$request_id" "$instance")
+    assert_json "$completed" '
+        .status == "succeeded"
+        and .result != null
+        and .completed_at_unix_ms != null
+    '
+
+    local denied_operation
+    denied_operation=$(control_status \
+        "$CLIENT_READ_TOKEN" \
+        GET \
+        "/operations/$request_id?instance=$instance" \
+        403)
+    assert_json "$denied_operation" '.error.code == "scope_denied"'
+
+    local after_state
+    after_state=$(control_get "$CLIENT_ADMIN_TOKEN" '/state')
+    [[ "$(jq -r '.generation' <<<"$after_state")" == "$((generation + 1))" ]] \
+        || fail 'duplicate reload submission advanced generation twice'
+
+    local active
+    active=$(control_get "$CLIENT_ADMIN_TOKEN" '/policy/status' 'view=active')
+    local disk
+    disk=$(control_get "$CLIENT_ADMIN_TOKEN" '/policy/status' 'view=disk')
+    local active_digest
+    active_digest=$(jq -r '.digest' <<<"$active")
+    local disk_digest
+    disk_digest=$(jq -r '.digest' <<<"$disk")
+    [[ "$active_digest" == "$disk_digest" && "$active_digest" != 'null' ]] \
+        || fail 'remote reload did not apply the staged policy live'
+
+    local active_policy
+    active_policy=$(control_get "$CLIENT_ADMIN_TOKEN" '/policy/show' 'view=active' 'name=fixture')
+    assert_json "$active_policy" '.definitions.fixture.tiers.chosen == "fixture:fixture-b"'
+
+    printf 'REMOTE_ADMIN_OPERATION_ID=%s\n' "$request_id"
+    printf 'REMOTE_ADMIN_OPERATION_INSTANCE=%s\n' "$instance"
+}
+
+assert_successful_cli_reload_and_operation_show() {
+    bitrouter context add administrator \
+        --endpoint "$control_endpoint" \
+        --token-env CLIENT_ADMIN_TOKEN >/tmp/context-administrator.json
+    bitrouter --context administrator reload >/tmp/cli-reload.json
+    jq --exit-status '
+        .status == "succeeded"
+        and .result.outcome == "succeeded"
+        and (.request_id | type == "string")
+        and (.server_instance_id | type == "string")
+        and .completed_at_unix_ms != null
+    ' /tmp/cli-reload.json >/dev/null \
+        || fail 'remote CLI reload did not return a successful retained operation'
+
+    local request_id
+    request_id=$(jq -r '.request_id' /tmp/cli-reload.json)
+    local instance
+    instance=$(jq -r '.server_instance_id' /tmp/cli-reload.json)
+    bitrouter --context administrator operations show "$request_id" \
+        --instance "$instance" >/tmp/cli-operations-show.json
+    jq --exit-status --arg request_id "$request_id" --arg instance "$instance" '
+        .request_id == $request_id
+        and .server_instance_id == $instance
+        and .status == "succeeded"
+        and .result.outcome == "succeeded"
+        and .completed_at_unix_ms != null
+    ' /tmp/cli-operations-show.json >/dev/null \
+        || fail 'remote CLI operations show did not recover the successful operation'
+}
+
+assert_boot_change() {
+    local prior_request_id=$1
+    local prior_instance=$2
+    local state
+    state=$(control_get "$CLIENT_ADMIN_TOKEN" '/state')
+    local current_instance
+    current_instance=$(jq -r '.server_instance_id' <<<"$state")
+    [[ "$current_instance" != "$prior_instance" ]] \
+        || fail 'server restart did not issue a new server instance id'
+
+    local prior
+    prior=$(control_status \
+        "$CLIENT_ADMIN_TOKEN" \
+        GET \
+        "/operations/$prior_request_id?instance=$prior_instance" \
+        409)
+    assert_json "$prior" '.error.code == "server_instance_changed"'
+}
+
+assert_legacy_token_read_only() {
+    bitrouter context add legacy \
+        --endpoint "$control_endpoint" \
+        --token-env CLIENT_READ_TOKEN >/tmp/context-legacy.json
+    bitrouter --context legacy status >/tmp/legacy-status.json
+    jq --exit-status 'has("running")' /tmp/legacy-status.json >/dev/null \
+        || fail 'legacy control token could not read status'
+
+    local capabilities
+    capabilities=$(control_get "$CLIENT_READ_TOKEN" '/capabilities')
+    assert_json "$capabilities" '
+        .scopes == ["control:read"]
+        and .action_descriptors.reload == null
+    '
+
+    local state
+    state=$(control_get "$CLIENT_READ_TOKEN" '/state')
+    local body
+    body=$(jq --null-input \
+        --arg request_id "$(python3 -c 'import uuid; print(uuid.uuid4())')" \
+        --arg instance "$(jq -r '.server_instance_id' <<<"$state")" \
+        --argjson generation "$(jq -r '.generation' <<<"$state")" \
+        '{request_id: $request_id, expected_server_instance_id: $instance, expected_generation: $generation}')
+
+    local denied
+    denied=$(control_status "$CLIENT_READ_TOKEN" POST '/reload' 403 "$body")
+    assert_json "$denied" '.error.code == "scope_denied"'
+
+    local old_admin
+    old_admin=$(control_status "$CLIENT_ADMIN_TOKEN" GET '/status' 401)
+    assert_json "$old_admin" '.error.code == "unauthorized"'
+
+    if bitrouter --context legacy reload >/tmp/legacy-reload.json 2>/tmp/legacy-reload.err; then
+        fail 'legacy read-only context unexpectedly reloaded the router'
+    fi
+}
+
+assert_partial_reload_cli() {
+    bitrouter context add administrator \
+        --endpoint "$control_endpoint" \
+        --token-env CLIENT_ADMIN_TOKEN >/tmp/context-administrator.json
+    if bitrouter --context administrator reload >/tmp/partial-reload.json 2>/tmp/partial-reload.err; then
+        fail 'CLI reported success for a partially-applied reload'
+    fi
+    if ! jq --slurp --exit-status '
+        length == 2
+        and .[0].status == "partially_applied"
+        and .[0].result.outcome == "partially_applied"
+        and any(.[0].result.participants[]; .outcome == "applied")
+        and any(
+            .[0].result.participants[];
+            .outcome == "failed"
+            and .error.code == "fixture_policy_failure"
+        )
+        and .[1].error.kind == "internal"
+        and (.[1].error.message | contains("partially applied"))
+    ' /tmp/partial-reload.json >/dev/null; then
+        printf '%s\n' 'partial reload stdout:' >&2
+        cat /tmp/partial-reload.json >&2
+        printf '%s\n' 'partial reload stderr:' >&2
+        cat /tmp/partial-reload.err >&2
+        fail 'CLI did not render the ordered partial reload report and error envelope'
+    fi
+}
+
+main() {
+    local phase=${1-read}
+    assert_client_boundary
+    case "$phase" in
+        read)
+            assert_cli_reaches_tls_proxy
+            assert_control_is_loopback_only
+            seed_requests
+            wait_for_metering
+            assert_read_actions
+            assert_cli_read_actions
+            # This remains mandatory in the normal acceptance run. The opt-out
+            # only lets an MCP transport failure be diagnosed without hiding
+            # the independent CLI and dashboard journeys.
+            if [[ "${BITROUTER_REMOTE_ADMIN_SKIP_MCP:-0}" != "1" ]]; then
+                assert_mcp_control_tools
+            fi
+            assert_remote_target_isolation
+            assert_request_filters
+            assert_request_filter_validation
+            ;;
+        diverged)
+            assert_policy_divergence
+            ;;
+        reload)
+            [[ -n "${CLIENT_ADMIN_TOKEN-}" ]] || fail 'admin token is required for reload acceptance'
+            assert_disconnected_reload_recovery
+            ;;
+        cli-reload)
+            [[ -n "${CLIENT_ADMIN_TOKEN-}" ]] || fail 'admin token is required for CLI reload acceptance'
+            assert_successful_cli_reload_and_operation_show
+            ;;
+        boot-change)
+            [[ -n "${CLIENT_ADMIN_TOKEN-}" ]] || fail 'admin token is required for boot-change acceptance'
+            [[ $# -eq 3 ]] || fail 'boot-change requires request id and prior instance'
+            assert_boot_change "$2" "$3"
+            ;;
+        legacy)
+            [[ -n "${CLIENT_ADMIN_TOKEN-}" ]] || fail 'admin token is required for legacy-token acceptance'
+            assert_legacy_token_read_only
+            ;;
+        partial)
+            [[ -n "${CLIENT_ADMIN_TOKEN-}" ]] || fail 'admin token is required for partial reload acceptance'
+            assert_partial_reload_cli
+            ;;
+        *)
+            fail "unknown acceptance phase $phase"
+            ;;
+    esac
+}
+
+main "$@"

--- a/tests/remote-administration/client-entrypoint.sh
+++ b/tests/remote-administration/client-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# The Rust client uses the system trust store while curl gets --cacert below.
+# This copy is made inside the ephemeral client container, never in its home.
+install -D -m 0644 /tls/ca.crt /usr/local/share/ca-certificates/remote-admin-ca.crt
+update-ca-certificates >/dev/null
+
+exec "$@"

--- a/tests/remote-administration/disconnect-submit.py
+++ b/tests/remote-administration/disconnect-submit.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Submit a reload, receive only its HTTP receipt headers, then lose the body."""
+
+import json
+import os
+import socket
+import ssl
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: disconnect-submit.py JSON_BODY")
+
+    body = sys.argv[1].encode("utf-8")
+    token = os.environ["CLIENT_ADMIN_TOKEN"]
+    context = ssl.create_default_context(cafile="/tls/ca.crt")
+    raw = socket.create_connection(("server", 8443), timeout=5)
+    tls = context.wrap_socket(raw, server_hostname="server")
+    request = b"".join(
+        [
+            b"POST /control/v1/reload HTTP/1.1\r\n",
+            b"Host: server:8443\r\n",
+            b"Content-Type: application/json\r\n",
+            b"Connection: close\r\n",
+            f"Authorization: Bearer {token}\r\n".encode("utf-8"),
+            f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"),
+            body,
+        ]
+    )
+    tls.sendall(request)
+    # Consume only the HTTP receipt headers, one byte at a time so a buffered
+    # read cannot accidentally consume the operation body. A 202 proves the
+    # server admitted the operation; closing now models loss of its report.
+    headers = bytearray()
+    while b"\r\n\r\n" not in headers:
+        byte = tls.recv(1)
+        if not byte:
+            raise SystemExit("server closed disconnected reload submission before its receipt")
+        headers.extend(byte)
+        if len(headers) > 16 * 1024:
+            raise SystemExit("reload receipt headers exceeded their bound")
+    status_line = bytes(headers).split(b"\r\n", 1)[0]
+    if b" 202 " not in status_line:
+        raise SystemExit(f"reload submission was not admitted: {status_line.decode('ascii', 'replace')}")
+    tls.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/remote-administration/mcp-check.py
+++ b/tests/remote-administration/mcp-check.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Exercise every authenticated control MCP tool over the TLS sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import ssl
+import urllib.error
+import urllib.request
+
+
+class McpFailure(RuntimeError):
+    """The remote MCP endpoint did not satisfy its advertised contract."""
+
+
+def parse_jsonrpc(body: bytes, content_type: str, expected_id: int) -> dict:
+    """Decode either ordinary JSON or the JSON event in an SSE response."""
+
+    text = body.decode("utf-8", "replace").strip()
+    payloads: list[str] = []
+    if "text/event-stream" in content_type:
+        current: list[str] = []
+        for line in text.splitlines():
+            if not line:
+                if current:
+                    payloads.append("\n".join(current))
+                    current = []
+                continue
+            if line.startswith("data:"):
+                current.append(line[5:].lstrip())
+        if current:
+            payloads.append("\n".join(current))
+    else:
+        payloads.append(text)
+
+    for payload in payloads:
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError as error:
+            raise McpFailure(f"MCP response was not JSON: {payload!r}") from error
+        candidates = decoded if isinstance(decoded, list) else [decoded]
+        for candidate in candidates:
+            if candidate.get("id") == expected_id:
+                return candidate
+    raise McpFailure(f"MCP response did not contain JSON-RPC id {expected_id}: {text!r}")
+
+
+class McpClient:
+    def __init__(self, endpoint: str, token: str, context: ssl.SSLContext) -> None:
+        self.endpoint = endpoint
+        self.token = token
+        self.context = context
+        self.next_id = 1
+        self.session_id: str | None = None
+
+    def _post(self, payload: dict, expected_id: int | None) -> dict | None:
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self.session_id is not None:
+            headers["Mcp-Session-Id"] = self.session_id
+        request = urllib.request.Request(
+            self.endpoint,
+            data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, context=self.context, timeout=10) as response:
+                body = response.read()
+                self.session_id = response.headers.get("Mcp-Session-Id", self.session_id)
+                if expected_id is None:
+                    if response.status not in (200, 202):
+                        raise McpFailure(f"MCP notification returned HTTP {response.status}")
+                    return None
+                return parse_jsonrpc(
+                    body,
+                    response.headers.get("Content-Type", ""),
+                    expected_id,
+                )
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", "replace")
+            raise McpFailure(f"MCP HTTP {error.code}: {body}") from error
+
+    def call(self, method: str, params: dict) -> dict:
+        request_id = self.next_id
+        self.next_id += 1
+        reply = self._post(
+            {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params},
+            request_id,
+        )
+        if reply is None:
+            raise McpFailure(f"MCP {method} returned no JSON-RPC result")
+        if "error" in reply:
+            raise McpFailure(f"MCP {method} failed: {reply['error']}")
+        return reply["result"]
+
+    def notify(self, method: str, params: dict) -> None:
+        self._post({"jsonrpc": "2.0", "method": method, "params": params}, None)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise McpFailure(message)
+
+
+def structured(result: dict, tool: str) -> dict:
+    value = result.get("structuredContent")
+    require(isinstance(value, dict), f"{tool} did not return structured content")
+    return value
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", default="https://server:8443/mcp-control")
+    parser.add_argument("--ca", default="/tls/ca.crt")
+    parser.add_argument("--token-env", default="CLIENT_READ_TOKEN")
+    args = parser.parse_args()
+
+    token = os.environ.get(args.token_env)
+    require(token is not None and len(token) >= 32, f"{args.token_env} is not a reader credential")
+    client = McpClient(args.endpoint, token, ssl.create_default_context(cafile=args.ca))
+
+    initialized = client.call(
+        "initialize",
+        {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "remote-administration-acceptance", "version": "1"},
+        },
+    )
+    require(isinstance(initialized.get("protocolVersion"), str), "MCP initialize omitted protocolVersion")
+    client.notify("notifications/initialized", {})
+
+    listed = client.call("tools/list", {})
+    tools = listed.get("tools")
+    require(isinstance(tools, list), "MCP tools/list did not return a tools array")
+    names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
+    require(all(isinstance(name, str) for name in names), "MCP tools/list returned an unnamed tool")
+    require(len(set(names)) == len(names), f"MCP tools/list returned duplicate tools: {names}")
+
+    expected = {"list_models", "route_preview", "status"}
+    discovered = set(names)
+    require(
+        discovered == expected,
+        f"MCP tools/list changed without a live-call assertion: {sorted(discovered)}",
+    )
+
+    for name in sorted(discovered):
+        arguments = {
+            "list_models": {"provider": "fixture"},
+            "route_preview": {"model": "fixture-a", "prompt": "MCP TLS acceptance"},
+            "status": {},
+        }[name]
+        result = structured(client.call("tools/call", {"name": name, "arguments": arguments}), name)
+        if name == "list_models":
+            require(
+                any(model.get("id") == "fixture-a" for model in result.get("models", [])),
+                "list_models did not return fixture-a through the TLS endpoint",
+            )
+        elif name == "route_preview":
+            require(result.get("requested_model") == "fixture-a", "route_preview changed the requested model")
+            require(bool(result.get("provider_chain")), "route_preview returned no provider chain")
+        else:
+            require(result.get("running") is True, "status did not report the running production daemon")
+            require(result.get("socket") is None, "status disclosed the server control socket")
+
+    print(json.dumps({"mcp": "passed", "tools": sorted(discovered), "session": client.session_id is not None}))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/remote-administration/mock-openai.py
+++ b/tests/remote-administration/mock-openai.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Small deterministic OpenAI-compatible upstream for container acceptance."""
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import time
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, _format, *_args):
+        # The harness needs deterministic logs, not one line per synthetic request.
+        return
+
+    def respond(self, status, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self.respond(200, {"ok": True})
+            return
+        self.respond(404, {"error": {"message": "not found"}})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length)
+        try:
+            request = json.loads(raw)
+        except json.JSONDecodeError:
+            self.respond(400, {"error": {"message": "invalid JSON"}})
+            return
+
+        if self.path != "/v1/chat/completions":
+            self.respond(404, {"error": {"message": "not found"}})
+            return
+
+        messages = request.get("messages", [])
+        content = " ".join(
+            message.get("content", "")
+            for message in messages
+            if isinstance(message, dict) and isinstance(message.get("content", ""), str)
+        )
+        if "force-rate-limit" in content:
+            self.respond(
+                429,
+                {
+                    "error": {
+                        "message": "rate limit fixture-upstream-secret",
+                        "type": "rate_limit_error",
+                    }
+                },
+            )
+            return
+
+        model = request.get("model", "fixture-a")
+        self.respond(
+            200,
+            {
+                "id": "chatcmpl-remote-administration",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "fixture response"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+            },
+        )
+
+
+ThreadingHTTPServer(("127.0.0.1", 8080), Handler).serve_forever()

--- a/tests/remote-administration/pty-check.py
+++ b/tests/remote-administration/pty-check.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Real PTY acceptance for the remote dashboard; standard library only.
+
+Uses a bounded virtual terminal and observable state conditions, not timing
+sleeps. Tests refresh without mutation, explicit reload rendering, clean quit,
+terminal restoration, and subsequent shell output on the same PTY.
+"""
+import argparse
+import codecs
+import fcntl
+import json
+import os
+import pty
+import re
+import select
+import ssl
+import struct
+import subprocess
+import termios
+import time
+import urllib.parse
+import urllib.request
+
+
+class Screen:
+    def __init__(self, rows=60, cols=180):
+        self.rows, self.cols = rows, cols
+        self.cells = [[" "] * cols for _ in range(rows)]
+        self.row = self.col = 0
+        self.pending = ""
+        self.decoder = codecs.getincrementaldecoder("utf-8")("replace")
+
+    def feed(self, data):
+        text = self.pending + self.decoder.decode(data)
+        self.pending = ""
+        index = 0
+        while index < len(text):
+            char = text[index]
+            if char == "\x1b":
+                match = re.match(r"\x1b\[([0-?]*)([ -/]*)([@-~])", text[index:])
+                if match:
+                    raw, _, command = match.groups()
+                    values = [int(value) if value else 0 for value in raw.lstrip("?<=>").split(";")]
+                    first = values[0] or 1
+                    if command in "Hf":
+                        self.row = min(self.rows - 1, first - 1)
+                        self.col = min(self.cols - 1, (values[1] or 1) - 1 if len(values) > 1 else 0)
+                    elif command == "G":
+                        self.col = min(self.cols - 1, first - 1)
+                    elif command == "d":
+                        self.row = min(self.rows - 1, first - 1)
+                    elif command in "ABCD":
+                        self.row = max(0, min(self.rows - 1, self.row + (first if command == "B" else -first if command == "A" else 0)))
+                        self.col = max(0, min(self.cols - 1, self.col + (first if command == "C" else -first if command == "D" else 0)))
+                    elif command == "J" and values[0] in (2, 3):
+                        self.cells = [[" "] * self.cols for _ in range(self.rows)]
+                    elif command == "K":
+                        start, end = (0, self.cols) if values[0] == 2 else (0, self.col + 1) if values[0] == 1 else (self.col, self.cols)
+                        self.cells[self.row][start:end] = [" "] * (end - start)
+                    index += len(match.group(0))
+                    continue
+                if text[index:].startswith("\x1b]"):
+                    end = text.find("\x07", index)
+                    if end < 0:
+                        self.pending = text[index:]
+                        break
+                    index = end + 1
+                    continue
+                if index + 1 >= len(text) or text[index + 1] == "[":
+                    self.pending = text[index:]
+                    break
+                index += 2
+                continue
+            if char == "\r":
+                self.col = 0
+            elif char == "\n":
+                self.row = min(self.rows - 1, self.row + 1)
+            elif char == "\b":
+                self.col = max(0, self.col - 1)
+            elif char >= " ":
+                self.cells[self.row][self.col] = char
+                self.col = min(self.cols - 1, self.col + 1)
+            index += 1
+
+    def text(self):
+        return "\n".join("".join(row) for row in self.cells)
+
+    def resize(self, rows, cols):
+        self.rows, self.cols = rows, cols
+        self.cells = [[" "] * cols for _ in range(rows)]
+        self.row = self.col = 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", default="bitrouter")
+    parser.add_argument("--context", default="administrator")
+    parser.add_argument("--expected", choices=("succeeded", "partially_applied"), required=True)
+    parser.add_argument("--token-env", default="CLIENT_ADMIN_TOKEN")
+    parser.add_argument("--endpoint", default="https://server:8443/control/v1")
+    parser.add_argument("--ca", default="/tls/ca.crt")
+    parser.add_argument("--read-panels", action="store_true")
+    args = parser.parse_args()
+    context = ssl.create_default_context(cafile=args.ca)
+
+    def control_get(path, query=None):
+        if query:
+            path += "?" + urllib.parse.urlencode(query)
+        request = urllib.request.Request(
+            args.endpoint + path,
+            headers={"Authorization": "Bearer " + os.environ[args.token_env]},
+        )
+        with urllib.request.urlopen(request, context=context, timeout=5) as response:
+            return json.load(response)
+
+    def control_post(path, payload):
+        request = urllib.request.Request(
+            args.endpoint + path,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": "Bearer " + os.environ[args.token_env],
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, context=context, timeout=5) as response:
+            return json.load(response)
+
+    def state():
+        return control_get("/state")
+
+    initial = state()
+    master, slave = pty.openpty()
+    original = termios.tcgetattr(slave)
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 60, 180, 0, 0))
+    screen = Screen()
+    transcript = bytearray()
+
+    def session():
+        os.setsid()
+        fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+
+    child = subprocess.Popen([args.binary, "--context", args.context, "code"], stdin=slave, stdout=slave, stderr=slave, close_fds=True, preexec_fn=session, env={**os.environ, "TERM": "xterm-256color"})
+
+    def until(predicate, description, timeout=45):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate(screen.text()):
+                return
+            if child.poll() is not None:
+                raise AssertionError(f"dashboard exited {child.returncode} before {description}:\n{screen.text()}")
+            readable, _, _ = select.select([master], [], [], min(0.25, deadline - time.monotonic()))
+            if readable:
+                data = os.read(master, 65536)
+                transcript.extend(data)
+                if len(transcript) > 8 * 1024 * 1024:
+                    raise AssertionError("PTY output exceeded bound")
+                screen.feed(data)
+        raise AssertionError(f"timed out waiting for {description}:\n{screen.text()}")
+
+    def resize(rows):
+        screen.resize(rows, 180)
+        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, 180, 0, 0))
+
+    def exercise_read_panels():
+        """Render each remote inspection result and its available read controls."""
+
+        models = control_get("/models")
+        model_ids = [model["id"] for model in models["models"]]
+        assert model_ids, "fixture did not expose a model for dashboard verification"
+        model_count = str(len(model_ids))
+        providers = control_get("/providers")["providers"]
+        assert providers, "fixture did not expose a provider for dashboard verification"
+        provider_id = providers[0]["id"]
+        requests = control_get("/requests", {"limit": "5"})["rows"]
+        assert requests, "fixture did not persist requests for dashboard verification"
+        request_model = requests[0]["model"]
+        route = control_post("/route/preview", {"model": "fixture-a"})
+        route_requested = route["requested_model"]
+        route_effective = route["effective_model"]
+        route_providers = [hop["provider"] for hop in route["provider_chain"]]
+        assert route_providers, "fixture route preview did not expose a provider chain"
+        agents = control_get("/agents")["agents"]
+        assert agents, "fixture did not expose an agent catalog for dashboard verification"
+        agent_id = {"claude-acp": "claude", "codex-acp": "codex"}.get(
+            agents[0]["id"], agents[0]["id"]
+        )
+        policies = control_get("/policy/status", {"view": "active"})["policies"]
+        assert "fixture" in policies and "fixture-detail" in policies, (
+            "fixture did not expose the bounded policy-selection data"
+        )
+
+        until(
+            lambda text: "connected" in text
+            and "models" in text
+            and re.search(r"\bmodels\s{2,}" + re.escape(model_count) + r"\b", text)
+            and provider_id in text,
+            "semantic remote home panel",
+        )
+        home_output = len(transcript)
+        os.write(master, b"r")
+        until(
+            lambda text: len(transcript) > home_output
+            and "connected" in text
+            and re.search(r"\bmodels\s{2,}" + re.escape(model_count) + r"\b", text),
+            "read-only dashboard refresh",
+        )
+
+        os.write(master, b"2")
+        until(
+            lambda text: "Agent catalog" in text
+            and agent_id in text
+            and "remote catalog is read-only" in text,
+            "remote agent catalog",
+        )
+        os.write(master, b"\r")
+        until(
+            lambda text: "Remote agent catalogs are read-only" in text,
+            "remote agent launch denial",
+        )
+
+        os.write(master, b"3")
+        until(
+            lambda text: "not connected" in text and "Message" in text,
+            "remote conversation exclusion",
+        )
+        os.write(master, b"\t")
+        until(
+            lambda text: "Native sessions" in text and "No active native session" in text,
+            "remote sessions exclusion",
+        )
+
+        os.write(master, b"5")
+        until(
+            lambda text: "Models" in text and model_ids[0] in text,
+            "semantic models panel",
+        )
+        os.write(master, b"6")
+        until(
+            lambda text: "Recent requests" in text
+            and request_model in text
+            and provider_id in text,
+            "semantic requests panel",
+        )
+
+        os.write(master, b"7")
+        until(lambda text: "Type a model selector" in text, "route preview input")
+        os.write(master, b"fixture-aX")
+        until(lambda text: "fixture-aX" in text, "route preview model entry")
+        os.write(master, b"\x7f")
+        until(
+            lambda text: "fixture-a" in text and "fixture-aX" not in text,
+            "route preview input backspace",
+        )
+        os.write(master, b"\r")
+        until(
+            lambda text: re.search(
+                r"\brequested\s{2,}" + re.escape(route_requested) + r"\b", text
+            )
+            and re.search(
+                r"\beffective\s{2,}" + re.escape(route_effective) + r"\b", text
+            )
+            and re.search(
+                r"\bproviders\s{2,}" + re.escape(route_providers[0]) + r"\b", text
+            ),
+            "semantic route preview",
+        )
+        os.write(master, b"\x15")
+        until(
+            lambda text: "Type a model selector" in text,
+            "route preview clear",
+        )
+
+        os.write(master, b"\t")
+        until(
+            lambda text: "Providers" in text and provider_id in text and "ACTIVE" in text,
+            "semantic providers panel",
+        )
+        os.write(master, b"9")
+        until(
+            lambda text: "Telemetry" in text and "daemon" in text and "reachable" in text,
+            "semantic telemetry panel",
+        )
+
+        os.write(master, b"0")
+        until(
+            lambda text: "Policy" in text and "active" in text and "fixture-detail" in text,
+            "active policy overview",
+        )
+        os.write(master, b"\x1b[B")
+        until(
+            lambda text: "> fixture-detail" in text,
+            "policy selection",
+        )
+        selection_after_down = screen.text()
+        os.write(master, b"\x1b[A")
+        until(
+            lambda text: text != selection_after_down,
+            "policy previous selection",
+        )
+        os.write(master, b"\r")
+        until(
+            lambda text: "Detail: fixture" in text and "Detail: fixture-detail" not in text,
+            "policy previous typed detail",
+        )
+        os.write(master, b"\x1b[B")
+        until(
+            lambda text: "Detail:" not in text,
+            "policy detail reset after next selection",
+        )
+        os.write(master, b"\r")
+        until(
+            lambda text: "Detail: fixture-detail" in text
+            and "concise" in text
+            and "detailed" in text,
+            "active policy typed detail",
+        )
+
+        # A short PTY makes a real scroll observable instead of only proving
+        # that the PageDown key reaches the reducer.
+        resize(18)
+        until(
+            lambda text: "Detail: fixture-detail" in text,
+            "resized policy detail",
+        )
+        before_scroll = screen.text()
+        os.write(master, b"\x1b[6~")
+        until(
+            lambda text: text != before_scroll and "Source: active" in text,
+            "policy detail scroll",
+        )
+        os.write(master, b"\x1b[5~")
+        until(
+            lambda text: text == before_scroll,
+            "policy detail scroll restore",
+        )
+
+        os.write(master, b"v")
+        until(
+            lambda text: "Policy" in text and "disk" in text and "fixture-detail" in text,
+            "disk policy overview",
+        )
+        resize(60)
+        until(
+            lambda text: "Policy" in text and "disk" in text,
+            "restored dashboard size",
+        )
+        os.write(master, b"\r")
+        until(
+            lambda text: "Detail: fixture-detail" in text and "detailed" in text,
+            "disk policy typed detail",
+        )
+
+        after_reads = state()
+        assert after_reads["generation"] == initial["generation"], (
+            "dashboard read panels mutated the router"
+        )
+
+    try:
+        until(lambda text: "Reload" in text and "remote:" in text, "initial dashboard")
+        if args.read_panels:
+            exercise_read_panels()
+            os.write(master, b"\t")
+        else:
+            os.write(master, b"\t" * 10)
+        until(lambda text: "generation" in text and "instance" in text and "Enter" in text, "reload page")
+        before = state()
+        assert before["generation"] == initial["generation"], "dashboard startup mutated the router"
+        # Explicit refresh must remain read-only. A redraw is observed before
+        # sending the reload key, and the request count is checked through state.
+        prior_output = len(transcript)
+        os.write(master, b"r")
+        until(lambda text: len(transcript) > prior_output and "generation" in text and "instance" in text, "read-only refresh")
+        assert state()["generation"] == initial["generation"], "dashboard refresh mutated the router"
+        os.write(master, b"\r")
+        expected = args.expected.replace("_", " ")
+        until(lambda text: "request" in text and (args.expected in text or expected in text), "terminal reload outcome")
+        final = state()
+        assert final["generation"] == initial["generation"] + 1, "explicit reload did not execute exactly once"
+        assert final["last_outcome"]["outcome"] == args.expected
+        if args.expected == "partially_applied":
+            assert final["consistency"] == "mixed"
+            until(lambda text: "mixed" in text and "failed" in text, "mixed state and failed participant")
+        os.write(master, b"q")
+        child.wait(timeout=10)
+        assert child.returncode == 0, f"dashboard quit failed: {child.returncode}"
+        restored = termios.tcgetattr(slave)
+        mask = termios.ICANON | termios.ECHO | termios.ISIG
+        assert restored[3] & mask == original[3] & mask, "terminal input modes were not restored"
+        shell = subprocess.Popen(["/bin/sh", "-c", "printf 'REMOTE_ADMIN_SHELL_USABLE\\n'"], stdin=slave, stdout=slave, stderr=slave)
+        shell.wait(timeout=5)
+        deadline = time.monotonic() + 5
+        while b"REMOTE_ADMIN_SHELL_USABLE" not in transcript and time.monotonic() < deadline:
+            readable, _, _ = select.select([master], [], [], 0.25)
+            if readable:
+                transcript.extend(os.read(master, 65536))
+        assert b"REMOTE_ADMIN_SHELL_USABLE" in transcript, "subsequent shell output was unusable"
+        print(json.dumps({"pty": "passed", "outcome": args.expected, "generation": final["generation"], "read_panels": args.read_panels, "terminal_restored": True, "shell_usable": True}))
+    finally:
+        if child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait(timeout=5)
+        os.close(master)
+        os.close(slave)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/remote-administration/pty-check.py
+++ b/tests/remote-administration/pty-check.py
@@ -28,6 +28,8 @@ class Screen:
         self.cells = [[" "] * cols for _ in range(rows)]
         self.row = self.col = 0
         self.pending = ""
+        self.responses = bytearray()
+        self.synchronized_text = None
         self.decoder = codecs.getincrementaldecoder("utf-8")("replace")
 
     def feed(self, data):
@@ -52,8 +54,23 @@ class Screen:
                     elif command in "ABCD":
                         self.row = max(0, min(self.rows - 1, self.row + (first if command == "B" else -first if command == "A" else 0)))
                         self.col = max(0, min(self.cols - 1, self.col + (first if command == "C" else -first if command == "D" else 0)))
-                    elif command == "J" and values[0] in (2, 3):
-                        self.cells = [[" "] * self.cols for _ in range(self.rows)]
+                    elif command == "J":
+                        if values[0] in (2, 3):
+                            self.cells = [[" "] * self.cols for _ in range(self.rows)]
+                        elif values[0] == 0:
+                            self.cells[self.row][self.col:] = [" "] * (self.cols - self.col)
+                            for row in range(self.row + 1, self.rows):
+                                self.cells[row] = [" "] * self.cols
+                        elif values[0] == 1:
+                            for row in range(self.row):
+                                self.cells[row] = [" "] * self.cols
+                            self.cells[self.row][:self.col + 1] = [" "] * (self.col + 1)
+                    elif command == "h" and raw == "?2026":
+                        self.synchronized_text = self.text()
+                    elif command == "l" and raw == "?2026":
+                        self.synchronized_text = None
+                    elif command == "n" and raw == "6":
+                        self.responses.extend(f"\x1b[{self.row + 1};{self.col + 1}R".encode())
                     elif command == "K":
                         start, end = (0, self.cols) if values[0] == 2 else (0, self.col + 1) if values[0] == 1 else (self.col, self.cols)
                         self.cells[self.row][start:end] = [" "] * (end - start)
@@ -74,7 +91,11 @@ class Screen:
             if char == "\r":
                 self.col = 0
             elif char == "\n":
-                self.row = min(self.rows - 1, self.row + 1)
+                if self.row == self.rows - 1:
+                    self.cells.pop(0)
+                    self.cells.append([" "] * self.cols)
+                else:
+                    self.row += 1
             elif char == "\b":
                 self.col = max(0, self.col - 1)
             elif char >= " ":
@@ -83,9 +104,12 @@ class Screen:
             index += 1
 
     def text(self):
+        if self.synchronized_text is not None:
+            return self.synchronized_text
         return "\n".join("".join(row) for row in self.cells)
 
     def resize(self, rows, cols):
+        self.synchronized_text = None
         self.rows, self.cols = rows, cols
         self.cells = [[" "] * cols for _ in range(rows)]
         self.row = self.col = 0
@@ -156,6 +180,9 @@ def main():
                 if len(transcript) > 8 * 1024 * 1024:
                     raise AssertionError("PTY output exceeded bound")
                 screen.feed(data)
+                if screen.responses:
+                    os.write(master, screen.responses)
+                    screen.responses.clear()
         raise AssertionError(f"timed out waiting for {description}:\n{screen.text()}")
 
     def resize(rows):
@@ -323,15 +350,23 @@ def main():
             lambda text: "Detail: fixture-detail" in text,
             "resized policy detail",
         )
-        before_scroll = screen.text()
+        def policy_content(text):
+            # Refresh timestamps are independent of scrolling. Compare the
+            # complete policy body, after the synchronized frame commits.
+            lines = text.splitlines()
+            start = next(index for index, line in enumerate(lines) if "┌ Policy" in line)
+            end = next(index for index in range(start + 1, len(lines)) if "└" in lines[index])
+            return lines[start + 1:end]
+
+        before_scroll = policy_content(screen.text())
         os.write(master, b"\x1b[6~")
         until(
-            lambda text: text != before_scroll and "Source: active" in text,
+            lambda text: policy_content(text) != before_scroll and "Source: active" in text,
             "policy detail scroll",
         )
         os.write(master, b"\x1b[5~")
         until(
-            lambda text: text == before_scroll,
+            lambda text: policy_content(text) == before_scroll,
             "policy detail scroll restore",
         )
 

--- a/tests/remote-administration/pty-entrypoint.sh
+++ b/tests/remote-administration/pty-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+bitrouter context add administrator \
+    --endpoint "${REMOTE_ADMIN_ENDPOINT:?remote endpoint is required}" \
+    --token-env CLIENT_ADMIN_TOKEN >/tmp/context-administrator.json
+
+exec python3 /usr/local/libexec/pty-check.py "$@"

--- a/tests/remote-administration/run.sh
+++ b/tests/remote-administration/run.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+readonly script_dir
+repository_root=$(cd -- "$script_dir/../.." && pwd)
+readonly repository_root
+readonly image=${BITROUTER_REMOTE_ADMIN_IMAGE:-bitrouter-remote-administration:local}
+readonly run_id="bitrouter-remote-admin-${RANDOM}-$$"
+readonly network_name="${run_id}-net"
+readonly server_name="${run_id}-server"
+readonly proxy_name="${run_id}-proxy"
+readonly partial_server_name="${run_id}-partial-server"
+readonly partial_proxy_name="${run_id}-partial-proxy"
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/bitrouter-remote-administration.XXXXXX")
+readonly scratch
+readonly server_dir="$scratch/server"
+readonly tls_dir="$scratch/tls"
+
+# These are fixture-only bearer values. Config references their variable names;
+# values live only in the respective ephemeral container environments.
+readonly reader_token='reader-control-token-012345678901234567890123456789'
+readonly admin_token='admin-control-token-0123456789012345678901234567890'
+readonly upstream_token='fixture-upstream-token-012345678901234567890123456'
+
+cleanup() {
+    local status=$?
+    if [[ "$status" -ne 0 ]]; then
+        printf '%s\n' 'remote-administration container logs follow:' >&2
+        docker logs "$partial_proxy_name" >&2 2>/dev/null || true
+        docker logs "$partial_server_name" >&2 2>/dev/null || true
+        docker logs "$proxy_name" >&2 2>/dev/null || true
+        docker logs "$server_name" >&2 2>/dev/null || true
+    fi
+    docker rm --force \
+        "$partial_proxy_name" \
+        "$partial_server_name" \
+        "$proxy_name" \
+        "$server_name" >/dev/null 2>&1 || true
+    docker network rm "$network_name" >/dev/null 2>&1 || true
+    rm -rf -- "$scratch"
+    exit "$status"
+}
+trap cleanup EXIT
+
+write_policy() {
+    local model=$1
+    printf '%s\n' \
+        'lockfileVersion: 1' \
+        'policies:' \
+        '  fixture:' \
+        '    key_strategy: agent_trace' \
+        '    tiers:' \
+        "      chosen: fixture:$model" \
+        '    routes: {}' \
+        '    default_tier: chosen' \
+        '    tool_use_tier: chosen' \
+        '    tool_safe_tiers: [chosen]' \
+        '  fixture-detail:' \
+        '    key_strategy: agent_trace' \
+        '    tiers:' \
+        '      concise: fixture:fixture-a' \
+        '      detailed: fixture:fixture-b' \
+        '    routes: {}' \
+        '    default_tier: concise' \
+        '    tool_use_tier: detailed' \
+        '    tool_safe_tiers: [concise, detailed]' \
+        >"$server_dir/policy-lock.yaml"
+}
+
+write_server_config() {
+    install -d -m 0700 "$server_dir" "$tls_dir"
+    printf '%s\n' \
+        'server:' \
+        '  listen: "0.0.0.0:4356"' \
+        '  control_socket: "/tmp/bitrouter.sock"' \
+        '  skip_auth: true' \
+        'database:' \
+        '  url: "sqlite:///tmp/bitrouter.db?mode=rwc"' \
+        'control:' \
+        '  enabled: true' \
+        '  listen: "127.0.0.1:4358"' \
+        '  credentials:' \
+        '    - id: reader' \
+        '      token_env: SERVER_READER_TOKEN' \
+        '      scopes: ["control:read"]' \
+        '    - id: administrator' \
+        '      token_env: SERVER_ADMIN_TOKEN' \
+        '      scopes: ["control:read", "control:reload"]' \
+        'inherit_defaults: false' \
+        'registry:' \
+        '  enabled: false' \
+        'providers:' \
+        '  fixture:' \
+        '    api_base: "http://127.0.0.1:8080/v1"' \
+        "    api_key: \"\${SERVER_UPSTREAM_TOKEN}\"" \
+        '    api_protocol:' \
+        '      - "*": chat_completions' \
+        '    models:' \
+        '      - id: fixture-a' \
+        '      - id: fixture-b' \
+        'policy:' \
+        '  path: "./policy-lock.yaml"' \
+        '  mode: frozen' \
+        'presets:' \
+        '  fixture:' \
+        '    model: fixture:fixture-a' \
+        '    policy: fixture' \
+        >"$server_dir/bitrouter.yaml"
+    write_policy fixture-a
+}
+
+write_tls_material() {
+    openssl req \
+        -x509 \
+        -newkey rsa:2048 \
+        -nodes \
+        -days 1 \
+        -subj '/CN=bitrouter-remote-administration test CA' \
+        -addext 'basicConstraints=critical,CA:TRUE' \
+        -addext 'keyUsage=critical,keyCertSign,cRLSign' \
+        -keyout "$tls_dir/ca.key" \
+        -out "$tls_dir/ca.crt" >/dev/null 2>&1
+    openssl req \
+        -newkey rsa:2048 \
+        -nodes \
+        -subj '/CN=server' \
+        -keyout "$tls_dir/server.key" \
+        -out "$tls_dir/server.csr" >/dev/null 2>&1
+    printf '%s\n' \
+        'basicConstraints=critical,CA:FALSE' \
+        'keyUsage=critical,digitalSignature,keyEncipherment' \
+        'extendedKeyUsage=serverAuth' \
+        'subjectAltName=DNS:server,DNS:localhost' \
+        >"$tls_dir/server.ext"
+    openssl x509 \
+        -req \
+        -in "$tls_dir/server.csr" \
+        -CA "$tls_dir/ca.crt" \
+        -CAkey "$tls_dir/ca.key" \
+        -CAcreateserial \
+        -days 1 \
+        -sha256 \
+        -extfile "$tls_dir/server.ext" \
+        -out "$tls_dir/server.crt" >/dev/null 2>&1
+    rm -f -- "$tls_dir/ca.key" "$tls_dir/ca.srl" "$tls_dir/server.csr" "$tls_dir/server.ext"
+}
+
+build_image() {
+    if [[ "${BITROUTER_REMOTE_ADMIN_SKIP_BUILD:-0}" == 1 ]]; then
+        return
+    fi
+    DOCKER_BUILDKIT=1 docker build \
+        --platform linux/arm64 \
+        --progress=plain \
+        --file "$script_dir/Dockerfile" \
+        --tag "$image" \
+        "$repository_root"
+}
+
+start_server() {
+    docker network create "$network_name" >/dev/null
+    docker run \
+        --detach \
+        --name "$server_name" \
+        --network "$network_name" \
+        --network-alias server \
+        --volume "$server_dir:/work/server" \
+        --env "SERVER_READER_TOKEN=$reader_token" \
+        --env "SERVER_ADMIN_TOKEN=$admin_token" \
+        --env "BITROUTER_CONTROL_TOKEN=$reader_token" \
+        --env "SERVER_UPSTREAM_TOKEN=$upstream_token" \
+        "$image" \
+        /usr/local/bin/remote-admin-server >/dev/null
+    start_proxy "$server_name" "$proxy_name"
+}
+
+start_proxy() {
+    local target_server=$1
+    local target_proxy=$2
+    docker run \
+        --detach \
+        --name "$target_proxy" \
+        --network "container:$target_server" \
+        --volume "$tls_dir:/tls:ro" \
+        "$image" \
+        /usr/local/bin/remote-admin-tls-proxy >/dev/null
+}
+
+wait_for_control() {
+    for _ in $(seq 1 120); do
+        if docker run \
+            --rm \
+            --network "$network_name" \
+            --volume "$tls_dir/ca.crt:/tls/ca.crt:ro" \
+            "$image" \
+            curl \
+                --silent \
+                --show-error \
+                --fail \
+                --cacert /tls/ca.crt \
+                --header "Authorization: Bearer $reader_token" \
+                https://server:8443/control/v1/capabilities >/dev/null 2>&1; then
+            return
+        fi
+        sleep 0.25
+    done
+    printf '%s\n' 'control API did not become ready' >&2
+    return 1
+}
+
+run_client() {
+    local phase=$1
+    shift
+    local -a env_args=(
+        --env HOME=/home/bitrouter
+        --env BITROUTER_HOME=/home/bitrouter/.bitrouter
+        --env SSL_CERT_FILE=/tls/ca.crt
+        --env "CLIENT_READ_TOKEN=$reader_token"
+    )
+    if [[ "$phase" == reload || "$phase" == cli-reload || "$phase" == boot-change || "$phase" == legacy || "$phase" == partial ]]; then
+        env_args+=(--env "CLIENT_ADMIN_TOKEN=$admin_token")
+    fi
+    # The default acceptance path always invokes MCP. This is a diagnostic
+    # selector for completing independent live journeys after an MCP failure.
+    if [[ "${BITROUTER_REMOTE_ADMIN_SKIP_MCP:-0}" == "1" ]]; then
+        env_args+=(--env BITROUTER_REMOTE_ADMIN_SKIP_MCP=1)
+    fi
+    docker run \
+        --rm \
+        --network "$network_name" \
+        --tmpfs /home/bitrouter:rw,noexec,nosuid,size=16m \
+        --volume "$tls_dir/ca.crt:/tls/ca.crt:ro" \
+        "${env_args[@]}" \
+        "$image" \
+        /usr/local/bin/remote-admin-client \
+        /usr/local/bin/remote-admin-checks \
+        "$phase" \
+        "$@"
+}
+
+run_pty_check() {
+    local expected=$1
+    local -a pty_args=(
+        /usr/local/bin/remote-admin-client
+        /usr/local/bin/remote-admin-pty
+        --context administrator
+        --expected "$expected"
+        --token-env CLIENT_ADMIN_TOKEN
+        --endpoint https://server:8443/control/v1
+        --ca /tls/ca.crt
+    )
+    if [[ "$expected" == succeeded ]]; then
+        pty_args+=(--read-panels)
+    fi
+    docker run \
+        --rm \
+        --network "$network_name" \
+        --tmpfs /home/bitrouter:rw,noexec,nosuid,size=16m \
+        --volume "$tls_dir/ca.crt:/tls/ca.crt:ro" \
+        --env HOME=/home/bitrouter \
+        --env BITROUTER_HOME=/home/bitrouter/.bitrouter \
+        --env SSL_CERT_FILE=/tls/ca.crt \
+        --env REMOTE_ADMIN_ENDPOINT=https://server:8443/control/v1 \
+        --env "CLIENT_READ_TOKEN=$reader_token" \
+        --env "CLIENT_ADMIN_TOKEN=$admin_token" \
+        "$image" \
+        "${pty_args[@]}"
+}
+
+restart_server() {
+    docker rm --force "$proxy_name" >/dev/null
+    docker restart "$server_name" >/dev/null
+    start_proxy "$server_name" "$proxy_name"
+    wait_for_control
+}
+
+remove_explicit_credentials() {
+    python3 - "$server_dir/bitrouter.yaml" <<'PYTHON'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+start = text.find("  credentials:\n")
+end = text.find("inherit_defaults: false\n", start)
+if start < 0 or end < 0:
+    raise SystemExit("fixture credentials block was not found")
+path.write_text(text[:start] + text[end:])
+PYTHON
+}
+
+stop_production_server() {
+    docker rm --force "$proxy_name" "$server_name" >/dev/null
+}
+
+start_partial_fixture() {
+    docker run \
+        --detach \
+        --name "$partial_server_name" \
+        --network "$network_name" \
+        --network-alias server \
+        --env "SERVER_READER_TOKEN=$reader_token" \
+        --env "SERVER_ADMIN_TOKEN=$admin_token" \
+        "$image" \
+        /usr/local/bin/bitrouter-lib-tests \
+        remote_control::tests::docker_partial_fixture \
+        --ignored \
+        --exact \
+        --nocapture >/dev/null
+    start_proxy "$partial_server_name" "$partial_proxy_name"
+    wait_for_control
+}
+
+main() {
+    build_image
+    write_server_config
+    write_tls_material
+    start_server
+    wait_for_control
+
+    run_client read
+
+    # The host stages this file change. The next reader observes disk and live
+    # policy disagreeing before an administrator chooses to apply it.
+    write_policy fixture-b
+    run_client diverged
+    run_client cli-reload
+
+    local reload_output
+    reload_output=$(run_client reload)
+    printf '%s\n' "$reload_output"
+    local request_id
+    request_id=$(awk -F= '$1 == "REMOTE_ADMIN_OPERATION_ID" { print $2 }' <<<"$reload_output")
+    local prior_instance
+    prior_instance=$(awk -F= '$1 == "REMOTE_ADMIN_OPERATION_INSTANCE" { print $2 }' <<<"$reload_output")
+    [[ -n "$request_id" && -n "$prior_instance" ]] \
+        || fail 'reload client did not return its recoverable operation identity'
+
+    restart_server
+    run_client boot-change "$request_id" "$prior_instance"
+    run_pty_check succeeded
+
+    # Credentials are intentionally removed only after the scoped production
+    # journey. The legacy token is then the sole accepted reader credential.
+    remove_explicit_credentials
+    restart_server
+    run_client legacy
+
+    stop_production_server
+    start_partial_fixture
+    run_client partial
+    run_pty_check partially_applied
+
+    if [[ "${BITROUTER_REMOTE_ADMIN_SKIP_MCP:-0}" == "1" ]]; then
+        printf '%s\n' 'remote-administration selected CLI/dashboard acceptance passed (MCP skipped)'
+    else
+        printf '%s\n' 'remote-administration Docker acceptance passed'
+    fi
+}
+
+fail() {
+    printf 'remote-administration Docker acceptance failed: %s\n' "$*" >&2
+    return 1
+}
+
+main "$@"

--- a/tests/remote-administration/select-test-binary.py
+++ b/tests/remote-administration/select-test-binary.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Copy the single bitrouter lib-test executable named by Cargo JSON output."""
+
+import json
+from pathlib import Path
+import shutil
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: select-test-binary.py DESTINATION")
+
+    executables = []
+    for line in sys.stdin:
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            message.get("reason") == "compiler-message"
+            and message.get("message", {}).get("level") == "error"
+        ):
+            rendered = message["message"].get("rendered")
+            if rendered:
+                print(rendered, file=sys.stderr, end="" if rendered.endswith("\n") else "\n")
+        target = message.get("target", {})
+        if (
+            message.get("reason") == "compiler-artifact"
+            and target.get("name") == "bitrouter"
+            and target.get("kind") == ["lib"]
+            and message.get("executable")
+        ):
+            executables.append(Path(message["executable"]))
+
+    if len(executables) != 1:
+        raise SystemExit(
+            f"expected one bitrouter lib-test executable, found {len(executables)}"
+        )
+
+    destination = Path(sys.argv[1])
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(executables[0], destination)
+    destination.chmod(0o755)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/remote-administration/server-entrypoint.sh
+++ b/tests/remote-administration/server-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Resolve the policy lock from the mounted server configuration directory.
+# The fixture explicitly keeps its daemon socket and SQLite file container-local.
+cd /work/server
+
+python3 /usr/local/libexec/mock-openai.py &
+mock_pid=$!
+trap 'kill "$mock_pid" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 40); do
+    if curl --silent --fail http://127.0.0.1:8080/health >/dev/null; then
+        exec bitrouter serve --config /work/server/bitrouter.yaml
+    fi
+    sleep 0.1
+done
+
+printf '%s\n' 'mock upstream did not start' >&2
+exit 1

--- a/tests/remote-administration/target-isolation.py
+++ b/tests/remote-administration/target-isolation.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Exercise remote-target failure paths against observable local traps.
+
+The Docker client normally has an empty BitRouter home.  That proves the
+network boundary, but it cannot prove that a remote failure did not silently
+fall back to a tempting local router.  This script supplies such a router and
+uses Linux inotify plus Unix-socket traps to make any local config, metering,
+or control-socket access observable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import os
+from pathlib import Path
+import select
+import shutil
+import socket
+import sqlite3
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+
+CONFIG_SENTINEL = "TARGET_ISOLATION_LOCAL_CONFIG_SENTINEL"
+METERING_SENTINEL = "TARGET_ISOLATION_LOCAL_METERING_SENTINEL"
+PROVIDER_SENTINEL = "TARGET_ISOLATION_LOCAL_PROVIDER_SECRET"
+WRONG_TOKEN = "target-isolation-wrong-token-000000000000000000000000"
+COMMAND_TIMEOUT_SECONDS = 20.0
+
+IN_ACCESS = 0x00000001
+IN_MODIFY = 0x00000002
+IN_ATTRIB = 0x00000004
+IN_CLOSE_WRITE = 0x00000008
+IN_CLOSE_NOWRITE = 0x00000010
+IN_OPEN = 0x00000020
+IN_MOVED_FROM = 0x00000040
+IN_MOVED_TO = 0x00000080
+IN_CREATE = 0x00000100
+IN_DELETE = 0x00000200
+IN_DELETE_SELF = 0x00000400
+IN_MOVE_SELF = 0x00000800
+IN_IGNORED = 0x00008000
+
+FILE_WATCH_MASK = (
+    IN_ACCESS
+    | IN_MODIFY
+    | IN_ATTRIB
+    | IN_CLOSE_WRITE
+    | IN_CLOSE_NOWRITE
+    | IN_OPEN
+)
+DIRECTORY_WATCH_MASK = (
+    IN_MODIFY
+    | IN_ATTRIB
+    | IN_CLOSE_WRITE
+    | IN_MOVED_FROM
+    | IN_MOVED_TO
+    | IN_CREATE
+    | IN_DELETE
+    | IN_DELETE_SELF
+    | IN_MOVE_SELF
+)
+EVENT_HEADER = struct.Struct("iIII")
+
+
+class IsolationFailure(RuntimeError):
+    """A remote command observed or disclosed a local trap."""
+
+
+class InotifyMonitor:
+    """Nonblocking Linux inotify watcher for only the poisoned local inputs."""
+
+    def __init__(self, paths: list[tuple[str, Path, int]]) -> None:
+        if sys.platform != "linux":
+            raise IsolationFailure("target-isolation requires Linux inotify")
+        libc = ctypes.CDLL(None, use_errno=True)
+        try:
+            init = libc.inotify_init1
+            add_watch = libc.inotify_add_watch
+        except AttributeError as error:
+            raise IsolationFailure("target-isolation requires inotify_init1") from error
+        init.argtypes = [ctypes.c_int]
+        init.restype = ctypes.c_int
+        add_watch.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_uint32]
+        add_watch.restype = ctypes.c_int
+
+        fd = init(os.O_NONBLOCK | os.O_CLOEXEC)
+        if fd < 0:
+            raise OSError(ctypes.get_errno(), "inotify_init1")
+        self._fd = fd
+        self._labels: dict[int, str] = {}
+        self._add_watch = add_watch
+        try:
+            for label, path, mask in paths:
+                watch_descriptor = self._add_watch(
+                    self._fd,
+                    os.fsencode(path),
+                    mask,
+                )
+                if watch_descriptor < 0:
+                    raise OSError(
+                        ctypes.get_errno(),
+                        f"inotify_add_watch {label}",
+                    )
+                self._labels[watch_descriptor] = label
+        except BaseException:
+            os.close(self._fd)
+            raise
+
+    @property
+    def fd(self) -> int:
+        return self._fd
+
+    def drain(self) -> list[str]:
+        events: list[str] = []
+        while True:
+            try:
+                data = os.read(self._fd, 64 * 1024)
+            except BlockingIOError:
+                break
+            if not data:
+                break
+            offset = 0
+            while offset < len(data):
+                watch_descriptor, mask, _, name_size = EVENT_HEADER.unpack_from(data, offset)
+                offset += EVENT_HEADER.size
+                name_end = offset + name_size
+                name = data[offset:name_end].rstrip(b"\0").decode("utf-8", "replace")
+                offset = name_end
+                if mask & IN_IGNORED:
+                    continue
+                label = self._labels.get(watch_descriptor, "unknown")
+                suffix = f"/{name}" if name else ""
+                events.append(f"{label}{suffix}:{event_names(mask)}")
+        return events
+
+    def close(self) -> None:
+        if self._fd >= 0:
+            os.close(self._fd)
+            self._fd = -1
+
+
+def event_names(mask: int) -> str:
+    names = [
+        (IN_ACCESS, "access"),
+        (IN_OPEN, "open"),
+        (IN_MODIFY, "modify"),
+        (IN_ATTRIB, "attrib"),
+        (IN_CLOSE_WRITE, "close_write"),
+        (IN_CLOSE_NOWRITE, "close_nowrite"),
+        (IN_CREATE, "create"),
+        (IN_DELETE, "delete"),
+        (IN_MOVED_FROM, "moved_from"),
+        (IN_MOVED_TO, "moved_to"),
+    ]
+    rendered = [name for flag, name in names if mask & flag]
+    return ",".join(rendered) if rendered else f"0x{mask:x}"
+
+
+class UnixSocketTrap:
+    """Records a local daemon control connection without polling or sleeping."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._listener.bind(os.fspath(path))
+        self._listener.listen()
+        self._listener.setblocking(False)
+        self._wake_reader, self._wake_writer = socket.socketpair()
+        self._stopped = threading.Event()
+        self._lock = threading.Lock()
+        self._hits = 0
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    @property
+    def hits(self) -> int:
+        with self._lock:
+            return self._hits
+
+    def _serve(self) -> None:
+        while not self._stopped.is_set():
+            readable, _, _ = select.select([self._listener, self._wake_reader], [], [])
+            if self._wake_reader in readable:
+                self._wake_reader.recv(1)
+                return
+            if self._listener not in readable:
+                continue
+            while True:
+                try:
+                    connection, _ = self._listener.accept()
+                except BlockingIOError:
+                    break
+                except OSError:
+                    return
+                with self._lock:
+                    self._hits += 1
+                connection.close()
+
+    def close(self) -> None:
+        if self._stopped.is_set():
+            return
+        self._stopped.set()
+        try:
+            self._wake_writer.send(b"x")
+        except OSError:
+            pass
+        self._thread.join(timeout=2)
+        self._listener.close()
+        self._wake_reader.close()
+        self._wake_writer.close()
+        try:
+            self.path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", default="bitrouter")
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--ca", type=Path)
+    return parser.parse_args()
+
+
+def require_file(path: Path | None) -> None:
+    if path is not None and not path.is_file():
+        raise IsolationFailure("the supplied control CA is unavailable")
+
+
+def require_token() -> str:
+    token = os.environ.get("CLIENT_READ_TOKEN")
+    if token is None or len(token) < 32:
+        raise IsolationFailure("CLIENT_READ_TOKEN must provide a reader credential")
+    return token
+
+
+def write_metering_database(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("CREATE TABLE local_trap (marker TEXT NOT NULL)")
+        connection.execute("INSERT INTO local_trap (marker) VALUES (?)", (METERING_SENTINEL,))
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def write_local_config(config: Path, socket_path: Path, database_path: Path) -> None:
+    config.write_text(
+        "\n".join(
+            [
+                f"# {CONFIG_SENTINEL}",
+                "server:",
+                '  listen: "127.0.0.1:4356"',
+                f'  control_socket: "{socket_path}"',
+                "  skip_auth: true",
+                "database:",
+                f'  url: "sqlite://{database_path}?mode=rwc"',
+                "inherit_defaults: false",
+                "registry:",
+                "  enabled: false",
+                "providers:",
+                "  local-trap:",
+                '    api_base: "http://127.0.0.1:9/v1"',
+                '    api_key: "${OPENAI_API_KEY}"',
+                "    api_protocol:",
+                '      - "*": chat_completions',
+                "    models:",
+                "      - id: local-trap-model",
+                "policy:",
+                '  path: "./local-trap-policy.yaml"',
+                "  mode: frozen",
+                "presets:",
+                "  local-trap:",
+                "    model: local-trap:local-trap-model",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def file_signature(path: Path) -> tuple[int, int, int]:
+    stat = path.stat()
+    return stat.st_ino, stat.st_size, stat.st_mtime_ns
+
+
+def directory_signature(path: Path) -> tuple[tuple[str, int, int, int], ...]:
+    rows: list[tuple[str, int, int, int]] = []
+    for candidate in sorted(path.rglob("*")):
+        if candidate.is_file():
+            stat = candidate.stat()
+            rows.append((str(candidate.relative_to(path)), stat.st_ino, stat.st_size, stat.st_mtime_ns))
+    return tuple(rows)
+
+
+def file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def directory_digest(path: Path) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (str(candidate.relative_to(path)), file_digest(candidate))
+        for candidate in sorted(path.rglob("*"))
+        if candidate.is_file()
+    )
+
+
+def run_setup(binary: str, environment: dict[str, str], args: list[str], cwd: Path) -> None:
+    completed = subprocess.run(
+        [binary, *args],
+        cwd=cwd,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise IsolationFailure("could not create an isolated remote context")
+
+
+def run_remote_failure(
+    label: str,
+    binary: str,
+    args: list[str],
+    environment: dict[str, str],
+    cwd: Path,
+    monitor: InotifyMonitor,
+    socket_traps: list[UnixSocketTrap],
+    config_signature: tuple[int, int, int],
+    metering_signature: tuple[tuple[str, int, int, int], ...],
+    required_markers: tuple[str, ...],
+) -> None:
+    monitor.drain()
+    initial_hits = [trap.hits for trap in socket_traps]
+    process = subprocess.Popen(
+        [binary, *args],
+        cwd=cwd,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + COMMAND_TIMEOUT_SECONDS
+    events: list[str] = []
+    while process.poll() is None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            process.kill()
+            process.communicate()
+            raise IsolationFailure(f"{label} did not complete within its bounded timeout")
+        select.select([monitor.fd], [], [], min(remaining, 0.25))
+        events.extend(monitor.drain())
+    stdout, stderr = process.communicate()
+    events.extend(monitor.drain())
+    combined = f"{stdout}\n{stderr}"
+    folded = combined.lower()
+
+    if process.returncode == 0:
+        raise IsolationFailure(f"{label} unexpectedly succeeded")
+    for sentinel in (CONFIG_SENTINEL, METERING_SENTINEL, PROVIDER_SENTINEL):
+        if sentinel.lower() in folded:
+            raise IsolationFailure(f"{label} disclosed a local sentinel")
+    if not any(marker in folded for marker in required_markers):
+        raise IsolationFailure(f"{label} did not report its expected remote failure")
+    if events:
+        raise IsolationFailure(f"{label} accessed a local file trap ({'; '.join(events)})")
+    if [trap.hits for trap in socket_traps] != initial_hits:
+        raise IsolationFailure(f"{label} contacted a local control-socket trap")
+    if config_signature != file_signature(_config_path(environment)):
+        raise IsolationFailure(f"{label} changed the local config trap")
+    if metering_signature != directory_signature(_metering_directory(environment)):
+        raise IsolationFailure(f"{label} changed the local metering trap")
+
+
+def _config_path(environment: dict[str, str]) -> Path:
+    return Path(environment["BITROUTER_HOME"]) / "bitrouter.yaml"
+
+
+def _metering_directory(environment: dict[str, str]) -> Path:
+    return Path(environment["TARGET_ISOLATION_METERING_DIR"])
+
+
+def reserve_unreachable_loopback_port() -> int:
+    reservation = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        reservation.bind(("127.0.0.1", 0))
+        return int(reservation.getsockname()[1])
+    finally:
+        reservation.close()
+
+
+def build_environment(home: Path, router_home: Path, metering_directory: Path, token: str) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(home),
+            "BITROUTER_HOME": str(router_home),
+            "CLIENT_READ_TOKEN": token,
+            "ISOLATION_READ_TOKEN": token,
+            "ISOLATION_WRONG_TOKEN": WRONG_TOKEN,
+            "OPENAI_API_KEY": PROVIDER_SENTINEL,
+            "TARGET_ISOLATION_METERING_DIR": str(metering_directory),
+        }
+    )
+    return environment
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    require_file(arguments.ca)
+    token = require_token()
+    binary = shutil.which(arguments.binary) or arguments.binary
+
+    with tempfile.TemporaryDirectory(prefix="bitrouter-target-isolation-") as temporary:
+        root = Path(temporary)
+        home = root / "home"
+        router_home = home / ".bitrouter"
+        workdir = root / "workdir"
+        metering_directory = root / "metering"
+        home.mkdir()
+        router_home.mkdir()
+        workdir.mkdir()
+        metering_directory.mkdir()
+
+        configured_socket = root / "configured-control.sock"
+        default_socket = router_home / "bitrouter.sock"
+        database = metering_directory / "local-metering.sqlite"
+        config = router_home / "bitrouter.yaml"
+        write_metering_database(database)
+        write_local_config(config, configured_socket, database)
+        environment = build_environment(home, router_home, metering_directory, token)
+        config_before = file_signature(config)
+        metering_before = directory_signature(metering_directory)
+        config_digest_before = file_digest(config)
+        metering_digest_before = directory_digest(metering_directory)
+
+        configured_trap = UnixSocketTrap(configured_socket)
+        default_trap = UnixSocketTrap(default_socket)
+        monitor: InotifyMonitor | None = None
+        try:
+            run_setup(
+                binary,
+                environment,
+                [
+                    "context",
+                    "add",
+                    "wrong-auth",
+                    "--endpoint",
+                    arguments.endpoint,
+                    "--token-env",
+                    "ISOLATION_WRONG_TOKEN",
+                ],
+                workdir,
+            )
+            unreachable_port = reserve_unreachable_loopback_port()
+            run_setup(
+                binary,
+                environment,
+                [
+                    "context",
+                    "add",
+                    "unreachable",
+                    "--endpoint",
+                    f"http://127.0.0.1:{unreachable_port}/control/v1",
+                    "--token-env",
+                    "ISOLATION_READ_TOKEN",
+                ],
+                workdir,
+            )
+
+            # Context metadata is deliberately local and expected. Start
+            # watching only after those client-local writes complete.
+            monitor = InotifyMonitor(
+                [
+                    ("local-config", config, FILE_WATCH_MASK),
+                    ("local-metering", database, FILE_WATCH_MASK),
+                    ("local-metering-directory", metering_directory, DIRECTORY_WATCH_MASK),
+                ]
+            )
+
+            wrong_auth_reads = [
+                ("wrong-token-status", ["--context", "wrong-auth", "status"]),
+                (
+                    "wrong-token-models",
+                    ["--context", "wrong-auth", "models", "--provider", "local-trap"],
+                ),
+                (
+                    "wrong-token-route",
+                    [
+                        "--context",
+                        "wrong-auth",
+                        "route",
+                        "local-trap/local-trap-model",
+                    ],
+                ),
+                (
+                    "wrong-token-requests",
+                    ["--context", "wrong-auth", "requests", "--limit", "1"],
+                ),
+                (
+                    "wrong-token-providers",
+                    ["--context", "wrong-auth", "providers", "list"],
+                ),
+                (
+                    "wrong-token-observe",
+                    ["--context", "wrong-auth", "observe", "status"],
+                ),
+                (
+                    "wrong-token-policy-status",
+                    ["--context", "wrong-auth", "policy", "status", "--view", "active"],
+                ),
+                (
+                    "wrong-token-policy-show",
+                    [
+                        "--context",
+                        "wrong-auth",
+                        "policy",
+                        "show",
+                        "local-trap",
+                        "--view",
+                        "active",
+                    ],
+                ),
+                (
+                    "wrong-token-agents",
+                    ["--context", "wrong-auth", "agents", "list"],
+                ),
+                (
+                    "wrong-token-operation-lookup",
+                    [
+                        "--context",
+                        "wrong-auth",
+                        "operations",
+                        "show",
+                        "00000000-0000-0000-0000-000000000000",
+                        "--instance",
+                        "00000000-0000-0000-0000-000000000000",
+                    ],
+                ),
+                ("wrong-token-reload", ["--context", "wrong-auth", "reload"]),
+            ]
+            for label, command in wrong_auth_reads:
+                run_remote_failure(
+                    label,
+                    binary,
+                    command,
+                    environment,
+                    workdir,
+                    monitor,
+                    [configured_trap, default_trap],
+                    config_before,
+                    metering_before,
+                    ("unauthorized", "401"),
+                )
+
+            for label, command in [
+                ("unreachable-status", ["--context", "unreachable", "status"]),
+                ("unreachable-requests", ["--context", "unreachable", "requests", "--limit", "1"]),
+                (
+                    "unreachable-providers",
+                    ["--context", "unreachable", "providers", "list"],
+                ),
+            ]:
+                run_remote_failure(
+                    label,
+                    binary,
+                    command,
+                    environment,
+                    workdir,
+                    monitor,
+                    [configured_trap, default_trap],
+                    config_before,
+                    metering_before,
+                    ("remote control endpoint",),
+                )
+
+            run_remote_failure(
+                "excluded-remote-agent-registry",
+                binary,
+                ["--context", "wrong-auth", "agents", "list", "--remote"],
+                environment,
+                workdir,
+                monitor,
+                [configured_trap, default_trap],
+                config_before,
+                metering_before,
+                ("cannot run against a remote bitrouter context",),
+            )
+        finally:
+            if monitor is not None:
+                monitor.close()
+            configured_trap.close()
+            default_trap.close()
+
+        if file_digest(config) != config_digest_before:
+            raise IsolationFailure("a remote failure changed the local config trap")
+        if directory_digest(metering_directory) != metering_digest_before:
+            raise IsolationFailure("a remote failure changed the local metering trap")
+
+    print('{"target_isolation":"passed","read_actions":9,"failure_modes":2}')
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (IsolationFailure, OSError, subprocess.SubprocessError) as error:
+        print(f"remote target-isolation acceptance failed: {error}", file=sys.stderr)
+        raise SystemExit(1) from None

--- a/tests/remote-administration/tls-proxy-entrypoint.sh
+++ b/tests/remote-administration/tls-proxy-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+exec socat \
+    OPENSSL-LISTEN:8443,reuseaddr,fork,cert=/tls/server.crt,key=/tls/server.key,verify=0 \
+    TCP:127.0.0.1:4358


### PR DESCRIPTION
Remote contexts currently expose only a small read surface. This change lets an authenticated administrator inspect router state and explicitly reload a remote daemon from the CLI or operations dashboard.

## Changes

- Share typed, redacted reports for status, models, route preview, bounded requests, providers, telemetry, agents, and active/disk policy across local and remote clients. Remote contexts never fall back to local config, sockets, or metering data.
- Add named bearer credentials with separate read/reload scopes and a canonical capability inventory. Legacy credentials remain read-only.
- Run reload through one coordinator for HTTP, local IPC, and SIGHUP. Retained operations use caller-owned request IDs, boot/generation guards, and same-ID deduplication so clients can recover a lost receipt without executing twice. Reports preserve failed, partially applied, and unknown outcomes.
- Add independent dashboard refresh state, passive remote agent catalogs, policy inspection controls, and explicit reload with operation receipts. Preserve main's native terminal scrollback and docked controls.
- Update the design spec, progress ledger, CLI reference, shipped agent guidance, generated schema, and Docker/PTY acceptance harness.

## Validation

Validated after merging `main` at `a59bd6b3`:

- All-feature nextest: **3,195 passed, 12 skipped**. One earlier timeout-sensitive worker-probe failure passed in the complete final rerun.
- Documentation tests: 5 passed, 1 ignored. All-feature Clippy, formatting, strict workspace rustdoc, and distribution/schema checks passed.
- Rebuilt Linux/ARM64 selected Docker acceptance passed: all CLI/REST reads, request filters, active/disk policy, authentication and local-input traps, successful CLI reload and retained lookup, lost receipt recovery, and successful/partial real-PTY dashboard journeys with terminal restoration.
- Bash/Python syntax, ShellCheck, terminal-emulator behavior checks, and diff checks passed. All eight extracted workspace packages compiled successfully before the main integration.

See `docs/REMOTE_ADMINISTRATION_PROGRESS.md` for the acceptance scope and evidence. The PTY harness handles main-screen cursor queries, scrolling, and synchronized frames; policy scrolling assertions compare content independently of refresh timestamps.

## Known limitation

The default Docker acceptance run exposes a pre-existing MCP Host allowlist restriction: TLS `/mcp-control` initialization with the deployment hostname `server:8443` returns HTTP 403. The baseline already uses rmcp's loopback-only default Host policy. Consequently, runtime `tools/list` and the three MCP control tool calls have not passed through this external TLS deployment. The harness preserves the real Host and fails explicitly; it does not bypass the guard.

The separately labeled `BITROUTER_REMOTE_ADMIN_SKIP_MCP=1` run covers CLI, REST, and dashboard behavior only. A deployment-owned MCP allowed-host configuration remains follow-up work. Docker uses isolated client/server containers, synthetic credentials, and a mock inference upstream; it does not establish physical-host or real-provider acceptance.
