### PR TITLE
feat(acp): add checkpoints and assessment revisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           - shard: interfaces
             retries: "0"
             targets: >-
-              --test acp --test cloud_api --test daemon --test e2e
+              --test acp --test acp_checkpoints --test cloud_api --test daemon --test e2e
               --test full_stack
           - shard: observability
             retries: "0"

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/assessment.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/assessment.rs
@@ -1,0 +1,338 @@
+//! Explicit revision selection prevents retry and checkpoint sample inflation.
+
+use super::*;
+
+async fn head(db: &impl ConnectionTrait, key: &str) -> Result<Option<String>> {
+    Ok(heads::Entity::find_by_id(key)
+        .one(db)
+        .await?
+        .and_then(|h| h.revision_id))
+}
+
+async fn revision(db: &impl ConnectionTrait, id: &str) -> Result<AssessmentRevision> {
+    let row = revisions::Entity::find_by_id(id)
+        .one(db)
+        .await?
+        .context("assessment revision missing")?;
+    Ok(serde_json::from_str(&row.revision_json)?)
+}
+
+fn validate_digest(value: &str) -> Result<()> {
+    let hex = value.strip_prefix("sha256:").unwrap_or(value);
+    ensure!(
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()),
+        "assessment digests must be lowercase SHA-256 values"
+    );
+    Ok(())
+}
+
+fn validate(input: &RevisionInput, cp: &Checkpoint) -> Result<()> {
+    ensure!(
+        !input.submission_id.trim().is_empty()
+            && !input.evaluator_id.trim().is_empty()
+            && !input.evaluator_version.trim().is_empty(),
+        "submission and evaluator identity are required"
+    );
+    if let Some(assessment) = &input.assessment {
+        validate_digest(&assessment.pipeline_config_digest)?;
+        validate_digest(&assessment.selection_digest)?;
+        ensure!(
+            !assessment.scores.is_empty(),
+            "assessment score vector is empty"
+        );
+        for (criterion, score) in &assessment.scores {
+            ensure!(!criterion.trim().is_empty(), "criterion ID is empty");
+            if let CriterionScore::Scored { value_ppm } = score {
+                ensure!(
+                    *value_ppm <= 1_000_000,
+                    "criterion score exceeds one million ppm"
+                );
+            }
+        }
+        let references: BTreeMap<_, _> = cp
+            .segments
+            .iter()
+            .flat_map(|s| s.events.iter().chain(&s.setup))
+            .map(|r| (r.node_id(), &r.digest))
+            .collect();
+        for cite in &assessment.evidence {
+            ensure!(
+                references
+                    .get(&cite.node_id)
+                    .is_some_and(|digest| **digest == cite.digest),
+                "evidence citation is not in this checkpoint or its digest differs"
+            );
+        }
+    } else {
+        ensure!(
+            !input.reason.trim().is_empty(),
+            "retraction requires a reason"
+        );
+        ensure!(
+            input.source == AssessmentSource::Human,
+            "automatic evaluation cannot retract a human-selected history"
+        );
+    }
+    Ok(())
+}
+
+impl CanonicalStore {
+    /// A submission key is idempotent. Explicit compare-and-set prevents an old
+    /// worker from overwriting a correction made while that worker was running.
+    pub async fn submit_assessment(
+        &self,
+        identity: &SessionIdentity,
+        input: RevisionInput,
+    ) -> Result<AssessmentRevision> {
+        let cp = self
+            .checkpoint_content(identity, &input.checkpoint_id)
+            .await?
+            .checkpoint;
+        validate(&input, &cp)?;
+        let key = identity.key()?;
+        let revision_id = digest(&(&key, &input.submission_id))?;
+        let input_digest = digest(&input)?;
+        let tx = self.db.begin().await?;
+        let keys: BTreeSet<_> = cp
+            .segments
+            .iter()
+            .map(|s| s.identity.key())
+            .collect::<Result<_>>()?;
+        for key in keys {
+            lock_session(&tx, &key).await?;
+        }
+        manifest(&tx, identity, &input.checkpoint_id).await?;
+        if let Some(existing) = revisions::Entity::find_by_id(&revision_id).one(&tx).await? {
+            let value: AssessmentRevision = serde_json::from_str(&existing.revision_json)?;
+            ensure!(
+                value.input_digest == input_digest,
+                "submission ID already used for different input"
+            );
+            tx.commit().await?;
+            return Ok(value);
+        }
+        let current_id = head(&tx, &key).await?;
+        ensure!(
+            current_id == input.expected_revision,
+            "effective revision changed; refresh before submitting"
+        );
+        let current = match &current_id {
+            Some(id) => Some(revision(&tx, id).await?),
+            None => None,
+        };
+        let mut selected = true;
+        let mut selection_reason = "selected";
+        if let Some(current) = &current {
+            let previous = manifest(&tx, identity, &current.input.checkpoint_id).await?;
+            if input.assessment.is_none() {
+                ensure!(
+                    current.input.assessment.is_some()
+                        && current.input.checkpoint_id == input.checkpoint_id,
+                    "retraction must target the current assessment"
+                );
+                selection_reason = "retracted";
+            } else if cp.watermark < previous.watermark {
+                selected = false;
+                selection_reason = "historical_checkpoint";
+            } else if cp.checkpoint_id == previous.checkpoint_id
+                && current.input.source == AssessmentSource::Human
+                && input.source == AssessmentSource::Agentic
+            {
+                selected = false;
+                selection_reason = "human_revision_preserved";
+            }
+        } else {
+            ensure!(
+                input.assessment.is_some(),
+                "no current assessment to retract"
+            );
+        }
+        let value = AssessmentRevision {
+            revision_id: revision_id.clone(),
+            input_digest,
+            input,
+            supersedes: if selected { current_id } else { None },
+            selected_on_submission: selected,
+            selection_reason: selection_reason.into(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+        revisions::ActiveModel {
+            revision_id: Set(revision_id.clone()),
+            session_key: Set(key.clone()),
+            checkpoint_id: Set(cp.checkpoint_id),
+            created_at: Set(value.created_at.clone()),
+            revision_json: Set(serde_json::to_string(&value)?),
+        }
+        .insert(&tx)
+        .await?;
+        if selected {
+            heads::Entity::insert(heads::ActiveModel {
+                session_key: Set(key),
+                revision_id: Set(Some(revision_id)),
+            })
+            .on_conflict(
+                OnConflict::column(heads::Column::SessionKey)
+                    .update_column(heads::Column::RevisionId)
+                    .to_owned(),
+            )
+            .exec(&tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(value)
+    }
+
+    pub async fn assessment_history(
+        &self,
+        identity: &SessionIdentity,
+    ) -> Result<Vec<AssessmentRevision>> {
+        session(&self.db, &identity.key()?).await?;
+        let rows = revisions::Entity::find()
+            .filter(revisions::Column::SessionKey.eq(identity.key()?))
+            .order_by_asc(revisions::Column::CreatedAt)
+            .order_by_asc(revisions::Column::RevisionId)
+            .all(&self.db)
+            .await?;
+        let mut result = Vec::new();
+        for row in rows {
+            manifest(&self.db, identity, &row.checkpoint_id).await?;
+            result.push(serde_json::from_str(&row.revision_json)?);
+        }
+        Ok(result)
+    }
+
+    /// Exactly one selected assessment per native session. Stale labels remain
+    /// visible, but are explicitly excluded from the current family label count.
+    pub async fn effective_assessment(
+        &self,
+        identity: &SessionIdentity,
+    ) -> Result<EffectiveAssessment> {
+        let key = identity.key()?;
+        let initial = session(&self.db, &key).await?;
+        let current_revision = head(&self.db, &key).await?;
+        let current = match &current_revision {
+            Some(id) => Some(revision(&self.db, id).await?),
+            None => None,
+        };
+        let checkpoint = if let Some(current) = &current {
+            Some(
+                self.checkpoint_content(identity, &current.input.checkpoint_id)
+                    .await?
+                    .checkpoint,
+            )
+        } else {
+            self.checkpoints(identity).await?.pop()
+        };
+        let mut reasons = Vec::new();
+        let stale = checkpoint
+            .as_ref()
+            .is_some_and(|cp| cp.watermark != initial.head);
+        if stale {
+            reasons.push("new_content_unassessed".into());
+        }
+        let mut resource = None;
+        if let Some(cp) = &checkpoint {
+            reasons.extend(cp.gaps.clone());
+            resource = self
+                .checkpoint_resource_history(identity, &cp.checkpoint_id)
+                .await?
+                .pop();
+        }
+        let assessment = match current {
+            Some(value) if value.input.assessment.is_some() => Some(value),
+            Some(_) => {
+                reasons.push("assessment_retracted".into());
+                None
+            }
+            None => {
+                reasons.push("no_assessment".into());
+                None
+            }
+        };
+        ensure!(
+            session(&self.db, &key).await? == initial
+                && head(&self.db, &key).await? == current_revision,
+            "effective assessment changed while reading; retry"
+        );
+        Ok(EffectiveAssessment {
+            identity: identity.clone(),
+            current_watermark: initial.head,
+            current_revision,
+            assessment,
+            checkpoint,
+            stale,
+            reasons,
+            resource,
+        })
+    }
+
+    /// Related forks form one cluster. Costs are a request union, while labels
+    /// remain separate native-session observations with explicit correlation.
+    pub async fn checkpoint_family(&self, identity: &SessionIdentity) -> Result<FamilyView> {
+        session(&self.db, &identity.key()?).await?;
+        let family_id = self.family_id(identity).await?;
+        let before = self.list(&identity.owner, &identity.source).await?;
+        let mut sessions = Vec::new();
+        let mut requests: BTreeMap<String, super::super::RequestAssociation> = BTreeMap::new();
+        let mut conflicts = BTreeSet::new();
+        let mut current_assessments = 0;
+        for row in &before {
+            let identity = native(row);
+            if self.family_id(&identity).await? != family_id {
+                continue;
+            }
+            let view = self.effective_assessment(&identity).await?;
+            if view.assessment.is_some() && !view.stale {
+                current_assessments += 1;
+            }
+            if let Some(resource) = &view.resource {
+                for request in &resource.requests {
+                    if let Some(existing) = requests.get(&request.request_id) {
+                        if existing.charge_micro_usd != request.charge_micro_usd
+                            || existing.model_id != request.model_id
+                            || existing.provider_id != request.provider_id
+                        {
+                            conflicts.insert(request.request_id.clone());
+                        }
+                    } else {
+                        requests.insert(request.request_id.clone(), request.clone());
+                    }
+                }
+            }
+            sessions.push(view);
+        }
+        for id in &conflicts {
+            if let Some(request) = requests.get_mut(id) {
+                request.charge_micro_usd = None;
+                request
+                    .basis
+                    .push_str("; conflicting_resource_observations");
+            }
+        }
+        ensure!(
+            self.list(&identity.owner, &identity.source).await? == before,
+            "family changed while reading; retry"
+        );
+        for view in &sessions {
+            ensure!(
+                head(&self.db, &view.identity.key()?).await? == view.current_revision,
+                "family assessment changed while reading; retry"
+            );
+        }
+        let requests: Vec<_> = requests.into_values().collect();
+        let (known_cost_micro_usd, unpriced_requests) = super::resource::totals(&requests)?;
+        Ok(FamilyView {
+            family_id,
+            sessions,
+            current_assessments,
+            requests,
+            conflicting_request_ids: conflicts.into_iter().collect(),
+            known_cost_micro_usd,
+            unpriced_requests,
+            metering_complete: false,
+        })
+    }
+}

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/assessment.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/assessment.rs
@@ -227,15 +227,36 @@ impl CanonicalStore {
             self.checkpoints(identity).await?.pop()
         };
         let mut reasons = Vec::new();
-        let stale = checkpoint
+        let mut stale = checkpoint
             .as_ref()
             .is_some_and(|cp| cp.watermark != initial.head);
         if stale {
             reasons.push("new_content_unassessed".into());
         }
         let mut resource = None;
+        let mut source_states = BTreeMap::new();
         if let Some(cp) = &checkpoint {
             reasons.extend(cp.gaps.clone());
+            // A recording failure can leave the canonical head unchanged. Keep
+            // the old checkpoint intact, but do not present its prior label as
+            // current when its own capture source subsequently became incomplete.
+            // Later changes to inherited parents do not alter a child's prefix.
+            if let Some(own) = cp.segments.last() {
+                for captured in &own.connections {
+                    let connection = connections::Entity::find_by_id(&captured.connection_id)
+                        .one(&self.db)
+                        .await?
+                        .context("capture connection missing")?;
+                    if connection.state == "interrupted" {
+                        reasons.push(format!(
+                            "source_capture_interrupted:{}",
+                            connection.connection_id
+                        ));
+                        stale |= captured.state != "interrupted";
+                    }
+                    source_states.insert(connection.connection_id, connection.state);
+                }
+            }
             resource = self
                 .checkpoint_resource_history(identity, &cp.checkpoint_id)
                 .await?
@@ -257,6 +278,15 @@ impl CanonicalStore {
                 && head(&self.db, &key).await? == current_revision,
             "effective assessment changed while reading; retry"
         );
+        for (id, state) in &source_states {
+            ensure!(
+                connections::Entity::find_by_id(id)
+                    .one(&self.db)
+                    .await?
+                    .is_some_and(|row| row.state == *state),
+                "capture health changed while reading; retry"
+            );
+        }
         Ok(EffectiveAssessment {
             identity: identity.clone(),
             current_watermark: initial.head,
@@ -265,6 +295,7 @@ impl CanonicalStore {
             checkpoint,
             stale,
             reasons,
+            source_capture_states: source_states,
             resource,
         })
     }
@@ -321,6 +352,15 @@ impl CanonicalStore {
                 head(&self.db, &view.identity.key()?).await? == view.current_revision,
                 "family assessment changed while reading; retry"
             );
+            for (id, state) in &view.source_capture_states {
+                ensure!(
+                    connections::Entity::find_by_id(id)
+                        .one(&self.db)
+                        .await?
+                        .is_some_and(|row| row.state == *state),
+                    "family capture health changed while reading; retry"
+                );
+            }
         }
         let requests: Vec<_> = requests.into_values().collect();
         let (known_cost_micro_usd, unpriced_requests) = super::resource::totals(&requests)?;

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/entities.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/entities.rs
@@ -1,0 +1,81 @@
+//! Application-owned checkpoint, revision and resource observation tables.
+
+pub mod checkpoints {
+    use sea_orm::entity::prelude::*;
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "acp_checkpoints")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub checkpoint_id: String,
+        pub session_key: String,
+        pub watermark: i64,
+        pub manifest_json: String,
+        pub deleted: bool,
+    }
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod members {
+    use sea_orm::entity::prelude::*;
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "acp_checkpoint_members")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub checkpoint_id: String,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub session_key: String,
+    }
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod resources {
+    use sea_orm::entity::prelude::*;
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "acp_resource_observations")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub observation_id: String,
+        pub checkpoint_id: String,
+        pub revision: i64,
+        pub observed_at: String,
+        pub observation_json: String,
+    }
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod revisions {
+    use sea_orm::entity::prelude::*;
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "acp_assessment_revisions")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub revision_id: String,
+        pub session_key: String,
+        pub checkpoint_id: String,
+        pub created_at: String,
+        pub revision_json: String,
+    }
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod heads {
+    use sea_orm::entity::prelude::*;
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "acp_effective_assessments")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub session_key: String,
+        pub revision_id: Option<String>,
+    }
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/mod.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/mod.rs
@@ -1,0 +1,517 @@
+//! Immutable native-session prefixes, assessment revisions and family views.
+//!
+//! Capture remains the only content source. These operations do not contact a
+//! harness, inspect a workspace, invoke a judge, or publish routing changes.
+
+mod assessment;
+pub mod entities;
+mod resource;
+#[cfg(test)]
+mod tests;
+pub mod types;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result, ensure};
+use bitrouter_sdk::acp::capture::{CaptureEvent, CaptureKind};
+use sea_orm::sea_query::{Expr, OnConflict};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseTransaction, EntityTrait, QueryFilter,
+    QueryOrder, Set, TransactionTrait,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::entities::{connections, events, sessions};
+use super::{CANONICAL_VERSION, CanonicalEvent, CanonicalStore, SessionIdentity};
+use entities::{checkpoints, heads, members, resources, revisions};
+use types::*;
+
+fn digest(value: &impl Serialize) -> Result<String> {
+    Ok(Sha256::digest(serde_json::to_vec(value)?)
+        .iter()
+        .map(|v| format!("{v:02x}"))
+        .collect())
+}
+
+fn reference(row: &events::Model) -> Result<EventReference> {
+    Ok(EventReference {
+        connection_id: row.connection_id.clone(),
+        sequence: row.sequence,
+        session_sequence: row.session_sequence,
+        digest: digest(&(
+            &row.event_json,
+            &row.captured_at,
+            &row.session_key,
+            row.session_sequence,
+        ))?,
+    })
+}
+
+fn content_digest(segments: &[PrefixSegment]) -> Result<String> {
+    let content: Vec<_> = segments
+        .iter()
+        .map(|s| {
+            (
+                &s.identity,
+                s.watermark,
+                &s.parent_key,
+                s.parent_watermark,
+                &s.events,
+                &s.setup,
+            )
+        })
+        .collect();
+    digest(&(CANONICAL_VERSION, content))
+}
+
+fn native(row: &sessions::Model) -> SessionIdentity {
+    SessionIdentity {
+        owner: row.owner.clone(),
+        source: row.source.clone(),
+        native_session_id: row.native_session_id.clone(),
+    }
+}
+
+async fn session(db: &impl ConnectionTrait, key: &str) -> Result<sessions::Model> {
+    let row = sessions::Entity::find_by_id(key)
+        .one(db)
+        .await?
+        .context("recorded native session not found")?;
+    ensure!(!row.deleted, "recorded ACP content was deleted");
+    Ok(row)
+}
+
+async fn lock_session(tx: &DatabaseTransaction, key: &str) -> Result<sessions::Model> {
+    // A write locks the row on every supported database, including SQLite.
+    // Do not inspect rows_affected: MySQL may report zero for an unchanged value.
+    sessions::Entity::update_many()
+        .col_expr(
+            sessions::Column::Head,
+            Expr::col(sessions::Column::Head).into(),
+        )
+        .filter(sessions::Column::SessionKey.eq(key))
+        .exec(tx)
+        .await?;
+    session(tx, key).await
+}
+
+async fn manifest(
+    db: &impl ConnectionTrait,
+    identity: &SessionIdentity,
+    id: &str,
+) -> Result<Checkpoint> {
+    let row = checkpoints::Entity::find_by_id(id)
+        .one(db)
+        .await?
+        .context("checkpoint not found")?;
+    ensure!(
+        row.session_key == identity.key()?,
+        "checkpoint belongs to a different native session"
+    );
+    ensure!(!row.deleted, "checkpoint content was deleted");
+    let cp: Checkpoint = serde_json::from_str(&row.manifest_json)?;
+    ensure!(
+        cp.schema_version == 1 && cp.canonical_version == CANONICAL_VERSION,
+        "unsupported checkpoint version"
+    );
+    ensure!(
+        cp.identity == *identity && cp.watermark == row.watermark,
+        "checkpoint identity or watermark mismatch"
+    );
+    ensure!(
+        content_digest(&cp.segments)? == cp.prefix_digest,
+        "checkpoint prefix digest mismatch"
+    );
+    ensure!(
+        digest(&(identity, cp.watermark, &cp.prefix_digest))? == id,
+        "checkpoint ID mismatch"
+    );
+    for segment in &cp.segments {
+        session(db, &segment.identity.key()?).await?;
+    }
+    Ok(cp)
+}
+
+impl CanonicalStore {
+    /// Freeze the observed current prefix. A stale expected watermark is an
+    /// error, not permission to silently evaluate a different input.
+    pub async fn freeze_checkpoint(
+        &self,
+        identity: &SessionIdentity,
+        expected_watermark: i64,
+    ) -> Result<Checkpoint> {
+        ensure!(expected_watermark >= 0, "watermark must be nonnegative");
+        let first = session(&self.db, &identity.key()?).await?;
+        ensure!(
+            first.head == expected_watermark,
+            "session changed; refresh the expected watermark"
+        );
+        let mut current = first.clone();
+        let mut watermark = expected_watermark;
+        let mut dependencies = BTreeMap::new();
+        let mut segments = Vec::new();
+        let mut gaps = BTreeSet::new();
+        loop {
+            ensure!(
+                !dependencies.contains_key(&current.session_key),
+                "cyclic native fork lineage"
+            );
+            dependencies.insert(current.session_key.clone(), current.clone());
+            ensure!(
+                watermark <= current.head,
+                "inherited watermark exceeds recorded parent history"
+            );
+            let (segment, segment_gaps) = self.prefix_segment(&current, watermark).await?;
+            gaps.extend(segment_gaps);
+            let parent = segment.parent_key.clone();
+            let parent_watermark = segment.parent_watermark;
+            segments.push(segment);
+            let Some(parent_key) = parent else {
+                break;
+            };
+            let Some(parent_watermark) = parent_watermark else {
+                gaps.insert(format!("parent_watermark_unknown:{parent_key}"));
+                break;
+            };
+            let Some(parent) = sessions::Entity::find_by_id(&parent_key)
+                .one(&self.db)
+                .await?
+            else {
+                gaps.insert(format!("parent_history_missing:{parent_key}"));
+                break;
+            };
+            ensure!(
+                parent.owner == identity.owner && parent.source == identity.source,
+                "fork lineage crosses native identity scope"
+            );
+            if parent.deleted {
+                gaps.insert(format!("parent_history_deleted:{parent_key}"));
+                break;
+            }
+            current = parent;
+            watermark = parent_watermark;
+        }
+        segments.reverse();
+        let prefix_digest = content_digest(&segments)?;
+        let checkpoint_id = digest(&(identity, expected_watermark, &prefix_digest))?;
+        let family_id = self.family_id(identity).await?;
+        let tx = self.db.begin().await?;
+        // Stable lock ordering prevents two overlapping fork freezes from
+        // acquiring parent/child locks in opposite orders.
+        for (key, expected) in &dependencies {
+            ensure!(
+                lock_session(&tx, key).await? == *expected,
+                "session changed while freezing; retry with a fresh prefix"
+            );
+        }
+        if checkpoints::Entity::find_by_id(&checkpoint_id)
+            .one(&tx)
+            .await?
+            .is_some()
+        {
+            let existing = manifest(&tx, identity, &checkpoint_id).await?;
+            tx.commit().await?;
+            self.observe_checkpoint_resources(identity, &checkpoint_id)
+                .await?;
+            return Ok(existing);
+        }
+        let previous = checkpoints::Entity::find()
+            .filter(checkpoints::Column::SessionKey.eq(identity.key()?))
+            .filter(checkpoints::Column::Deleted.eq(false))
+            .filter(checkpoints::Column::Watermark.lt(expected_watermark))
+            .order_by_desc(checkpoints::Column::Watermark)
+            .one(&tx)
+            .await?;
+        let cp = Checkpoint {
+            schema_version: 1,
+            canonical_version: CANONICAL_VERSION,
+            checkpoint_id: checkpoint_id.clone(),
+            identity: identity.clone(),
+            watermark: expected_watermark,
+            prefix_digest,
+            previous_checkpoint_id: previous.map(|row| row.checkpoint_id),
+            family_id,
+            segments,
+            gaps: gaps.into_iter().collect(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+        checkpoints::ActiveModel {
+            checkpoint_id: Set(checkpoint_id.clone()),
+            session_key: Set(identity.key()?),
+            watermark: Set(expected_watermark),
+            manifest_json: Set(serde_json::to_string(&cp)?),
+            deleted: Set(false),
+        }
+        .insert(&tx)
+        .await?;
+        for key in dependencies.keys() {
+            members::ActiveModel {
+                checkpoint_id: Set(checkpoint_id.clone()),
+                session_key: Set(key.clone()),
+            }
+            .insert(&tx)
+            .await?;
+        }
+        tx.commit().await?;
+        self.observe_checkpoint_resources(identity, &checkpoint_id)
+            .await?;
+        Ok(cp)
+    }
+
+    async fn prefix_segment(
+        &self,
+        row: &sessions::Model,
+        watermark: i64,
+    ) -> Result<(PrefixSegment, Vec<String>)> {
+        let rows = events::Entity::find()
+            .filter(events::Column::SessionKey.eq(&row.session_key))
+            .filter(events::Column::SessionSequence.lte(watermark))
+            .filter(events::Column::Replay.eq(false))
+            .order_by_asc(events::Column::SessionSequence)
+            .all(&self.db)
+            .await?;
+        let mut gaps = Vec::new();
+        if rows.len() as u128 != watermark as u128
+            || rows
+                .iter()
+                .enumerate()
+                .any(|(i, r)| r.session_sequence != Some(i as i64 + 1))
+        {
+            gaps.push(format!("canonical_sequence_gap:{}", row.session_key));
+        }
+        let mut events = Vec::new();
+        let mut setup = Vec::new();
+        let mut connection_ids = BTreeSet::new();
+        let mut setup_calls = Vec::new();
+        let mut pending = BTreeSet::new();
+        let mut observed_new = false;
+        let mut observed_fork = false;
+        for raw in &rows {
+            connection_ids.insert(raw.connection_id.clone());
+            let event: CaptureEvent = serde_json::from_str(&raw.event_json)?;
+            if let Some(call) = event.call_id {
+                let key = (raw.connection_id.clone(), call);
+                match event.kind {
+                    CaptureKind::Request => {
+                        pending.insert(key);
+                    }
+                    CaptureKind::Response => {
+                        pending.remove(&key);
+                    }
+                    _ => {}
+                }
+                if event.kind == CaptureKind::Response
+                    && event
+                        .payload
+                        .get("result")
+                        .and_then(|r| r.get("sessionId"))
+                        .is_some()
+                {
+                    observed_new |= event.method == "session/new";
+                    observed_fork |= event.method == "session/fork";
+                    if matches!(event.method.as_str(), "session/new" | "session/fork") {
+                        setup_calls.push((raw.connection_id.clone(), call, event.method.clone()));
+                    }
+                }
+            }
+            if matches!(event.method.as_str(), "session/load" | "session/resume") {
+                gaps.push(format!(
+                    "history_across_load_or_resume_unknown:{}",
+                    raw.connection_id
+                ));
+            }
+            events.push(reference(raw)?);
+        }
+        if !pending.is_empty() {
+            gaps.push(format!("requests_pending_at_watermark:{}", row.session_key));
+        }
+        for (connection, call, method) in setup_calls {
+            let candidates = super::events::Entity::find()
+                .filter(super::events::Column::ConnectionId.eq(&connection))
+                .all(&self.db)
+                .await?;
+            let mut found = false;
+            for raw in candidates {
+                let event: CaptureEvent = serde_json::from_str(&raw.event_json)?;
+                if event.kind == CaptureKind::Request
+                    && event.call_id == Some(call)
+                    && event.method == method
+                {
+                    setup.push(reference(&raw)?);
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                gaps.push(format!("setup_evidence_missing:{connection}:{call}"));
+            }
+        }
+        if row.history_origin == "native_id_reused" {
+            gaps.push(format!("native_identity_reused:{}", row.session_key));
+        } else if !observed_new && !observed_fork {
+            gaps.push(format!(
+                "history_before_recording_unknown:{}",
+                row.session_key
+            ));
+        }
+        let mut observed_connections = Vec::new();
+        for id in connection_ids {
+            let connection = connections::Entity::find_by_id(&id)
+                .one(&self.db)
+                .await?
+                .context("capture connection missing")?;
+            if connection.state == "interrupted" {
+                gaps.push(format!("capture_interrupted:{id}"));
+            }
+            observed_connections.push(ConnectionObservation {
+                connection_id: id,
+                state: connection.state,
+                controller_instance_id: connection.controller_instance_id,
+                route_scope_id: connection.route_scope_id,
+                metadata: serde_json::from_str(&connection.metadata_json)?,
+            });
+        }
+        Ok((
+            PrefixSegment {
+                identity: native(row),
+                watermark,
+                parent_key: if observed_fork {
+                    row.parent_key.clone()
+                } else {
+                    None
+                },
+                parent_watermark: if observed_fork {
+                    row.parent_watermark
+                } else {
+                    None
+                },
+                events,
+                setup,
+                connections: observed_connections,
+                boundary_at: rows
+                    .last()
+                    .map(|r| r.captured_at.clone())
+                    .unwrap_or_default(),
+            },
+            gaps,
+        ))
+    }
+
+    pub async fn checkpoints(&self, identity: &SessionIdentity) -> Result<Vec<Checkpoint>> {
+        session(&self.db, &identity.key()?).await?;
+        let rows = checkpoints::Entity::find()
+            .filter(checkpoints::Column::SessionKey.eq(identity.key()?))
+            .filter(checkpoints::Column::Deleted.eq(false))
+            .order_by_asc(checkpoints::Column::Watermark)
+            .all(&self.db)
+            .await?;
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(manifest(&self.db, identity, &row.checkpoint_id).await?);
+        }
+        Ok(result)
+    }
+
+    pub async fn checkpoint_content(
+        &self,
+        identity: &SessionIdentity,
+        id: &str,
+    ) -> Result<CheckpointContent> {
+        let cp = manifest(&self.db, identity, id).await?;
+        let mut canonical = Vec::new();
+        let mut setup = Vec::new();
+        for segment in &cp.segments {
+            for (refs, target) in [
+                (&segment.events, &mut canonical),
+                (&segment.setup, &mut setup),
+            ] {
+                for expected in refs {
+                    let row = events::Entity::find_by_id((
+                        expected.connection_id.clone(),
+                        expected.sequence,
+                    ))
+                    .one(&self.db)
+                    .await?
+                    .context("checkpoint source event missing")?;
+                    ensure!(
+                        reference(&row)? == *expected,
+                        "checkpoint source content changed"
+                    );
+                    target.push(CanonicalEvent {
+                        node_id: expected.node_id(),
+                        sequence: expected.session_sequence.unwrap_or_default(),
+                        captured_at: row.captured_at,
+                        event: serde_json::from_str(&row.event_json)?,
+                    });
+                }
+            }
+        }
+        // A deletion during the reads must invalidate the whole export.
+        manifest(&self.db, identity, id).await?;
+        Ok(CheckpointContent {
+            checkpoint: cp,
+            events: canonical,
+            setup,
+        })
+    }
+
+    async fn family_id(&self, identity: &SessionIdentity) -> Result<String> {
+        let mut key = identity.key()?;
+        let mut visited = BTreeSet::new();
+        loop {
+            ensure!(visited.insert(key.clone()), "cyclic native fork lineage");
+            let Some(row) = sessions::Entity::find_by_id(&key).one(&self.db).await? else {
+                return Ok(key);
+            };
+            ensure!(
+                row.owner == identity.owner && row.source == identity.source,
+                "fork lineage crosses native identity scope"
+            );
+            match row.parent_key {
+                Some(parent) => key = parent,
+                None => return Ok(key),
+            }
+        }
+    }
+}
+
+/// Content deletion invalidates every checkpoint which references the source,
+/// including child checkpoints. Assessment explanations can quote that content.
+pub(super) async fn delete_dependents(tx: &DatabaseTransaction, key: &str) -> Result<()> {
+    let affected = members::Entity::find()
+        .filter(members::Column::SessionKey.eq(key))
+        .all(tx)
+        .await?;
+    for member in affected {
+        let revisions = revisions::Entity::find()
+            .filter(revisions::Column::CheckpointId.eq(&member.checkpoint_id))
+            .all(tx)
+            .await?;
+        for revision in revisions {
+            heads::Entity::update_many()
+                .col_expr(
+                    heads::Column::RevisionId,
+                    Expr::value(Option::<String>::None),
+                )
+                .filter(heads::Column::RevisionId.eq(revision.revision_id))
+                .exec(tx)
+                .await?;
+        }
+        revisions::Entity::delete_many()
+            .filter(revisions::Column::CheckpointId.eq(&member.checkpoint_id))
+            .exec(tx)
+            .await?;
+        resources::Entity::delete_many()
+            .filter(resources::Column::CheckpointId.eq(&member.checkpoint_id))
+            .exec(tx)
+            .await?;
+        checkpoints::Entity::update_many()
+            .col_expr(checkpoints::Column::Deleted, Expr::value(true))
+            .col_expr(checkpoints::Column::ManifestJson, Expr::value("{}"))
+            .filter(checkpoints::Column::CheckpointId.eq(&member.checkpoint_id))
+            .exec(tx)
+            .await?;
+    }
+    Ok(())
+}

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/resource.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/resource.rs
@@ -1,0 +1,148 @@
+//! Resource snapshots can advance without mutating an immutable content prefix.
+
+use super::*;
+
+fn at_or_before(value: &str, boundary: &str) -> Result<bool> {
+    if boundary.is_empty() {
+        return Ok(false);
+    }
+    Ok(chrono::DateTime::parse_from_rfc3339(value)?
+        <= chrono::DateTime::parse_from_rfc3339(boundary)?)
+}
+
+pub(super) fn totals(requests: &[super::super::RequestAssociation]) -> Result<(i64, usize)> {
+    let mut known = 0_i64;
+    let mut unknown = 0;
+    for request in requests {
+        if let Some(cost) = request.charge_micro_usd {
+            known = known.checked_add(cost).context("request cost overflow")?;
+        } else {
+            unknown += 1;
+        }
+    }
+    Ok((known, unknown))
+}
+
+impl CanonicalStore {
+    /// Refresh only already stored metering and route observations. No receipt
+    /// fetch or other external validation is started by this operation.
+    pub async fn observe_checkpoint_resources(
+        &self,
+        identity: &SessionIdentity,
+        id: &str,
+    ) -> Result<ResourceObservation> {
+        let cp = self.checkpoint_content(identity, id).await?.checkpoint;
+        let mut requests = BTreeMap::new();
+        let mut unassigned = BTreeSet::new();
+        for segment in &cp.segments {
+            let mut scoped = Vec::new();
+            for captured in &segment.connections {
+                let row = connections::Entity::find_by_id(&captured.connection_id)
+                    .one(&self.db)
+                    .await?
+                    .context("capture connection missing")?;
+                ensure!(
+                    row.controller_instance_id == captured.controller_instance_id
+                        && row.route_scope_id == captured.route_scope_id,
+                    "recording scope changed"
+                );
+                scoped.push(row);
+            }
+            for mut request in self.associated_requests(&segment.identity, &scoped).await? {
+                let mut preceding = Vec::new();
+                for event in request.route_events {
+                    if at_or_before(&event.captured_at, &segment.boundary_at)? {
+                        preceding.push(event);
+                    }
+                }
+                let metered_before = at_or_before(&request.first_metered_at, &segment.boundary_at)?;
+                if preceding.is_empty() && !metered_before {
+                    unassigned.insert(request.request_id);
+                    continue;
+                }
+                request.route_events = preceding;
+                request.basis.push_str(if metered_before {
+                    "; metered_before_prefix_boundary"
+                } else {
+                    "; route_evidence_before_prefix_boundary"
+                });
+                requests.insert(request.request_id.clone(), request);
+            }
+        }
+        unassigned.retain(|id| !requests.contains_key(id));
+        let requests: Vec<_> = requests.into_values().collect();
+        let unassigned_request_ids: Vec<_> = unassigned.into_iter().collect();
+        let (known_cost_micro_usd, unpriced_requests) = totals(&requests)?;
+        let content_digest = digest(&(&requests, &unassigned_request_ids))?;
+        let mut observation = ResourceObservation {
+            observation_id: String::new(),
+            checkpoint_id: id.into(),
+            revision: 1,
+            previous_observation_id: None,
+            observed_at: chrono::Utc::now().to_rfc3339(),
+            requests,
+            unassigned_request_ids,
+            known_cost_micro_usd,
+            unpriced_requests,
+            metering_complete: false,
+        };
+        let tx = self.db.begin().await?;
+        let keys: BTreeSet<_> = cp
+            .segments
+            .iter()
+            .map(|s| s.identity.key())
+            .collect::<Result<_>>()?;
+        for key in keys {
+            lock_session(&tx, &key).await?;
+        }
+        manifest(&tx, identity, id).await?;
+        if let Some(existing) = resources::Entity::find()
+            .filter(resources::Column::CheckpointId.eq(id))
+            .order_by_desc(resources::Column::Revision)
+            .one(&tx)
+            .await?
+        {
+            let previous: ResourceObservation = serde_json::from_str(&existing.observation_json)?;
+            if digest(&(&previous.requests, &previous.unassigned_request_ids))? == content_digest {
+                tx.commit().await?;
+                return Ok(previous);
+            }
+            observation.revision = previous
+                .revision
+                .checked_add(1)
+                .context("resource revision overflow")?;
+            observation.previous_observation_id = Some(previous.observation_id);
+        }
+        observation.observation_id = digest(&(id, observation.revision, &content_digest))?;
+        resources::ActiveModel {
+            observation_id: Set(observation.observation_id.clone()),
+            checkpoint_id: Set(id.into()),
+            revision: Set(observation.revision),
+            observed_at: Set(observation.observed_at.clone()),
+            observation_json: Set(serde_json::to_string(&observation)?),
+        }
+        .insert(&tx)
+        .await?;
+        tx.commit().await?;
+        Ok(observation)
+    }
+
+    pub async fn checkpoint_resource_history(
+        &self,
+        identity: &SessionIdentity,
+        id: &str,
+    ) -> Result<Vec<ResourceObservation>> {
+        manifest(&self.db, identity, id).await?;
+        let rows = resources::Entity::find()
+            .filter(resources::Column::CheckpointId.eq(id))
+            .order_by_asc(resources::Column::Revision)
+            .all(&self.db)
+            .await?;
+        let result = rows
+            .into_iter()
+            .map(|r| serde_json::from_str(&r.observation_json).map_err(Into::into))
+            .collect();
+        manifest(&self.db, identity, id).await?;
+        result
+    }
+}

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/tests.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/tests.rs
@@ -601,3 +601,62 @@ async fn long_session_manifests_and_large_assessments_round_trip() -> Result<()>
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn interruption_after_scoring_invalidates_freshness_without_rewriting_the_prefix()
+-> Result<()> {
+    let store = store().await?;
+    let recorder = store.recorder(scope()).await?;
+    new_session(recorder.as_ref(), "s").await?;
+    let cp = freeze(&store, "s").await?;
+    let label = store
+        .submit_assessment(
+            &identity("s"),
+            input(&cp, "scored", None, AssessmentSource::Human),
+        )
+        .await?;
+    assert!(!store.effective_assessment(&identity("s")).await?.stale);
+    let original = serde_json::to_value(
+        store
+            .checkpoint_content(&identity("s"), &cp.checkpoint_id)
+            .await?,
+    )?;
+    recorder
+        .record(event(
+            CaptureKind::Disconnected,
+            None,
+            "controller/disconnected",
+            json!({"clean":false}),
+        ))
+        .await?;
+    let view = store.effective_assessment(&identity("s")).await?;
+    assert_eq!(view.current_watermark, cp.watermark);
+    assert!(view.stale);
+    assert!(
+        view.reasons
+            .iter()
+            .any(|r| r.starts_with("source_capture_interrupted:"))
+    );
+    assert_eq!(
+        view.assessment
+            .context("historical assessment")?
+            .revision_id,
+        label.revision_id
+    );
+    assert_eq!(
+        store
+            .checkpoint_family(&identity("s"))
+            .await?
+            .current_assessments,
+        0
+    );
+    assert_eq!(
+        serde_json::to_value(
+            store
+                .checkpoint_content(&identity("s"), &cp.checkpoint_id)
+                .await?
+        )?,
+        original
+    );
+    Ok(())
+}

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/tests.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/tests.rs
@@ -1,0 +1,603 @@
+use bitrouter_sdk::acp::capture::CapturePort;
+use serde_json::json;
+
+use super::*;
+use crate::acp_trajectory::tests::{event, identity, new_session, scope, seed_request, store};
+
+async fn update(recorder: &dyn CapturePort, session: &str, text: &str) -> Result<()> {
+    recorder.record(event(CaptureKind::Notification, None, "session/update", json!({"sessionId":session,"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":text}}}))).await?;
+    Ok(())
+}
+
+async fn freeze(store: &CanonicalStore, id: &str) -> Result<Checkpoint> {
+    let identity = identity(id);
+    let head = session(&store.db, &identity.key()?).await?.head;
+    store.freeze_checkpoint(&identity, head).await
+}
+
+fn input(
+    cp: &Checkpoint,
+    id: &str,
+    expected: Option<&str>,
+    source: AssessmentSource,
+) -> RevisionInput {
+    RevisionInput {
+        submission_id: id.into(),
+        checkpoint_id: cp.checkpoint_id.clone(),
+        expected_revision: expected.map(str::to_owned),
+        source,
+        evaluator_id: "fixture-evaluator".into(),
+        evaluator_version: "1".into(),
+        reason: "recorded evidence".into(),
+        assessment: Some(AssessmentContent {
+            pipeline_config_digest: "a".repeat(64),
+            selection_digest: "b".repeat(64),
+            scores: BTreeMap::from([
+                (
+                    "correctness".into(),
+                    CriterionScore::Scored { value_ppm: 500_000 },
+                ),
+                ("delivery".into(), CriterionScore::Unknown),
+                ("pr".into(), CriterionScore::NotApplicable),
+            ]),
+            evidence: cp
+                .segments
+                .iter()
+                .flat_map(|s| &s.events)
+                .take(1)
+                .map(|r| EvidenceCitation {
+                    node_id: r.node_id(),
+                    digest: r.digest.clone(),
+                })
+                .collect(),
+            explanation: "fixture judgment".into(),
+        }),
+    }
+}
+
+#[tokio::test]
+async fn immutable_prefixes_keep_old_tool_versions_and_detect_content_corruption() -> Result<()> {
+    let store = store().await?;
+    let recorder = store.recorder(scope()).await?;
+    new_session(recorder.as_ref(), "s").await?;
+    recorder.record(event(CaptureKind::Notification, None, "session/update", json!({"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"test","status":"in_progress"}}))).await?;
+    let cp = freeze(&store, "s").await?;
+    assert!(
+        cp.gaps.is_empty(),
+        "an open connection alone does not invalidate a fixed prefix"
+    );
+    assert_eq!(cp.segments[0].setup.len(), 1);
+    assert_eq!(freeze(&store, "s").await?.checkpoint_id, cp.checkpoint_id);
+    let before = serde_json::to_value(
+        store
+            .checkpoint_content(&identity("s"), &cp.checkpoint_id)
+            .await?,
+    )?;
+    recorder.record(event(CaptureKind::Notification, None, "session/update", json!({"sessionId":"s","update":{"sessionUpdate":"tool_call_update","toolCallId":"test","status":"completed"}}))).await?;
+    assert!(
+        store
+            .freeze_checkpoint(&identity("s"), cp.watermark)
+            .await
+            .is_err()
+    );
+    let next = freeze(&store, "s").await?;
+    assert_eq!(
+        next.previous_checkpoint_id.as_deref(),
+        Some(cp.checkpoint_id.as_str())
+    );
+    assert_eq!(
+        serde_json::to_value(
+            store
+                .checkpoint_content(&identity("s"), &cp.checkpoint_id)
+                .await?
+        )?,
+        before
+    );
+    assert!(
+        store
+            .checkpoint_content(&identity("other"), &cp.checkpoint_id)
+            .await
+            .is_err()
+    );
+    let node = cp.segments[0].events.last().context("tool event")?;
+    events::Entity::update_many()
+        .col_expr(events::Column::EventJson, Expr::value("{}"))
+        .filter(events::Column::ConnectionId.eq(&node.connection_id))
+        .filter(events::Column::Sequence.eq(node.sequence))
+        .exec(&store.db)
+        .await?;
+    assert!(
+        store
+            .checkpoint_content(&identity("s"), &cp.checkpoint_id)
+            .await
+            .is_err()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revision_cas_retries_corrections_and_retractions_preserve_one_label() -> Result<()> {
+    let store = store().await?;
+    let recorder = store.recorder(scope()).await?;
+    new_session(recorder.as_ref(), "s").await?;
+    let cp = freeze(&store, "s").await?;
+    let auto_input = input(&cp, "auto", None, AssessmentSource::Agentic);
+    let auto = store
+        .submit_assessment(&identity("s"), auto_input.clone())
+        .await?;
+    assert_eq!(
+        store
+            .submit_assessment(&identity("s"), auto_input.clone())
+            .await?
+            .revision_id,
+        auto.revision_id
+    );
+    let mut collision = auto_input;
+    collision.reason = "different input".into();
+    assert!(
+        store
+            .submit_assessment(&identity("s"), collision)
+            .await
+            .is_err()
+    );
+    let human = store
+        .submit_assessment(
+            &identity("s"),
+            input(
+                &cp,
+                "human",
+                Some(&auto.revision_id),
+                AssessmentSource::Human,
+            ),
+        )
+        .await?;
+    assert_eq!(human.supersedes.as_deref(), Some(auto.revision_id.as_str()));
+    assert!(
+        store
+            .submit_assessment(
+                &identity("s"),
+                input(
+                    &cp,
+                    "late",
+                    Some(&auto.revision_id),
+                    AssessmentSource::Agentic
+                )
+            )
+            .await
+            .is_err()
+    );
+    let late = store
+        .submit_assessment(
+            &identity("s"),
+            input(
+                &cp,
+                "later",
+                Some(&human.revision_id),
+                AssessmentSource::Agentic,
+            ),
+        )
+        .await?;
+    assert!(!late.selected_on_submission);
+    assert_eq!(late.selection_reason, "human_revision_preserved");
+    assert_eq!(
+        store
+            .checkpoint_family(&identity("s"))
+            .await?
+            .current_assessments,
+        1
+    );
+    update(recorder.as_ref(), "s", "late negative feedback").await?;
+    assert!(store.effective_assessment(&identity("s")).await?.stale);
+    assert_eq!(
+        store
+            .checkpoint_family(&identity("s"))
+            .await?
+            .current_assessments,
+        0
+    );
+    let next = freeze(&store, "s").await?;
+    let next_revision = store
+        .submit_assessment(
+            &identity("s"),
+            input(
+                &next,
+                "next",
+                Some(&human.revision_id),
+                AssessmentSource::Agentic,
+            ),
+        )
+        .await?;
+    assert!(next_revision.selected_on_submission);
+    let historical = store
+        .submit_assessment(
+            &identity("s"),
+            input(
+                &cp,
+                "historical",
+                Some(&next_revision.revision_id),
+                AssessmentSource::Human,
+            ),
+        )
+        .await?;
+    assert!(!historical.selected_on_submission);
+    assert_eq!(historical.selection_reason, "historical_checkpoint");
+    let mut retract = input(
+        &next,
+        "retract",
+        Some(&next_revision.revision_id),
+        AssessmentSource::Human,
+    );
+    retract.assessment = None;
+    let retracted = store
+        .submit_assessment(&identity("s"), retract.clone())
+        .await?;
+    assert_eq!(
+        store
+            .submit_assessment(&identity("s"), retract)
+            .await?
+            .revision_id,
+        retracted.revision_id
+    );
+    let view = store.effective_assessment(&identity("s")).await?;
+    assert!(view.assessment.is_none());
+    assert_eq!(view.current_revision, Some(retracted.revision_id));
+    assert_eq!(store.assessment_history(&identity("s")).await?.len(), 6);
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_labels_and_out_of_prefix_citations_are_rejected() -> Result<()> {
+    let store = store().await?;
+    let recorder = store.recorder(scope()).await?;
+    new_session(recorder.as_ref(), "s").await?;
+    let cp = freeze(&store, "s").await?;
+    for field in ["assessment", "expected_revision"] {
+        let mut incomplete =
+            serde_json::to_value(input(&cp, "missing", None, AssessmentSource::Human))?;
+        incomplete
+            .as_object_mut()
+            .context("input object")?
+            .remove(field);
+        assert!(
+            serde_json::from_value::<RevisionInput>(incomplete).is_err(),
+            "{field} must be explicit"
+        );
+    }
+    let mut bad = input(&cp, "invalid", None, AssessmentSource::Human);
+    let assessment = bad.assessment.as_mut().context("assessment")?;
+    assessment.scores.insert(
+        "bad".into(),
+        CriterionScore::Scored {
+            value_ppm: 1_000_001,
+        },
+    );
+    assert!(store.submit_assessment(&identity("s"), bad).await.is_err());
+    let mut bad = input(&cp, "citation", None, AssessmentSource::Human);
+    bad.assessment
+        .as_mut()
+        .context("assessment")?
+        .evidence
+        .push(EvidenceCitation {
+            node_id: "missing:99".into(),
+            digest: "a".repeat(64),
+        });
+    assert!(store.submit_assessment(&identity("s"), bad).await.is_err());
+    assert!(store.assessment_history(&identity("s")).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn late_metering_changes_resources_without_changing_content_or_labels() -> Result<()> {
+    use crate::metering::entities::requests;
+    let store = store().await?;
+    let recorder = store.recorder(scope()).await?;
+    seed_request(&store, "r", "principal", "s", 0, "unknown").await?;
+    new_session(recorder.as_ref(), "s").await?;
+    let cp = freeze(&store, "s").await?;
+    let original = store
+        .checkpoint_resource_history(&identity("s"), &cp.checkpoint_id)
+        .await?
+        .pop()
+        .context("initial observation")?;
+    assert_eq!(original.unpriced_requests, 1);
+    requests::Entity::update_many()
+        .col_expr(requests::Column::ChargeStatus, Expr::value("computed"))
+        .col_expr(
+            requests::Column::EstimatedChargeMicroUsd,
+            Expr::value(17_i64),
+        )
+        .filter(requests::Column::RequestId.eq("r"))
+        .exec(&store.db)
+        .await?;
+    seed_request(&store, "after", "principal", "s", 99, "computed").await?;
+    let refreshed = store
+        .observe_checkpoint_resources(&identity("s"), &cp.checkpoint_id)
+        .await?;
+    assert_eq!(refreshed.known_cost_micro_usd, 17);
+    assert_eq!(refreshed.unassigned_request_ids, vec!["after"]);
+    assert_ne!(original.observation_id, refreshed.observation_id);
+    assert_eq!(
+        store
+            .observe_checkpoint_resources(&identity("s"), &cp.checkpoint_id)
+            .await?
+            .observation_id,
+        refreshed.observation_id
+    );
+    assert_eq!(
+        store
+            .checkpoint_resource_history(&identity("s"), &cp.checkpoint_id)
+            .await?
+            .len(),
+        2
+    );
+    requests::Entity::update_many()
+        .col_expr(requests::Column::ChargeStatus, Expr::value("unknown"))
+        .filter(requests::Column::RequestId.eq("r"))
+        .exec(&store.db)
+        .await?;
+    let unknown_again = store
+        .observe_checkpoint_resources(&identity("s"), &cp.checkpoint_id)
+        .await?;
+    assert_eq!(unknown_again.revision, 3);
+    requests::Entity::update_many()
+        .col_expr(requests::Column::ChargeStatus, Expr::value("computed"))
+        .filter(requests::Column::RequestId.eq("r"))
+        .exec(&store.db)
+        .await?;
+    let priced_again = store
+        .observe_checkpoint_resources(&identity("s"), &cp.checkpoint_id)
+        .await?;
+    assert_eq!(priced_again.revision, 4);
+    assert_ne!(priced_again.observation_id, refreshed.observation_id);
+    assert_eq!(
+        store
+            .checkpoint_resource_history(&identity("s"), &cp.checkpoint_id)
+            .await?
+            .pop()
+            .context("latest resource")?
+            .known_cost_micro_usd,
+        17
+    );
+    assert_eq!(freeze(&store, "s").await?.prefix_digest, cp.prefix_digest);
+    update(recorder.as_ref(), "s", "continued").await?;
+    let next = freeze(&store, "s").await?;
+    assert_eq!(
+        store
+            .checkpoint_resource_history(&identity("s"), &next.checkpoint_id)
+            .await?
+            .pop()
+            .context("next resource")?
+            .known_cost_micro_usd,
+        116
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn inherited_prefixes_family_unions_and_deletion_preserve_native_scope() -> Result<()> {
+    let store = store().await?;
+    let recorder = store.recorder(scope()).await?;
+    new_session(recorder.as_ref(), "parent").await?;
+    seed_request(&store, "root", "principal", "parent", 5, "computed").await?;
+    update(recorder.as_ref(), "parent", "inherited").await?;
+    let parent_boundary = freeze(&store, "parent").await?;
+    recorder
+        .record(event(
+            CaptureKind::Request,
+            Some(2),
+            "session/fork",
+            json!({"sessionId":"parent"}),
+        ))
+        .await?;
+    recorder
+        .record(event(
+            CaptureKind::Response,
+            Some(2),
+            "session/fork",
+            json!({"result":{"sessionId":"child"}}),
+        ))
+        .await?;
+    seed_request(&store, "child-request", "principal", "child", 7, "computed").await?;
+    update(recorder.as_ref(), "child", "child work").await?;
+    update(recorder.as_ref(), "parent", "not inherited").await?;
+    let child = freeze(&store, "child").await?;
+    let parent = freeze(&store, "parent").await?;
+    assert_eq!(child.family_id, identity("parent").key()?);
+    assert_eq!(child.segments.len(), 2);
+    assert_eq!(child.segments[0].watermark, parent_boundary.watermark);
+    let content = store
+        .checkpoint_content(&identity("child"), &child.checkpoint_id)
+        .await?;
+    let text = serde_json::to_string(&content)?;
+    assert!(text.contains("inherited"));
+    assert!(!text.contains("not inherited"));
+    assert_eq!(child.segments[0].events, parent_boundary.segments[0].events);
+    store
+        .submit_assessment(
+            &identity("parent"),
+            input(&parent, "p", None, AssessmentSource::Human),
+        )
+        .await?;
+    store
+        .submit_assessment(
+            &identity("child"),
+            input(&child, "c", None, AssessmentSource::Human),
+        )
+        .await?;
+    let family = store.checkpoint_family(&identity("child")).await?;
+    assert_eq!(family.sessions.len(), 2);
+    assert_eq!(family.current_assessments, 2);
+    assert_eq!(family.requests.len(), 2);
+    assert_eq!(family.known_cost_micro_usd, 12);
+    assert!(!family.metering_complete);
+    store.delete(&identity("parent")).await?;
+    assert!(
+        store
+            .checkpoint_content(&identity("child"), &child.checkpoint_id)
+            .await
+            .is_err()
+    );
+    assert!(
+        store
+            .assessment_history(&identity("child"))
+            .await?
+            .is_empty()
+    );
+    assert!(
+        store
+            .effective_assessment(&identity("child"))
+            .await?
+            .assessment
+            .is_none()
+    );
+    assert!(resources::Entity::find().all(&store.db).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_creation_and_revision_selection_are_durable() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("capture.db").display()
+    );
+    let db = crate::db::connect(&url).await?;
+    crate::db::run_migrations(&db).await?;
+    let store = CanonicalStore::new(db);
+    let recorder = store.recorder(scope()).await?;
+    new_session(recorder.as_ref(), "s").await?;
+    let identity = identity("s");
+    let (first, second) = tokio::join!(
+        store.freeze_checkpoint(&identity, 1),
+        store.freeze_checkpoint(&identity, 1)
+    );
+    let cp = first?;
+    assert_eq!(cp.checkpoint_id, second?.checkpoint_id);
+    assert_eq!(store.checkpoints(&identity).await?.len(), 1);
+    let (a, b) = tokio::join!(
+        store.submit_assessment(&identity, input(&cp, "a", None, AssessmentSource::Human)),
+        store.submit_assessment(&identity, input(&cp, "b", None, AssessmentSource::Human))
+    );
+    assert_ne!(
+        a.is_ok(),
+        b.is_ok(),
+        "only one submission may replace the expected empty selection"
+    );
+    assert_eq!(store.assessment_history(&identity).await?.len(), 1);
+    let selected = store
+        .effective_assessment(&identity)
+        .await?
+        .current_revision;
+    let (frozen, appended) = tokio::join!(
+        store.freeze_checkpoint(&identity, 1),
+        update(recorder.as_ref(), "s", "concurrent append")
+    );
+    appended?;
+    if let Ok(frozen) = frozen {
+        assert_eq!(frozen.checkpoint_id, cp.checkpoint_id);
+        assert_eq!(
+            store
+                .checkpoint_content(&identity, &frozen.checkpoint_id)
+                .await?
+                .events
+                .len(),
+            1
+        );
+    }
+    assert!(store.freeze_checkpoint(&identity, 1).await.is_err());
+    drop(recorder);
+    drop(store);
+    let reopened = CanonicalStore::new(crate::db::connect(&url).await?);
+    let view = reopened.effective_assessment(&identity).await?;
+    assert_eq!(view.current_revision, selected);
+    assert!(view.stale);
+    assert_eq!(
+        reopened
+            .checkpoint_content(&identity, &cp.checkpoint_id)
+            .await?
+            .events
+            .len(),
+        1
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn missing_parent_and_capture_gaps_remain_explicit() -> Result<()> {
+    let store = store().await?;
+    let recorder = store.recorder(scope()).await?;
+    recorder
+        .record(event(
+            CaptureKind::Request,
+            Some(2),
+            "session/fork",
+            json!({"sessionId":"unrecorded"}),
+        ))
+        .await?;
+    recorder
+        .record(event(
+            CaptureKind::Response,
+            Some(2),
+            "session/fork",
+            json!({"result":{"sessionId":"child"}}),
+        ))
+        .await?;
+    let cp = freeze(&store, "child").await?;
+    assert!(
+        cp.gaps
+            .iter()
+            .any(|g| g.starts_with("parent_watermark_unknown:"))
+    );
+    assert_eq!(cp.family_id, identity("unrecorded").key()?);
+    assert_eq!(cp.segments.len(), 1);
+    sessions::Entity::update_many()
+        .col_expr(
+            sessions::Column::ParentKey,
+            Expr::value(identity("child").key()?),
+        )
+        .filter(sessions::Column::SessionKey.eq(identity("child").key()?))
+        .exec(&store.db)
+        .await?;
+    assert!(freeze(&store, "child").await.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn long_session_manifests_and_large_assessments_round_trip() -> Result<()> {
+    let store = store().await?;
+    let recorder = store.recorder(scope()).await?;
+    new_session(recorder.as_ref(), "s").await?;
+    for i in 0..400 {
+        update(recorder.as_ref(), "s", &format!("event-{i}")).await?;
+    }
+    update(recorder.as_ref(), "s", &"large tool output ".repeat(8000)).await?;
+    let cp = freeze(&store, "s").await?;
+    assert!(serde_json::to_vec(&cp)?.len() > 65_535);
+    let mut submission = input(&cp, "large", None, AssessmentSource::Human);
+    submission
+        .assessment
+        .as_mut()
+        .context("assessment")?
+        .explanation = "recorded evidence ".repeat(8000);
+    store
+        .submit_assessment(&identity("s"), submission.clone())
+        .await?;
+    let stored = store
+        .assessment_history(&identity("s"))
+        .await?
+        .pop()
+        .context("revision")?;
+    assert_eq!(
+        serde_json::to_value(stored.input)?,
+        serde_json::to_value(submission)?
+    );
+    assert_eq!(
+        store
+            .checkpoint_content(&identity("s"), &cp.checkpoint_id)
+            .await?
+            .events
+            .len(),
+        402
+    );
+    Ok(())
+}

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/types.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/types.rs
@@ -1,0 +1,199 @@
+//! Versioned checkpoint and assessment contracts. No scoring model is invoked.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::super::{CanonicalEvent, RequestAssociation, SessionIdentity};
+
+/// An immutable raw observation reference, including its original content digest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventReference {
+    pub connection_id: String,
+    pub sequence: i64,
+    pub session_sequence: Option<i64>,
+    pub digest: String,
+}
+
+impl EventReference {
+    pub fn node_id(&self) -> String {
+        format!("{}:{}", self.connection_id, self.sequence)
+    }
+}
+
+/// A native session's own prefix; inherited prefixes remain separate references.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrefixSegment {
+    pub identity: SessionIdentity,
+    pub watermark: i64,
+    pub parent_key: Option<String>,
+    pub parent_watermark: Option<i64>,
+    pub events: Vec<EventReference>,
+    pub setup: Vec<EventReference>,
+    pub connections: Vec<ConnectionObservation>,
+    pub boundary_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectionObservation {
+    pub connection_id: String,
+    pub state: String,
+    pub controller_instance_id: Option<String>,
+    pub route_scope_id: Option<String>,
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Checkpoint {
+    pub schema_version: u32,
+    pub canonical_version: u32,
+    pub checkpoint_id: String,
+    pub identity: SessionIdentity,
+    pub watermark: i64,
+    pub prefix_digest: String,
+    pub previous_checkpoint_id: Option<String>,
+    pub family_id: String,
+    /// Ordered from the oldest inherited prefix to this session's own prefix.
+    pub segments: Vec<PrefixSegment>,
+    pub gaps: Vec<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CheckpointContent {
+    pub checkpoint: Checkpoint,
+    pub events: Vec<CanonicalEvent>,
+    pub setup: Vec<CanonicalEvent>,
+}
+
+/// A separate immutable observation of locally recorded metering/route evidence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceObservation {
+    pub observation_id: String,
+    pub checkpoint_id: String,
+    pub revision: i64,
+    pub previous_observation_id: Option<String>,
+    pub observed_at: String,
+    pub requests: Vec<RequestAssociation>,
+    /// Session correlation exists, but membership in this fixed prefix is unknown.
+    pub unassigned_request_ids: Vec<String>,
+    pub known_cost_micro_usd: i64,
+    pub unpriced_requests: usize,
+    pub metering_complete: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssessmentSource {
+    Human,
+    Agentic,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum CriterionScore {
+    Scored { value_ppm: u32 },
+    Unknown,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceCitation {
+    pub node_id: String,
+    pub digest: String,
+}
+
+/// Imported labels retain their evaluator identity. Templates and aggregation
+/// are deliberately owned by the scoring layer, not this persistence layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssessmentContent {
+    pub pipeline_config_digest: String,
+    pub selection_digest: String,
+    pub scores: BTreeMap<String, CriterionScore>,
+    pub evidence: Vec<EvidenceCitation>,
+    pub explanation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevisionInput {
+    pub submission_id: String,
+    pub checkpoint_id: String,
+    #[serde(deserialize_with = "required_nullable")]
+    pub expected_revision: Option<String>,
+    pub source: AssessmentSource,
+    pub evaluator_id: String,
+    pub evaluator_version: String,
+    /// None explicitly retracts the current assessment; old labels never revive.
+    #[serde(deserialize_with = "required_nullable")]
+    pub assessment: Option<AssessmentContent>,
+    pub reason: String,
+}
+
+fn required_nullable<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::deserialize(deserializer)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssessmentRevision {
+    pub revision_id: String,
+    pub input_digest: String,
+    pub input: RevisionInput,
+    pub supersedes: Option<String>,
+    pub selected_on_submission: bool,
+    pub selection_reason: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EffectiveAssessment {
+    pub identity: SessionIdentity,
+    pub current_watermark: i64,
+    pub current_revision: Option<String>,
+    pub assessment: Option<AssessmentRevision>,
+    pub checkpoint: Option<Checkpoint>,
+    pub stale: bool,
+    pub reasons: Vec<String>,
+    pub resource: Option<ResourceObservation>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FamilyView {
+    pub family_id: String,
+    pub sessions: Vec<EffectiveAssessment>,
+    /// Labels without newer content, not a quality or independence guarantee.
+    pub current_assessments: usize,
+    pub requests: Vec<RequestAssociation>,
+    pub conflicting_request_ids: Vec<String>,
+    pub known_cost_micro_usd: i64,
+    pub unpriced_requests: usize,
+    pub metering_complete: bool,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
+pub enum CheckpointReport {
+    Checkpoint(Checkpoint),
+    Checkpoints(Vec<Checkpoint>),
+    Content(Box<CheckpointContent>),
+    Resources(ResourceObservation),
+    ResourceHistory(Vec<ResourceObservation>),
+    Revision(AssessmentRevision),
+    History(Vec<AssessmentRevision>),
+    Effective(Box<EffectiveAssessment>),
+    Family(Box<FamilyView>),
+}
+
+impl crate::output::CliReport for CheckpointReport {
+    fn render(&self, h: &mut crate::output::human::Human<'_>) -> std::io::Result<()> {
+        // The detailed manifest is also useful as a human-readable audit export.
+        let text = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
+        h.line(&text)
+    }
+}

--- a/apps/bitrouter/src/acp_trajectory/checkpoint/types.rs
+++ b/apps/bitrouter/src/acp_trajectory/checkpoint/types.rs
@@ -160,6 +160,7 @@ pub struct EffectiveAssessment {
     pub checkpoint: Option<Checkpoint>,
     pub stale: bool,
     pub reasons: Vec<String>,
+    pub source_capture_states: BTreeMap<String, String>,
     pub resource: Option<ResourceObservation>,
 }
 
@@ -167,7 +168,7 @@ pub struct EffectiveAssessment {
 pub struct FamilyView {
     pub family_id: String,
     pub sessions: Vec<EffectiveAssessment>,
-    /// Labels without newer content, not a quality or independence guarantee.
+    /// Current labels, not a quality or independence guarantee.
     pub current_assessments: usize,
     pub requests: Vec<RequestAssociation>,
     pub conflicting_request_ids: Vec<String>,

--- a/apps/bitrouter/src/acp_trajectory/mod.rs
+++ b/apps/bitrouter/src/acp_trajectory/mod.rs
@@ -3,6 +3,7 @@
 //! Native IDs remain the harness's authority. Transport replays are retained
 //! for audit, separately from live canonical events and model execution costs.
 
+pub mod checkpoint;
 pub mod entities;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -16,7 +17,7 @@ use sea_orm::{
     ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter,
     QueryOrder, Set, TransactionTrait,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 
@@ -26,7 +27,7 @@ use entities::{connections, events, sessions};
 pub const CANONICAL_VERSION: u32 = 1;
 
 /// The complete native identity scope; `key()` is only a storage index.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionIdentity {
     pub owner: String,
     pub source: String,
@@ -61,7 +62,7 @@ pub struct CanonicalStore {
 }
 
 /// An immutable observed event with a stable connection reference.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalEvent {
     pub node_id: String,
     pub sequence: i64,
@@ -70,7 +71,7 @@ pub struct CanonicalEvent {
 }
 
 /// Setup evidence whose native identity became known when its response arrived.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetupEvidence {
     pub node_id: String,
     pub response_node_id: String,
@@ -79,7 +80,7 @@ pub struct SetupEvidence {
 }
 
 /// Session-level correlation does not claim a tool-to-model causal join.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequestAssociation {
     pub request_id: String,
     pub model_id: String,
@@ -88,6 +89,8 @@ pub struct RequestAssociation {
     pub native_agent_thread_id: Option<String>,
     pub basis: String,
     pub charge_micro_usd: Option<i64>,
+    /// First local metering observation, not an inferred model start time.
+    pub first_metered_at: String,
     pub identity_evidence: Option<serde_json::Value>,
     pub route_events: Vec<crate::trajectory::types::TrajectoryEvent>,
 }
@@ -388,6 +391,7 @@ impl CanonicalStore {
                         basis: "scoped_declared_session_identity; tool_to_request_unresolved"
                             .into(),
                         charge_micro_usd: charge,
+                        first_metered_at: row.created_at,
                         identity_evidence: evidence,
                         route_events,
                     },
@@ -408,6 +412,7 @@ impl CanonicalStore {
             .filter(sessions::Column::SessionKey.eq(&key))
             .exec(&tx)
             .await?;
+        checkpoint::delete_dependents(&tx, &key).await?;
         let rows = events::Entity::find()
             .filter(events::Column::SessionKey.eq(&key))
             .all(&tx)

--- a/apps/bitrouter/src/acp_trajectory/tests.rs
+++ b/apps/bitrouter/src/acp_trajectory/tests.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 
 use super::{CanonicalStore, RecordingScope, SessionIdentity, connections, events};
 
-fn identity(id: &str) -> SessionIdentity {
+pub(super) fn identity(id: &str) -> SessionIdentity {
     SessionIdentity {
         owner: "local".into(),
         source: "test-agent".into(),
@@ -24,7 +24,7 @@ fn identity(id: &str) -> SessionIdentity {
     }
 }
 
-fn scope() -> RecordingScope {
+pub(super) fn scope() -> RecordingScope {
     RecordingScope {
         owner: "local".into(),
         source: "test-agent".into(),
@@ -33,13 +33,13 @@ fn scope() -> RecordingScope {
     }
 }
 
-async fn store() -> anyhow::Result<CanonicalStore> {
+pub(super) async fn store() -> anyhow::Result<CanonicalStore> {
     let db = crate::db::connect("sqlite::memory:").await?;
     crate::db::run_migrations(&db).await?;
     Ok(CanonicalStore::new(db))
 }
 
-fn event(
+pub(super) fn event(
     kind: CaptureKind,
     call_id: Option<u64>,
     method: &str,
@@ -54,7 +54,7 @@ fn event(
     }
 }
 
-async fn new_session(recorder: &dyn CapturePort, session: &str) -> anyhow::Result<()> {
+pub(super) async fn new_session(recorder: &dyn CapturePort, session: &str) -> anyhow::Result<()> {
     recorder
         .record(event(
             CaptureKind::Request,
@@ -373,7 +373,7 @@ async fn delete_removes_content_and_fences_an_active_recorder() -> anyhow::Resul
     Ok(())
 }
 
-async fn seed_request(
+pub(super) async fn seed_request(
     store: &CanonicalStore,
     id: &str,
     principal: &str,

--- a/apps/bitrouter/src/db/migration/m20240101_000019_create_acp_checkpoints.rs
+++ b/apps/bitrouter/src/db/migration/m20240101_000019_create_acp_checkpoints.rs
@@ -1,0 +1,184 @@
+//! Portable persistence for immutable ACP prefixes and replaceable evaluations.
+use sea_orm::DatabaseBackend;
+use sea_orm_migration::prelude::*;
+
+fn content_column(name: &str, backend: DatabaseBackend) -> ColumnDef {
+    let mut column = ColumnDef::new(Alias::new(name));
+    // Long sessions and individual tool results can exceed MySQL TEXT capacity.
+    // https://dev.mysql.com/doc/refman/8.4/en/blob.html
+    if backend == DatabaseBackend::MySql {
+        column.custom(Alias::new("LONGTEXT"));
+    } else {
+        column.text();
+    }
+    column.not_null().to_owned()
+}
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+        if backend == DatabaseBackend::MySql {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Alias::new("acp_capture_events"))
+                        .modify_column(content_column("event_json", backend))
+                        .to_owned(),
+                )
+                .await?;
+        }
+        let definitions = [
+            (
+                "acp_checkpoints",
+                vec!["checkpoint_id"],
+                vec!["checkpoint_id", "session_key"],
+                vec!["manifest_json"],
+            ),
+            (
+                "acp_checkpoint_members",
+                vec!["checkpoint_id", "session_key"],
+                vec!["checkpoint_id", "session_key"],
+                vec![],
+            ),
+            (
+                "acp_resource_observations",
+                vec!["observation_id"],
+                vec!["observation_id", "checkpoint_id"],
+                vec!["observed_at", "observation_json"],
+            ),
+            (
+                "acp_assessment_revisions",
+                vec!["revision_id"],
+                vec!["revision_id", "session_key", "checkpoint_id"],
+                vec!["created_at", "revision_json"],
+            ),
+            (
+                "acp_effective_assessments",
+                vec!["session_key"],
+                vec!["session_key"],
+                vec![],
+            ),
+        ];
+        for (table_name, keys, ids, texts) in definitions {
+            let mut table = Table::create();
+            table.table(Alias::new(table_name));
+            for id in ids {
+                table.col(ColumnDef::new(Alias::new(id)).string_len(64).not_null());
+            }
+            for field in texts {
+                if field.ends_with("_json") {
+                    table.col(content_column(field, backend));
+                } else {
+                    table.col(ColumnDef::new(Alias::new(field)).text().not_null());
+                }
+            }
+            if table_name == "acp_checkpoints" {
+                table.col(
+                    ColumnDef::new(Alias::new("watermark"))
+                        .big_integer()
+                        .not_null(),
+                );
+                table.col(ColumnDef::new(Alias::new("deleted")).boolean().not_null());
+            }
+            if table_name == "acp_effective_assessments" {
+                table.col(ColumnDef::new(Alias::new("revision_id")).string_len(64));
+            }
+            if table_name == "acp_resource_observations" {
+                table.col(
+                    ColumnDef::new(Alias::new("revision"))
+                        .big_integer()
+                        .not_null(),
+                );
+            }
+            let mut primary = Index::create();
+            for key in keys {
+                primary.col(Alias::new(key));
+            }
+            table.primary_key(&mut primary);
+            manager.create_table(table.to_owned()).await?;
+        }
+        for (name, table, column) in [
+            (
+                "idx_acp_checkpoints_session",
+                "acp_checkpoints",
+                "session_key",
+            ),
+            (
+                "idx_acp_members_session",
+                "acp_checkpoint_members",
+                "session_key",
+            ),
+            (
+                "idx_acp_resources_checkpoint",
+                "acp_resource_observations",
+                "checkpoint_id",
+            ),
+            (
+                "idx_acp_revisions_session",
+                "acp_assessment_revisions",
+                "session_key",
+            ),
+            (
+                "idx_acp_revisions_checkpoint",
+                "acp_assessment_revisions",
+                "checkpoint_id",
+            ),
+        ] {
+            manager
+                .create_index(
+                    Index::create()
+                        .name(name)
+                        .table(Alias::new(table))
+                        .col(Alias::new(column))
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Keep the widened capture column: shrinking it could truncate content.
+        for table in [
+            "acp_effective_assessments",
+            "acp_assessment_revisions",
+            "acp_resource_observations",
+            "acp_checkpoint_members",
+            "acp_checkpoints",
+        ] {
+            manager
+                .drop_table(Table::drop().table(Alias::new(table)).to_owned())
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_columns_support_large_manifests_on_every_backend() {
+        for (backend, expected) in [
+            (DatabaseBackend::MySql, "LONGTEXT"),
+            (DatabaseBackend::Postgres, "text"),
+            (DatabaseBackend::Sqlite, "text"),
+        ] {
+            let table = Table::create()
+                .table(Alias::new("large_content"))
+                .col(content_column("manifest_json", backend))
+                .to_owned();
+            let sql = match backend {
+                DatabaseBackend::MySql => table.to_string(MysqlQueryBuilder),
+                DatabaseBackend::Postgres => table.to_string(PostgresQueryBuilder),
+                DatabaseBackend::Sqlite => table.to_string(SqliteQueryBuilder),
+            };
+            assert!(sql.contains(expected), "{sql}");
+        }
+    }
+}

--- a/apps/bitrouter/src/db/migration/mod.rs
+++ b/apps/bitrouter/src/db/migration/mod.rs
@@ -29,6 +29,7 @@ pub mod m20240101_000016_add_acp_metering_identity;
 pub mod m20240101_000017_add_metering_route_scope;
 
 pub mod m20240101_000018_create_acp_capture;
+pub mod m20240101_000019_create_acp_checkpoints;
 
 use sea_orm_migration::{MigrationTrait, MigratorTrait};
 
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240101_000016_add_acp_metering_identity::Migration),
             Box::new(m20240101_000017_add_metering_route_scope::Migration),
             Box::new(m20240101_000018_create_acp_capture::Migration),
+            Box::new(m20240101_000019_create_acp_checkpoints::Migration),
         ]
     }
 }

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -1563,7 +1563,44 @@ enum AcpRecordingAction {
 }
 
 #[derive(Subcommand)]
+enum AcpCheckpointAction {
+    /// Freeze exactly the currently observed prefix; rejects a stale watermark.
+    Create {
+        #[arg(long)]
+        watermark: i64,
+    },
+    /// List immutable prefixes for this native session.
+    List,
+    /// Read the original content versions referenced by a checkpoint.
+    Show { checkpoint: String },
+    /// Inspect resource snapshots, or refresh them from existing local records.
+    Resources {
+        checkpoint: String,
+        #[arg(long)]
+        refresh: bool,
+    },
+    /// Import an idempotent assessment revision or explicit retraction from JSON.
+    Submit { file: PathBuf },
+    /// Read immutable assessment revisions and their selection decisions.
+    History,
+    /// Inspect the selected assessment, including unassessed appends.
+    Effective,
+    /// Inspect related native forks with a union of observed request costs.
+    Family,
+}
+
+#[derive(Subcommand)]
 enum AcpCmd {
+    /// Freeze and evaluate already recorded native-session prefixes locally.
+    Checkpoints {
+        #[arg(long)]
+        agent: String,
+        session: String,
+        #[arg(short, long)]
+        config: Option<PathBuf>,
+        #[command(subcommand)]
+        action: AcpCheckpointAction,
+    },
     /// Inspect or delete locally recorded ACP conversation content.
     Recordings {
         #[command(subcommand)]
@@ -6140,6 +6177,76 @@ async fn resolve_prompt_input(
 
 async fn acp_cmd(cmd: AcpCmd, output: &Output) -> Result<()> {
     match cmd {
+        AcpCmd::Checkpoints {
+            agent,
+            session,
+            config,
+            action,
+        } => {
+            use bitrouter::acp_trajectory::checkpoint::types::{CheckpointReport, RevisionInput};
+            let source = bitrouter::paths::resolve_config(config.as_deref())?;
+            let cfg = bitrouter::paths::load_config(&source).await?;
+            let db = bitrouter::db::connect(&bitrouter::db::anchor_url(
+                &cfg.database.url,
+                source.home(),
+            ))
+            .await?;
+            bitrouter::db::run_migrations(&db).await?;
+            let store = bitrouter::acp_trajectory::CanonicalStore::new(db);
+            let identity = bitrouter::acp_trajectory::SessionIdentity {
+                owner: "local".into(),
+                source: agent,
+                native_session_id: session,
+            };
+            let report = match action {
+                AcpCheckpointAction::Create { watermark } => CheckpointReport::Checkpoint(
+                    store.freeze_checkpoint(&identity, watermark).await?,
+                ),
+                AcpCheckpointAction::List => {
+                    CheckpointReport::Checkpoints(store.checkpoints(&identity).await?)
+                }
+                AcpCheckpointAction::Show { checkpoint } => CheckpointReport::Content(Box::new(
+                    store.checkpoint_content(&identity, &checkpoint).await?,
+                )),
+                AcpCheckpointAction::Resources {
+                    checkpoint,
+                    refresh,
+                } => {
+                    if refresh {
+                        CheckpointReport::Resources(
+                            store
+                                .observe_checkpoint_resources(&identity, &checkpoint)
+                                .await?,
+                        )
+                    } else {
+                        CheckpointReport::ResourceHistory(
+                            store
+                                .checkpoint_resource_history(&identity, &checkpoint)
+                                .await?,
+                        )
+                    }
+                }
+                AcpCheckpointAction::Submit { file } => {
+                    let input: RevisionInput = serde_json::from_slice(
+                        &tokio::fs::read(&file)
+                            .await
+                            .context("reading assessment JSON")?,
+                    )?;
+                    CheckpointReport::Revision(store.submit_assessment(&identity, input).await?)
+                }
+                AcpCheckpointAction::History => {
+                    CheckpointReport::History(store.assessment_history(&identity).await?)
+                }
+                AcpCheckpointAction::Effective => CheckpointReport::Effective(Box::new(
+                    store.effective_assessment(&identity).await?,
+                )),
+                AcpCheckpointAction::Family => {
+                    CheckpointReport::Family(Box::new(store.checkpoint_family(&identity).await?))
+                }
+            };
+            output.emit(&report)?;
+            Ok(())
+        }
         AcpCmd::Recordings { action, config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;

--- a/apps/bitrouter/tests/acp_checkpoints.rs
+++ b/apps/bitrouter/tests/acp_checkpoints.rs
@@ -1,0 +1,175 @@
+//! Persistent checkpoint/assessment behavior through separate CLI processes.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, ensure};
+use bitrouter::acp_trajectory::{CanonicalStore, RecordingScope};
+use bitrouter_sdk::acp::capture::{CaptureDirection, CaptureEvent, CaptureKind, CapturePort};
+use serde_json::{Value, json};
+
+async fn command(config: &Path, cwd: &Path, args: &[&str]) -> Result<std::process::Output> {
+    Ok(tokio::time::timeout(
+        Duration::from_secs(30),
+        tokio::process::Command::new(env!("CARGO_BIN_EXE_bitrouter"))
+            .current_dir(cwd)
+            .args([
+                "acp",
+                "checkpoints",
+                "--agent",
+                "fixture",
+                "native",
+                "--config",
+            ])
+            .arg(config)
+            .args(args)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await??)
+}
+
+async fn run(config: &Path, cwd: &Path, args: &[&str]) -> Result<Value> {
+    let result = command(config, cwd, args).await?;
+    ensure!(
+        result.status.success(),
+        "checkpoint CLI failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    Ok(serde_json::from_slice(&result.stdout)?)
+}
+
+#[tokio::test]
+async fn cli_preserves_checkpoints_and_revisions_across_processes() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let cwd = temp.path().join("coding-directory");
+    std::fs::create_dir(&cwd)?;
+    let config = temp.path().join("bitrouter.yaml");
+    std::fs::write(&config, "database:\n  url: sqlite://history.db?mode=rwc\n")?;
+    let url = bitrouter::db::anchor_url("sqlite://history.db?mode=rwc", temp.path());
+    let db = bitrouter::db::connect(&url).await?;
+    bitrouter::db::run_migrations(&db).await?;
+    let store = CanonicalStore::new(db);
+    let recorder = store
+        .recorder(RecordingScope {
+            owner: "local".into(),
+            source: "fixture".into(),
+            controller_instance_id: None,
+            route_scope_id: None,
+        })
+        .await?;
+    for (kind, payload) in [
+        (CaptureKind::Request, json!({"cwd":"/fixture"})),
+        (
+            CaptureKind::Response,
+            json!({"result":{"sessionId":"native"}}),
+        ),
+    ] {
+        recorder
+            .record(CaptureEvent {
+                direction: CaptureDirection::Client,
+                kind,
+                call_id: Some(1),
+                method: "session/new".into(),
+                payload,
+            })
+            .await?;
+    }
+    let created = run(&config, &cwd, &["create", "--watermark", "1"]).await?;
+    let cp = created["data"]["checkpoint_id"]
+        .as_str()
+        .context("checkpoint ID")?;
+    let content = run(&config, &cwd, &["show", cp]).await?;
+    assert_eq!(
+        content["data"]["events"]
+            .as_array()
+            .context("events")?
+            .len(),
+        1
+    );
+    assert_eq!(
+        content["data"]["setup"].as_array().context("setup")?.len(),
+        1
+    );
+    assert!(temp.path().join("history.db").exists());
+    assert!(!cwd.join("history.db").exists());
+    let submission = temp.path().join("assessment.json");
+    std::fs::write(
+        &submission,
+        serde_json::to_vec(&json!({
+            "submission_id":"manual-1", "checkpoint_id":cp, "expected_revision":null,
+            "source":"human", "evaluator_id":"local-user", "evaluator_version":"1", "reason":"manual assessment",
+            "assessment":{"pipeline_config_digest":"a".repeat(64), "selection_digest":"b".repeat(64),
+                "scores":{"correctness":{"status":"unknown"}}, "evidence":[], "explanation":"Evidence is incomplete"}
+        }))?,
+    )?;
+    let input_path = submission.to_str().context("input path")?;
+    let submitted = run(&config, &cwd, &["submit", input_path]).await?;
+    assert_eq!(
+        run(&config, &cwd, &["submit", input_path]).await?,
+        submitted
+    );
+    assert_eq!(
+        run(&config, &cwd, &["history"]).await?["data"]
+            .as_array()
+            .context("history")?
+            .len(),
+        1
+    );
+    assert_eq!(
+        run(&config, &cwd, &["effective"]).await?["data"]["current_revision"],
+        submitted["data"]["revision_id"]
+    );
+    assert_eq!(
+        run(&config, &cwd, &["resources", cp, "--refresh"]).await?["data"]["metering_complete"],
+        false
+    );
+    assert_eq!(
+        run(&config, &cwd, &["resources", cp]).await?["data"]
+            .as_array()
+            .context("resources")?
+            .len(),
+        1
+    );
+    assert_eq!(
+        run(&config, &cwd, &["family"]).await?["data"]["current_assessments"],
+        1
+    );
+    assert_eq!(
+        run(&config, &cwd, &["list"]).await?["data"]
+            .as_array()
+            .context("checkpoints")?
+            .len(),
+        1
+    );
+    recorder.record(CaptureEvent { direction: CaptureDirection::Agent, kind: CaptureKind::Notification, call_id: None,
+        method: "session/update".into(), payload: json!({"sessionId":"native","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"additional content"}}}) }).await?;
+    assert_eq!(
+        run(&config, &cwd, &["effective"]).await?["data"]["stale"],
+        true
+    );
+    assert!(
+        !command(&config, &cwd, &["create", "--watermark", "1"])
+            .await?
+            .status
+            .success()
+    );
+    let next = run(&config, &cwd, &["create", "--watermark", "2"]).await?;
+    assert_eq!(next["data"]["previous_checkpoint_id"], cp);
+    assert_eq!(run(&config, &cwd, &["show", cp]).await?, content);
+    let deleted = tokio::process::Command::new(env!("CARGO_BIN_EXE_bitrouter"))
+        .current_dir(&cwd)
+        .args(["acp", "recordings", "--config"])
+        .arg(&config)
+        .args(["delete", "--agent", "fixture", "native"])
+        .output()
+        .await?;
+    ensure!(deleted.status.success(), "recording deletion failed");
+    assert!(
+        !command(&config, &cwd, &["show", cp])
+            .await?
+            .status
+            .success()
+    );
+    Ok(())
+}

--- a/docs/ACP_CANONICAL_CAPTURE_SPEC.md
+++ b/docs/ACP_CANONICAL_CAPTURE_SPEC.md
@@ -109,7 +109,7 @@ early notifications, reconnect/load replay, and durable shutdown. Storage tests
 cover failure latching, owner/source separation, fork boundaries, deletion,
 principal-scoped request unions, and unknown costs.
 
-This layer does not yet provide immutable checkpoint manifests, assessment
-revisions, effective evaluation selection, or inherited family projections.
-Those belong to the subsequent checkpoint layer. It also does not establish
-judge accuracy or a causal reward for individual model choices.
+The [checkpoint layer](ACP_CHECKPOINT_SPEC.md) builds immutable prefix manifests,
+assessment revisions, effective selection and inherited family projections on
+these observations. Neither layer establishes judge accuracy or a causal reward
+for individual model choices.

--- a/docs/ACP_CHECKPOINT_SPEC.md
+++ b/docs/ACP_CHECKPOINT_SPEC.md
@@ -105,6 +105,10 @@ Selection rules are explicit:
   `new_content_unassessed`. It is excluded from the current family label count
   until a new checkpoint receives a selected assessment. A failed import does
   not clear that freshness state or silently select an older label.
+- If the session's own capture connection becomes interrupted after the
+  checkpoint, the effective label becomes stale even if no new event could be
+  persisted. Current capture states and the interruption reason are exposed;
+  the immutable checkpoint and its original assessment remain unchanged.
 
 The effective view returns one selection per native session, with its fixed
 checkpoint, current source watermark, freshness, gaps and resource observation.

--- a/docs/ACP_CHECKPOINT_SPEC.md
+++ b/docs/ACP_CHECKPOINT_SPEC.md
@@ -1,0 +1,140 @@
+# Immutable ACP checkpoints and assessment revisions
+
+This application layer consumes the opt-in [canonical recording store](ACP_CANONICAL_CAPTURE_SPEC.md).
+It provides durable inputs and revision selection for later evaluators. It does
+not execute tests, inspect repositories, fetch PR state, invoke a judge, generate
+task goals, or change routing configuration.
+
+## Prefix contract
+
+`acp checkpoints --agent SOURCE NATIVE_SESSION create --watermark N` requires
+the observed current native-session head to equal N. Creation records source
+event references and content digests, canonicalizer version, inherited fork
+prefixes, gaps, and the preceding checkpoint reference. It does not duplicate
+the transcript into another content store. Source identity is still the native
+owner/source/session tuple; checkpoint hashes identify snapshots only.
+
+The builder verifies source heads again under transaction locks before commit.
+A concurrent append or deletion rejects a stale creation attempt. Repeating the
+same freeze returns the same checkpoint. New appends create a new prefix, while
+old reads resolve only the saved references. In particular, a later tool update
+cannot change the status or output visible in an earlier checkpoint. Exports
+verify each source digest and reject missing or changed source events.
+
+Connection lifetime, source visibility, and label freshness are distinct. An
+open connection permits a stable prefix. Interrupted capture, incomplete native
+history, missing setup data, pending requests, and uncertain load/resume history
+remain explicit gaps. These observations do not turn a partial prefix into a
+quality pass or fail. A scoring layer decides which criteria it can evaluate.
+
+Creation is an explicit service/CLI operation. Debounced automatic scheduling,
+scoring workers, and TUI mode controls are separate consumers of this contract.
+
+## Forks and families
+
+A child checkpoint references its parent's watermark recorded at the fork
+request, recursively through earlier forks. Parent work performed after that
+boundary is excluded. The original setup request is retained by reference to
+the native setup response, including the fork request when applicable. Missing
+parent data is reported; cyclic or cross-scope lineage is rejected.
+
+Every effective native-session result carries its family identity. The family
+view retains separate native-session labels and reports one related cluster;
+it never counts model calls, checkpoint retries, or assessment revisions as
+independent session outcomes. Related forks are not asserted to be statistically
+independent. A subsequent comparison layer must use that cluster information.
+
+## Resource observations
+
+Checkpoint creation also records an initial resource observation. Content and
+resources are separate durable operations: if the resource write fails, the
+valid checkpoint remains and the caller can retry. Refresh reads only existing
+local metering and immutable route events. It does not fetch billing receipts.
+
+A resource observation preserves its unique request set, actual model/provider,
+available historical route/policy evidence, price state, and observation time.
+Known cost uses a request-ID union across inherited and own prefixes. Unknown
+pricing remains unknown. Reconciliation of a previously known request creates
+a new observation without modifying the checkpoint or its assessment labels.
+Consecutive identical observations are idempotent. If values change and later
+return to an earlier value, that return is a new ordered resource revision;
+it does not reactivate an old timestamp or leave a superseded value current.
+
+Session correlation alone cannot place every request into an old prefix. The
+observation includes a request only when its first local metering record or
+recorded route evidence precedes that segment's event boundary. This is a
+declared temporal correlation, not an exact tool-to-model join. A late request
+without such evidence is listed as unassigned. Route events after the boundary
+are excluded, and current configuration is never used to fill historical gaps.
+The first metering timestamp is not presented as the model's start time.
+
+Family totals union requests rather than adding session or checkpoint totals.
+Conflicting resource snapshots for the same request mark its charge unknown
+and expose the conflict. All totals explicitly retain incomplete metering;
+unobserved local or remote requests cannot be assumed free.
+
+## Assessment revisions and effective selection
+
+The JSON submission envelope records evaluator identity/version, Human or
+Agentic source, pipeline and selection digests, a criterion vector, evidence
+references, and an explanation. Scores are `scored` with 0–1,000,000 ppm,
+`unknown`, or `not_applicable`. The persistence layer validates range, identity,
+and checkpoint references. Template applicability, semantic support, aggregation,
+judge calibration, and promotion eligibility belong to the scoring layer;
+importing a vector does not establish those properties.
+
+Each submission supplies an idempotency key and explicit `expected_revision`
+and `assessment` fields (null is allowed; omission is rejected). Reusing
+the key for identical input returns the original result; different input is an
+error. The expected revision is checked transactionally. A worker using an old
+revision cannot overwrite a later correction.
+
+Selection rules are explicit:
+
+- A newly selected revision supersedes the prior native-session selection.
+- An automatic result for the same checkpoint cannot replace a Human revision.
+  It can remain in history with `human_revision_preserved` as its reason.
+- A result for an older checkpoint remains historical and cannot replace a
+  newer selected checkpoint, including when the older correction is manual.
+- A new checkpoint can receive its own automatic assessment; an earlier Human
+  score is not copied onto new content.
+- An explicit Human retraction targets the current checkpoint and revision,
+  records a reason, and leaves no effective assessment. Prior scores do not
+  automatically revive.
+- When the session appends, the previous label remains visible with
+  `new_content_unassessed`. It is excluded from the current family label count
+  until a new checkpoint receives a selected assessment. A failed import does
+  not clear that freshness state or silently select an older label.
+
+The effective view returns one selection per native session, with its fixed
+checkpoint, current source watermark, freshness, gaps and resource observation.
+It detects concurrent source or selection changes while reading. Historical
+revisions are audit records, not additional statistical samples. There is no
+background optimizer or publication implied by a successful import.
+
+## Deletion and recovery
+
+Deleting recorded native content invalidates checkpoints that reference it,
+including descendant checkpoints. Their resource observations and assessment
+text are removed, and affected effective selections are cleared in the same
+deletion transaction. Metadata tombstones fence in-flight writers. Checkpoint
+references cannot resurrect deleted transcript content.
+
+Checkpoint, revision, selection and resource records survive application restart.
+They are stored in the configured application database with the same path
+anchoring as capture, not in a UI timer or boot-local operation cache. No worker
+or mode setting is required to inspect already stored history.
+
+Large content columns use MySQL `LONGTEXT` and the other backends' `TEXT`.
+The migration also widens MySQL's captured-event column without shrinking it
+on downgrade. Backend message-size and storage failures still propagate;
+this does not promise unlimited storage.
+
+## Validation
+
+Tests cover old tool versions, source integrity, stale watermarks, repeated
+creation, revision retries and collisions, correction precedence, historical
+submissions, retractions, late price reconciliation, ambiguous late request
+membership, inherited prefix boundaries, family cost unions and deletion.
+CLI validation also exercises persistence across separate processes. None of
+these tests establishes judge accuracy or routing benefit.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1460,3 +1460,64 @@ convention. Content persists until explicit deletion; deletion fences further
 recording for that native identity and does not touch native harness history
 or metering. See [the recording contract](ACP_CANONICAL_CAPTURE_SPEC.md) for
 visibility, write-failure, and cost-accounting semantics.
+
+## ACP checkpoints and assessment history
+
+Use the source and native ID from `acp recordings list`, and the current `head`
+from `acp recordings show`. Creation rejects a stale expected watermark.
+
+```bash
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID [--config PATH] create --watermark N
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID [--config PATH] list
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID [--config PATH] show CHECKPOINT_ID
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID [--config PATH] resources CHECKPOINT_ID [--refresh]
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID [--config PATH] submit assessment.json
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID [--config PATH] history
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID [--config PATH] effective
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID [--config PATH] family
+```
+
+These commands use existing local records only. `create` freezes event references
+and observes local resource records. `show` verifies and resolves original source
+versions. `resources` lists immutable metering observations; `--refresh` adds an
+observation if local data changed, without changing the content checkpoint.
+
+`submit` imports a JSON revision envelope. Copy checkpoint and current revision
+IDs from command output. The pipeline and selection digests identify the scoring
+configuration that produced the imported labels; this layer does not generate
+templates or scores. For example (replace identifiers and digest placeholders):
+
+```json
+{
+  "submission_id": "human-review-1",
+  "checkpoint_id": "CHECKPOINT_ID",
+  "expected_revision": null,
+  "source": "human",
+  "evaluator_id": "local-user",
+  "evaluator_version": "1",
+  "assessment": {
+    "pipeline_config_digest": "LOWERCASE_SHA256_DIGEST",
+    "selection_digest": "LOWERCASE_SHA256_DIGEST",
+    "scores": {
+      "completion": { "status": "scored", "value_ppm": 1000000 },
+      "correctness": { "status": "unknown" },
+      "pr_delivery": { "status": "not_applicable" }
+    },
+    "evidence": [],
+    "explanation": "Judgment based on the recorded checkpoint."
+  },
+  "reason": "Initial manual assessment"
+}
+```
+
+Use `expected_revision: null` only when no selection exists. For a correction,
+provide the current revision ID and a new submission ID. A retraction uses
+`assessment: null`, the current checkpoint/revision IDs, Human source and a
+reason. Evidence entries have `node_id` and `digest`, matching checkpoint
+references. Scores range from 0 to 1,000,000 ppm; unknown is not zero.
+
+Retries with the same submission ID and input are idempotent. Older workers
+cannot overwrite a newer selection. Appending a session marks its previous
+assessment stale, while preserving the old checkpoint. Deletion invalidates
+dependent checkpoints and removes associated assessment text. No command here
+invokes a judge or publishes a route. See [the checkpoint contract](ACP_CHECKPOINT_SPEC.md).

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -126,7 +126,7 @@ For an ACP client, use `bitrouter acp serve claude` or
 initializing the harness with the client's capabilities and transparently
 carrying multiple harness-native sessions on one connection. Native IDs and
 history remain harness-owned; `acp_recording.enabled` optionally records the
-observable ACP transcript locally. Route leases
+observable ACP transcript locally; `acp checkpoints` freezes and annotates it. Route leases
 (`_bitrouter/route/list|set|reset`) and session-attributed cost are
 capability-gated and need a local control binding, which an explicit remote
 `--base-url` does not provide. Read `references/sessions.md` — the pins and the

--- a/skills/bitrouter/references/sessions.md
+++ b/skills/bitrouter/references/sessions.md
@@ -229,3 +229,45 @@ observed native IDs. They preserve known model/provider, route-ledger evidence,
 and charge provenance. Tool-to-request relationships that ACP does not expose
 remain unresolved. Direct/remote or unmetered requests cannot be claimed as
 complete local cost; observed costs are summed over unique request IDs.
+
+### Checkpoints and imported assessments
+
+Read the native session's `head` from `acp recordings show`, then freeze that
+exact prefix. The agent source is the configured ID used when recording.
+
+```sh
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID --config PATH create --watermark N
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID --config PATH list
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID --config PATH show CHECKPOINT_ID
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID --config PATH resources CHECKPOINT_ID --refresh
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID --config PATH submit assessment.json
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID --config PATH history
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID --config PATH effective
+bitrouter acp checkpoints --agent SOURCE NATIVE_ID --config PATH family
+```
+
+Creation rejects an outdated watermark. Existing checkpoints keep original tool
+versions when a session appends. Resource refresh reads existing local records
+only; omit `--refresh` to inspect observation history. No judge, harness, test,
+PR query, or routing publication is started by these commands.
+
+An assessment JSON object requires `submission_id`, `checkpoint_id`,
+`expected_revision` (null only for the first selection), `source` (`human` or
+`agentic`), `evaluator_id`, `evaluator_version`, `reason`, and `assessment`.
+The assessment contains SHA-256 `pipeline_config_digest` and `selection_digest`,
+`scores`, `evidence`, and `explanation`. Scores map criterion IDs to
+`{"status":"scored","value_ppm":500000}`, `{"status":"unknown"}`, or
+`{"status":"not_applicable"}`. Evidence entries identify a checkpoint's
+`node_id` and `digest`. This store validates references and ranges, not rubric
+applicability or semantic correctness.
+
+For a correction, read `effective`, use its `current_revision`, and supply a new
+submission ID. Identical retries are idempotent. A stale expected revision is
+rejected; an automatic result cannot displace a Human correction on the same
+checkpoint. `assessment: null` explicitly retracts the current assessment and
+requires Human source and a reason. Old results do not automatically revive.
+
+An append marks the previous label stale. Fork views expose related labels as
+one family and union request costs rather than adding checkpoint totals. Deleting
+recordings also invalidates referencing checkpoints and removes their assessment
+text, including inherited references in descendant checkpoints.


### PR DESCRIPTION
Recorded ACP sessions can continue after an evaluation. Add immutable prefix manifests so later messages, tool updates, feedback, and price reconciliation cannot rewrite the evidence behind an earlier assessment.

The app stores source references and digests, inherited fork boundaries, explicit gaps, and ordered resource observations. Assessment imports have idempotency keys and compare-and-set selection: Human corrections survive late automatic results, older checkpoints remain historical, and explicit retraction never revives a previous score. Effective views expose unassessed appends and capture interruptions after scoring; family views preserve related labels and union request costs. Deleting source content invalidates referencing checkpoints and removes their assessment text.

`acp checkpoints` provides create/list/show, resource history/refresh, revision import/history, effective selection, and family inspection against the configured local database. CLI and agent guidance describe the input contract. The migration uses sufficiently large MySQL text columns for long manifests and tool output, and the new CLI integration target is included in Linux CI.

Validation:
- Workspace tests and doctests: 3,271 passed, 13 existing ignored tests.
- Workspace Clippy, all targets/features, warnings denied; formatting; rustdoc warnings denied; generated-artifact check.
- Tests cover fixed tool versions, source digest checks, concurrent freeze/append and competing revisions, persistence across CLI processes, corrections/retractions, post-checkpoint capture failures, explicit nullable fields, late prices including return to an earlier value, unknown request membership, inherited prefixes, family request unions, deletion, and large content.
- Schema rendering checks cover SQLite, PostgreSQL, and MySQL content types. Runtime database tests use SQLite; no live PostgreSQL/MySQL server was used locally.

All evaluation inputs are existing local records. These operations do not invoke a judge, rerun coding work, fetch external verification, aggregate rubric quality, or publish routing changes. Those consumers can build on the versioned checkpoint/revision contract. Resource observations preserve temporal association limits and incomplete metering rather than claiming exact per-call causal attribution.

Follows the canonical capture foundation merged in #902. Local tests bypass the host proxy for loopback addresses and omit debug/incremental artifacts to fit disk capacity; no tests or assertions are disabled.
