### PR TITLE
feat(tui): adopt native scrollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rmcp",
+ "rustix 1.1.4",
  "schemars 1.2.1",
  "sea-orm",
  "sea-orm-migration",

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -71,6 +71,9 @@ schemars.workspace = true
 [target.'cfg(windows)'.dependencies]
 atomicwrites.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true, features = ["process"] }
+
 [build-dependencies]
 # Reads the committed registry artifacts to generate the ACP harness catalog.
 serde_json.workspace = true

--- a/apps/bitrouter/src/actions/code.rs
+++ b/apps/bitrouter/src/actions/code.rs
@@ -117,7 +117,7 @@ impl CodeServices {
                 )
             }
         } else {
-            format!("bitrouter code · {}", std::env::current_dir()?.display())
+            conversation_label(&std::env::current_dir()?)
         };
         Ok(Arc::new(Self {
             target,
@@ -149,7 +149,7 @@ impl CodeServices {
         };
         let source = source.clone();
         let socket = crate::daemon::socket_path_for(&source, &config);
-        let label = format!("bitrouter code · {}", std::env::current_dir()?.display());
+        let label = conversation_label(&std::env::current_dir()?);
         let initial_launch = InitialLaunch {
             agent_id: agent_id.to_string(),
             selection: SessionSelection::New,
@@ -355,6 +355,14 @@ impl CodeServices {
     }
 }
 
+fn conversation_label(workspace: &Path) -> String {
+    let short = workspace
+        .file_name()
+        .unwrap_or(workspace.as_os_str())
+        .to_string_lossy();
+    format!("bitrouter code · {short}")
+}
+
 /// A socket or named remote target exposes only daemon reports. The typed
 /// session controls and route mutations require a local ACP session; route
 /// preview remains because it is a read-only report on both operation targets.
@@ -372,7 +380,9 @@ fn agent_is_selectable(row: &crate::agents::ListRow) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{CodeServices, agent_is_selectable, operation_command_supported};
+    use super::{
+        CodeServices, agent_is_selectable, conversation_label, operation_command_supported,
+    };
     use crate::acp_cli::{LaunchOptions, RoutingOptions, SessionSelection, SpawnContext};
     use crate::dashboard::SessionRequest;
     use crate::paths::ConfigSource;
@@ -384,6 +394,14 @@ mod tests {
             turn_timeout: None,
             routing: RoutingOptions::default(),
         }
+    }
+
+    #[test]
+    fn conversation_welcome_uses_only_the_short_workspace_name() {
+        assert_eq!(
+            conversation_label(std::path::Path::new("/workspaces/bitrouter")),
+            "bitrouter code · bitrouter"
+        );
     }
 
     #[test]

--- a/apps/bitrouter/src/chat/code.rs
+++ b/apps/bitrouter/src/chat/code.rs
@@ -143,6 +143,11 @@ impl Runtime {
         let mut paint_due = None;
         loop {
             while let Some(effect) = self.effects.pop_front() {
+                if effect == CodeEffect::Redraw {
+                    view.invalidate();
+                    dirty = true;
+                    continue;
+                }
                 let selection = match &effect {
                     CodeEffect::Select { selector, .. } => Some(selector.clone()),
                     _ => None,
@@ -236,7 +241,19 @@ impl Runtime {
                     }
                     dirty = true;
                 }
-                _ = shutdown.recv() => return Ok(()),
+                signal = shutdown.recv() => match signal {
+                    super::signals::TerminalSignal::Shutdown => return Ok(()),
+                    super::signals::TerminalSignal::Suspend => {
+                        // No input reader may retain buffered keys across the
+                        // terminal ownership boundary.
+                        drop(events.take());
+                        view.suspend()?;
+                        super::signals::suspend_current_process()?;
+                        view.resume()?;
+                        events = Some(EventStream::new());
+                        dirty = true;
+                    }
+                },
                 route = next_route(&mut self.route_probe) => {
                     self.route_probe = None;
                     match route {
@@ -450,7 +467,8 @@ impl Runtime {
             | CodeEffect::Cancel
             | CodeEffect::ResolvePermission { .. }
             | CodeEffect::Submit { .. }
-            | CodeEffect::AgentPrompt { .. } => {}
+            | CodeEffect::AgentPrompt { .. }
+            | CodeEffect::Redraw => {}
         }
         Ok(())
     }

--- a/apps/bitrouter/src/chat/signals.rs
+++ b/apps/bitrouter/src/chat/signals.rs
@@ -16,6 +16,16 @@ struct ShutdownSignals {
     interrupt: tokio::signal::unix::Signal,
     terminate: tokio::signal::unix::Signal,
     hangup: tokio::signal::unix::Signal,
+    suspend: tokio::signal::unix::Signal,
+}
+
+/// A process signal that changes terminal custody.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalSignal {
+    /// End the interactive process after its ordinary cleanup path runs.
+    Shutdown,
+    /// Restore terminal modes, stop, then reacquire them after `SIGCONT`.
+    Suspend,
 }
 
 #[cfg(unix)]
@@ -33,17 +43,39 @@ impl ShutdownSignals {
             interrupt: signal(SignalKind::interrupt())?,
             terminate: signal(SignalKind::terminate())?,
             hangup: signal(SignalKind::hangup())?,
+            suspend: signal(SignalKind::from_raw(rustix::process::Signal::TSTP.as_raw()))?,
         })
     }
 
     /// Resolve when any of them fires.
-    async fn recv(&mut self) {
+    async fn recv(&mut self) -> TerminalSignal {
         tokio::select! {
-            _ = self.interrupt.recv() => {}
-            _ = self.terminate.recv() => {}
-            _ = self.hangup.recv() => {}
+            _ = self.interrupt.recv() => TerminalSignal::Shutdown,
+            _ = self.terminate.recv() => TerminalSignal::Shutdown,
+            _ = self.hangup.recv() => TerminalSignal::Shutdown,
+            _ = self.suspend.recv() => TerminalSignal::Suspend,
         }
     }
+}
+
+/// Stop this process after terminal custody has been released.
+///
+/// `SIGSTOP` cannot be intercepted, so execution resumes immediately after
+/// this call only when the shell or supervisor delivers `SIGCONT`.
+#[cfg(unix)]
+pub fn suspend_current_process() -> std::io::Result<()> {
+    Ok(rustix::process::kill_process(
+        rustix::process::getpid(),
+        rustix::process::Signal::STOP,
+    )?)
+}
+
+#[cfg(not(unix))]
+pub fn suspend_current_process() -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "process suspension is unavailable on this platform",
+    ))
 }
 
 /// The third exit, as a `select!` arm.
@@ -71,11 +103,10 @@ impl Shutdown {
     }
 
     /// Resolve when one of them fires.
-    pub async fn recv(&mut self) {
+    pub async fn recv(&mut self) -> TerminalSignal {
         #[cfg(unix)]
         if let Some(signals) = self.signals.as_mut() {
-            signals.recv().await;
-            return;
+            return signals.recv().await;
         }
         std::future::pending().await
     }

--- a/apps/bitrouter/tests/code_tui_pty.rs
+++ b/apps/bitrouter/tests/code_tui_pty.rs
@@ -32,6 +32,10 @@ const PTY_TIMEOUT: Duration = Duration::from_secs(15);
 const CODE_COLUMNS: u16 = 80;
 const CODE_ROWS: u16 = 24;
 const REMOTE_FIXTURE_TOKEN: &str = "remote-a12-fixture-token-0123456789";
+const ENTER_ALTERNATE_SCREEN: &str = "\x1b[?1049h";
+const LEAVE_ALTERNATE_SCREEN: &str = "\x1b[?1049l";
+const BEGIN_SYNCHRONIZED_UPDATE: &[u8] = b"\x1b[?2026h";
+const END_SYNCHRONIZED_UPDATE: &[u8] = b"\x1b[?2026l";
 
 /// A deliberately small ACP agent. Its responses are protocol-shaped JSON, not
 /// terminal snapshots, so test failures describe lifecycle behavior instead of
@@ -102,6 +106,36 @@ def settle_pending(reason, text):
         update(text)
         finish(prompt, reason)
 
+def emit_permissions():
+    global permission_ids
+    with state_lock:
+        permission_ids = {"permission-1", "permission-2"}
+    for number in (1, 2):
+        send({
+            "jsonrpc": "2.0",
+            "id": "permission-" + str(number),
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": "pty-native",
+                "toolCall": {
+                    "toolCallId": "tool-" + str(number),
+                    "title": "fixture permission " + str(number),
+                },
+                "options": [
+                    {
+                        "optionId": "allow-" + str(number),
+                        "name": "Allow fixture " + str(number),
+                        "kind": "allow_once",
+                    },
+                    {
+                        "optionId": "deny-" + str(number),
+                        "name": "Deny fixture " + str(number),
+                        "kind": "reject_once",
+                    },
+                ],
+            },
+        })
+
 def control_loop(server):
     while True:
         connection, _ = server.accept()
@@ -111,6 +145,14 @@ def control_loop(server):
                 settle_pending("end_turn", "FXRL")
             elif command == "refusal":
                 settle_pending("refusal", "FXST")
+            elif command == "permission":
+                emit_permissions()
+            elif command == "backlog":
+                prompt = take_pending()
+                if prompt is not None:
+                    for number in range(90):
+                        update("BG" + str(number).zfill(3) + "\n")
+                    finish(prompt)
             connection.sendall(b"ok\n")
             if command == "disconnect":
                 os._exit(0)
@@ -201,32 +243,15 @@ with open(capture_path, "ab") as capture:
             elif scenario == "overlapping-permissions":
                 with state_lock:
                     pending_prompt = request_id
-                    permission_ids = {"permission-1", "permission-2"}
-                for number in (1, 2):
-                    send({
-                        "jsonrpc": "2.0",
-                        "id": "permission-" + str(number),
-                        "method": "session/request_permission",
-                        "params": {
-                            "sessionId": "pty-native",
-                            "toolCall": {
-                                "toolCallId": "tool-" + str(number),
-                                "title": "fixture permission " + str(number),
-                            },
-                            "options": [
-                                {
-                                    "optionId": "allow-" + str(number),
-                                    "name": "Allow fixture " + str(number),
-                                    "kind": "allow_once",
-                                },
-                                {
-                                    "optionId": "deny-" + str(number),
-                                    "name": "Deny fixture " + str(number),
-                                    "kind": "reject_once",
-                                },
-                            ],
-                        },
-                    })
+                emit_permissions()
+            elif scenario == "permission-during-inspector":
+                with state_lock:
+                    pending_prompt = request_id
+                update("FXPD")
+            elif scenario == "detached-backlog":
+                with state_lock:
+                    pending_prompt = request_id
+                update("FXBG")
             else:
                 update("FXRP" + str(prompt_count))
                 finish(request_id)
@@ -252,6 +277,8 @@ enum MockScenario {
     DelayedNormal,
     DelayedRefusal,
     OverlappingPermissions,
+    PermissionDuringInspector,
+    DetachedBacklog,
     SettingsConfirmed,
     SettingsFailure,
     SessionLifecycle,
@@ -265,6 +292,8 @@ impl MockScenario {
             Self::DelayedNormal => "delayed-normal",
             Self::DelayedRefusal => "delayed-refusal",
             Self::OverlappingPermissions => "overlapping-permissions",
+            Self::PermissionDuringInspector => "permission-during-inspector",
+            Self::DetachedBacklog => "detached-backlog",
             Self::SettingsConfirmed => "settings-confirmed",
             Self::SettingsFailure => "settings-failure",
             Self::SessionLifecycle => "session-lifecycle",
@@ -469,6 +498,14 @@ impl MockAcp {
 
     fn disconnect(&self) -> Result<()> {
         self.control("disconnect")
+    }
+
+    fn request_permissions(&self) -> Result<()> {
+        self.control("permission")
+    }
+
+    fn release_backlog(&self) -> Result<()> {
+        self.control("backlog")
     }
 
     fn control(&self, message: &str) -> Result<()> {
@@ -1098,7 +1135,7 @@ impl PtyRunner {
                     .any(|window| window == text.as_bytes())
                     || screen != checkpoint.screen
             });
-            if visible && changed_since_checkpoint {
+            if visible && changed_since_checkpoint && synchronized_update_complete(&self.output) {
                 return Ok(screen);
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -1159,6 +1196,45 @@ impl PtyRunner {
         }
     }
 
+    fn wait_for_raw_text_since(
+        &mut self,
+        checkpoint: &PtyCheckpoint,
+        text: &str,
+    ) -> Result<String> {
+        let deadline = Instant::now() + PTY_TIMEOUT;
+        loop {
+            let bytes = &self.output[checkpoint.output_len..];
+            if bytes
+                .windows(text.len())
+                .any(|window| window == text.as_bytes())
+            {
+                return Ok(String::from_utf8_lossy(bytes).to_string());
+            }
+            let transcript = String::from_utf8_lossy(bytes).to_string();
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                bail!(
+                    "timed out waiting for raw PTY text {text:?} after checkpoint; output was {transcript:?}"
+                );
+            }
+            match self.output_receiver.recv_timeout(remaining) {
+                Ok(Ok(bytes)) => {
+                    self.screen.process(&bytes);
+                    self.output.extend_from_slice(&bytes);
+                }
+                Ok(Err(error)) => {
+                    bail!("PTY reader failed while waiting for raw {text:?}: {error}")
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    bail!("timed out waiting for raw PTY text {text:?} after checkpoint")
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    bail!("PTY closed while waiting for raw {text:?} after checkpoint")
+                }
+            }
+        }
+    }
+
     fn wait_for_exit(&mut self) -> Result<portable_pty::ExitStatus> {
         match self.exit_receiver.recv_timeout(PTY_TIMEOUT) {
             Ok(Ok(status)) => Ok(status),
@@ -1167,6 +1243,16 @@ impl PtyRunner {
             Err(RecvTimeoutError::Disconnected) => bail!("PTY waiter exited without a status"),
         }
     }
+}
+
+fn synchronized_update_complete(output: &[u8]) -> bool {
+    let begin = output
+        .windows(BEGIN_SYNCHRONIZED_UPDATE.len())
+        .rposition(|window| window == BEGIN_SYNCHRONIZED_UPDATE);
+    let end = output
+        .windows(END_SYNCHRONIZED_UPDATE.len())
+        .rposition(|window| window == END_SYNCHRONIZED_UPDATE);
+    begin.is_none_or(|begin| end.is_some_and(|end| end > begin))
 }
 
 impl Drop for PtyRunner {
@@ -1301,14 +1387,14 @@ impl CodeFixture {
 
     fn close_to_composer(&mut self) -> Result<()> {
         let checkpoint = self.pty.checkpoint();
-        self.pty.send(b"\x03\x1b")?;
-        let _ = self.pty.wait_for_text_since(&checkpoint, "Composer")?;
+        self.pty.send(b"\x1b")?;
+        let _ = self.pty.wait_for_text_since(&checkpoint, "┃ Message")?;
         Ok(())
     }
 
     fn signal_child(&self, signal: &str) -> Result<()> {
         ensure!(
-            matches!(signal, "INT" | "TERM"),
+            matches!(signal, "INT" | "TERM" | "TSTP" | "CONT"),
             "unsupported fixture signal {signal:?}"
         );
         let deadline = Instant::now() + PTY_TIMEOUT;
@@ -1762,6 +1848,199 @@ fn code_minimal_agent_preserves_multiline_prompt_history_and_terminal() -> Resul
 }
 
 #[test]
+fn code_uses_normal_buffer_until_an_explicit_inspector() -> Result<()> {
+    let mut code = CodeFixture::agent(MockScenario::Minimal)?;
+    code.wait_for_agent_ready()?;
+    ensure!(
+        !code
+            .pty
+            .output
+            .windows(ENTER_ALTERNATE_SCREEN.len())
+            .any(|window| window == ENTER_ALTERNATE_SCREEN.as_bytes()),
+        "Code entered the alternate screen before an explicit inspector"
+    );
+
+    code.pty.send(b"inspect this turn\r")?;
+    let _ = code.pty.wait_for_text("Turn completed")?;
+    let open = code.pty.checkpoint();
+    code.pty.send(b"\x0f")?;
+    let _ = code
+        .pty
+        .wait_for_raw_text_since(&open, ENTER_ALTERNATE_SCREEN)?;
+    let _ = code.pty.wait_for_text_since(&open, "Full transcript")?;
+
+    let close = code.pty.checkpoint();
+    code.pty.send(b"\x1b")?;
+    let _ = code
+        .pty
+        .wait_for_raw_text_since(&close, LEAVE_ALTERNATE_SCREEN)?;
+    let normal = code.pty.wait_for_text_since(&close, "Message")?;
+    ensure!(
+        normal.contains("inspect this turn"),
+        "closing the inspector did not restore the normal-buffer transcript"
+    );
+    code.pty.send(b"\x04")?;
+    code.assert_terminal_restored()
+}
+
+#[test]
+fn code_detached_backlog_catches_up_once_after_resizes() -> Result<()> {
+    let mut code = CodeFixture::agent(MockScenario::DetachedBacklog)?;
+    code.wait_for_agent_ready()?;
+    code.pty.send(b"produce detached backlog\r")?;
+    let _ = code.pty.wait_for_text("FXBG")?;
+    code.pty.send(b"\x0f")?;
+    let _ = code.pty.wait_for_text("Full transcript")?;
+
+    let narrow = code.pty.checkpoint();
+    code.pty.resize(40, 16)?;
+    code.pty.send(b"\x0c")?;
+    let _ = code.pty.wait_for_text_since(&narrow, "Full transcript")?;
+    let wide = code.pty.checkpoint();
+    code.pty.resize(CODE_COLUMNS, CODE_ROWS)?;
+    code.pty.send(b"\x0c")?;
+    let _ = code.pty.wait_for_text_since(&wide, "Full transcript")?;
+
+    code.mock.release_backlog()?;
+    let _ = code.pty.wait_for_text("BG010")?;
+    code.pty.send(b"\x1b[F")?;
+    let _ = code.pty.wait_for_text("BG089")?;
+    let close = code.pty.checkpoint();
+    code.pty.send(b"\x1b")?;
+    let _ = code.pty.wait_for_text_since(&close, "Turn completed")?;
+    let emitted = &code.pty.output[close.output_len..];
+    for number in 0..90 {
+        let marker = format!("BG{number:03}");
+        let count = emitted
+            .windows(marker.len())
+            .filter(|window| *window == marker.as_bytes())
+            .count();
+        ensure!(
+            count == 1,
+            "detached catch-up emitted {marker} {count} times instead of once"
+        );
+    }
+    code.pty.send(b"\x04")?;
+    code.assert_terminal_restored()
+}
+
+#[test]
+fn permission_arriving_in_inspector_needs_f2_and_fresh_selection() -> Result<()> {
+    let mut code = CodeFixture::agent(MockScenario::PermissionDuringInspector)?;
+    code.wait_for_agent_ready()?;
+    code.pty.send(b"permission while detached\r")?;
+    let _ = code.pty.wait_for_text("FXPD")?;
+    code.pty.send(b"\x0f")?;
+    let _ = code.pty.wait_for_text("Full transcript")?;
+    code.mock.request_permissions()?;
+    let _ = code.pty.wait_for_text("Permission needed · F2 to review")?;
+
+    let ignored = code.pty.checkpoint();
+    code.pty.send(b"1\r\x0c")?;
+    let _ = code
+        .pty
+        .wait_for_text_since(&ignored, "Permission needed · F2 to review")?;
+    ensure!(
+        code.mock.captured_permission_outcomes()?.is_empty(),
+        "inspector keys answered a permission before explicit F2 focus"
+    );
+
+    code.pty.send(b"\x1b")?;
+    let _ = code
+        .pty
+        .wait_for_text("Permission needed · F2 focuses oldest pending request")?;
+    code.pty.send(b"\x1b[12~")?;
+    let _ = code.pty.wait_for_text("Press a number to highlight")?;
+    let no_selection = code.pty.checkpoint();
+    code.pty.send(b"\r\x0c")?;
+    let _ = code
+        .pty
+        .wait_for_text_since(&no_selection, "Press a number to highlight")?;
+    ensure!(
+        code.mock.captured_permission_outcomes()?.is_empty(),
+        "permission focus reused buffered selection input"
+    );
+
+    code.pty.send(b"1\r")?;
+    code.pty.send(b"\x1b[12~")?;
+    let _ = code.pty.wait_for_text("Allow fixture 2")?;
+    code.pty.send(b"1\r")?;
+    let _ = code.pty.wait_for_text("Turn completed")?;
+    let outcomes = code.mock.wait_for_permission_outcomes()?;
+    ensure!(
+        outcomes.len() == 2,
+        "permissions were not resolved exactly once"
+    );
+    code.pty.send(b"\x04")?;
+    code.assert_terminal_restored()
+}
+
+#[test]
+fn code_minimum_and_below_minimum_permission_paths_are_safe() -> Result<()> {
+    let mut code = CodeFixture::agent(MockScenario::OverlappingPermissions)?;
+    code.wait_for_agent_ready()?;
+    let resize_checkpoint = code.pty.checkpoint();
+    code.pty.resize(40, 16)?;
+    code.pty.send(b"\x0c")?;
+    let _ = code
+        .pty
+        .wait_for_raw_text_since(&resize_checkpoint, "\x1b[?2026l")?;
+    let resized = code.pty.checkpoint();
+    code.pty.send("中文 👩‍💻 permission\r".as_bytes())?;
+    let _ = code
+        .pty
+        .wait_for_text_since(&resized, "F2 permission (2)")?;
+
+    let small = code.pty.checkpoint();
+    code.pty.resize(30, 10)?;
+    code.pty.send(b"\x0c")?;
+    let raw_small = code
+        .pty
+        .wait_for_raw_text_since(&small, "Approval is disabled")?;
+    ensure!(
+        code.pty
+            .screen
+            .screen()
+            .contents()
+            .contains("Approval is disabled"),
+        "below-minimum safety copy was emitted but not visible; raw={raw_small:?}; screen={:?}",
+        code.pty.screen.screen().contents()
+    );
+    code.pty.send(b"\x1b[12~1\r")?;
+    let guarded = code.pty.checkpoint();
+    code.pty.send(b"\x0c")?;
+    let _ = code
+        .pty
+        .wait_for_text_since(&guarded, "Approval is disabled")?;
+    ensure!(
+        code.mock.captured_permission_outcomes()?.is_empty(),
+        "below-minimum input approved a permission"
+    );
+    code.pty.send(b"\x1b")?;
+    let _ = code.pty.wait_for_text("fixture permission 2")?;
+    let focus_second = code.pty.checkpoint();
+    code.pty.send(b"\x1b[12~\x0c")?;
+    let _ = code
+        .pty
+        .wait_for_raw_text_since(&focus_second, "\x1b[?2026h")?;
+    code.pty.send(b"\x1b")?;
+    let outcomes = code.mock.wait_for_permission_outcomes()?;
+    ensure!(
+        outcomes.len() == 2,
+        "safe denial did not resolve both requests"
+    );
+
+    code.pty.resize(40, 16)?;
+    let _ = code.pty.wait_for_text("Turn completed")?;
+    ensure!(
+        code.mock.captured_prompts()? == vec!["中文 👩‍💻 permission".to_string()],
+        "40×16 changed the submitted CJK/emoji prompt"
+    );
+    code.pty.send(b"\x04")?;
+    code.assert_terminal_restored()
+}
+
+#[test]
 fn code_external_editor_preserves_multiline_prompt_and_terminal() -> Result<()> {
     let mock = MockAcp::new(MockScenario::Minimal)?;
     let edited = "external-replacement 中文 👩‍💻\nsecond edited line  ";
@@ -1881,14 +2160,31 @@ fn code_sigint_restores_terminal_and_shell() -> Result<()> {
 }
 
 #[test]
+fn code_sigtstp_restores_then_sigcont_reacquires_terminal() -> Result<()> {
+    let mut code = CodeFixture::agent(MockScenario::Minimal)?;
+    code.wait_for_agent_ready()?;
+    let suspended = code.pty.checkpoint();
+    code.signal_child("TSTP")?;
+    let _ = code
+        .pty
+        .wait_for_raw_text_since(&suspended, "\x1b[?2004l")?;
+
+    let resumed = code.pty.checkpoint();
+    code.signal_child("CONT")?;
+    let _ = code.pty.wait_for_raw_text_since(&resumed, "\x1b[?2004h")?;
+    let screen = code.pty.wait_for_text_since(&resumed, "Message")?;
+    ensure!(
+        screen.contains("FXRD"),
+        "SIGCONT did not redraw the authoritative conversation"
+    );
+    code.pty.send(b"\x04")?;
+    code.assert_terminal_restored()
+}
+
+#[test]
 fn code_bare_entry_offers_selection_without_permanent_navigation() -> Result<()> {
     let mut bare = CodeFixture::bare()?;
-    let _ = bare.pty.wait_for_text("Ctrl-P commands")?;
-    let selection_checkpoint = bare.pty.checkpoint();
-    bare.pty.send(b"\x10")?;
-    let selection = bare
-        .pty
-        .wait_for_text_since(&selection_checkpoint, "Choose agent")?;
+    let selection = bare.pty.wait_for_text("claude-acp")?;
     ensure!(
         !selection.contains("Home")
             && !selection.contains("Agents")
@@ -1908,7 +2204,7 @@ fn code_bare_entry_offers_selection_without_permanent_navigation() -> Result<()>
     );
     let _ = bare
         .pty
-        .wait_for_text_since(&submit_checkpoint, "Choose agent")?;
+        .wait_for_text_since(&submit_checkpoint, "claude-acp")?;
     bare.close_to_composer()?;
     let clear_checkpoint = bare.pty.checkpoint();
     bare.pty.send(b"\x03")?;
@@ -1970,12 +2266,7 @@ fn code_hidden_chat_shares_palette_permissions_and_terminal_restoration() -> Res
 #[test]
 fn code_hidden_tui_bare_alias_uses_the_shared_empty_composer() -> Result<()> {
     let mut tui = CodeFixture::tui_bare()?;
-    let _ = tui.pty.wait_for_text("Ctrl-P commands")?;
-    let selection_checkpoint = tui.pty.checkpoint();
-    tui.pty.send(b"\x10")?;
-    let selection = tui
-        .pty
-        .wait_for_text_since(&selection_checkpoint, "Choose agent")?;
+    let selection = tui.pty.wait_for_text("claude-acp")?;
     ensure!(
         !selection.contains("Home")
             && !selection.contains("Agents")
@@ -1994,7 +2285,7 @@ fn code_queues_fifo_work_and_drains_after_each_normal_settlement() -> Result<()>
     queued.pty.send(b"first\r")?;
     let _ = queued.pty.wait_for_text("FXW1")?;
     queued.pty.paste("queued follow-up")?;
-    queued.pty.send(b"\t")?;
+    queued.pty.send(b"\r")?;
     let _ = queued.pty.wait_for_text("Queued for the next turn (")?;
 
     queued.mock.release()?;
@@ -2021,7 +2312,7 @@ fn code_cancellation_pauses_queue_without_replaying_uncertain_work() -> Result<(
     queued.pty.send(b"first\r")?;
     let _ = queued.pty.wait_for_text("FXCN")?;
     queued.pty.paste("queued follow-up")?;
-    queued.pty.send(b"\t")?;
+    queued.pty.send(b"\r")?;
     let _ = queued.pty.wait_for_text("Queued for the next turn (")?;
     let cancellation_checkpoint = queued.pty.checkpoint();
     queued.pty.send(b"\x03")?;
@@ -2047,7 +2338,7 @@ fn code_abnormal_stop_pauses_queue_without_draining_it() -> Result<()> {
     queued.pty.send(b"first\r")?;
     let _ = queued.pty.wait_for_text("FXRF")?;
     queued.pty.paste("queued after refusal")?;
-    queued.pty.send(b"\t")?;
+    queued.pty.send(b"\r")?;
     let _ = queued.pty.wait_for_text("Queued for the next turn (")?;
     let refusal_checkpoint = queued.pty.checkpoint();
     queued.mock.stop_with_refusal()?;
@@ -2110,7 +2401,7 @@ fn code_remote_operations_use_authenticated_remote_read_actions() -> Result<()> 
         "remote target and read-only scope were not visible: {root:?}"
     );
     ensure!(
-        !root.contains("Composer"),
+        !root.contains("Message"),
         "remote root exposed an enabled coding composer: {root:?}"
     );
     let capabilities = code
@@ -2129,8 +2420,7 @@ fn code_remote_operations_use_authenticated_remote_read_actions() -> Result<()> 
         palette.contains("Status")
             && palette.contains("Host requests")
             && palette.contains("Route preview")
-            && palette.contains("Providers")
-            && palette.contains("Telemetry"),
+            && palette.contains("Providers"),
         "remote palette omitted a supported read action: {palette:?}"
     );
     ensure!(
@@ -2139,6 +2429,18 @@ fn code_remote_operations_use_authenticated_remote_read_actions() -> Result<()> 
             && !palette.contains("Session route"),
         "remote palette offered ACP execution or route mutation: {palette:?}"
     );
+    code.pty.send(b"Telemetry")?;
+    let _ = code.pty.wait_for_text("Telemetry")?;
+    let palette_return = code.pty.checkpoint();
+    code.pty.send(b"\x1b")?;
+    let _ = code
+        .pty
+        .wait_for_text_since(&palette_return, "Ctrl-P opens target actions")?;
+    let models_palette = code.pty.checkpoint();
+    code.pty.send(b"\x10")?;
+    let _ = code
+        .pty
+        .wait_for_text_since(&models_palette, "Routable models")?;
     code.pty.send(b"Routable models\r")?;
     let models = code.pty.wait_for_text("REMOTE_A12_MODEL")?;
     ensure!(
@@ -2255,7 +2557,7 @@ fn code_socket_operations_remain_read_only_without_starting_an_agent() -> Result
     ensure!(
         root.contains("Local operations")
             && root.contains("read-only")
-            && !root.contains("Composer"),
+            && !root.contains("Message"),
         "socket-only entry did not show its read-only scope: {root:?}"
     );
     ensure!(
@@ -2300,7 +2602,7 @@ fn code_agent_settings_apply_only_a_confirmed_configuration() -> Result<()> {
     code.pty.send(b"A12 confirmed\r")?;
     let _ = code
         .pty
-        .wait_for_text_since(&confirmation_checkpoint, "Composer")?;
+        .wait_for_text_since(&confirmation_checkpoint, "Message")?;
     let request = code.mock.wait_for_request("session/set_config_option")?;
     ensure!(
         request["params"]["sessionId"] == "pty-native"

--- a/crates/bitrouter-tui/src/code.rs
+++ b/crates/bitrouter-tui/src/code.rs
@@ -1,4 +1,4 @@
-//! Conversation-first Code state and full-screen renderer.
+//! Conversation-first Code state and scrollback-native renderer.
 //!
 //! The application owns ACP I/O, reports, clipboard access, and async work.
 //! This module retains the conversation projection and returns plain effects.
@@ -13,8 +13,9 @@ use agent_client_protocol_schema::v1::{
 use crossterm::cursor::Hide;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::execute;
-use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Layout, Position, Rect};
+use ratatui::backend::{CrosstermBackend, TestBackend};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Position, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
@@ -28,6 +29,7 @@ use crate::journal::{Entry, EntryId, Journal, Voice};
 use crate::permission::Prompt;
 use crate::render::{self, Registry, ToolContext};
 use crate::wrap::wrap;
+use crate::writer::Writer;
 
 /// The four persistent conversation facts.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,6 +97,8 @@ pub enum CommandTarget {
         /// Opaque report id.
         id: String,
     },
+    /// Explicitly resume a paused next-turn queue.
+    ResumeQueue,
     /// Send an agent command as prompt text without local re-resolution.
     AgentPrompt {
         /// Exact command prompt.
@@ -330,6 +334,8 @@ pub enum CodeEffect {
         /// Exact text.
         text: String,
     },
+    /// Invalidate and repaint the presentation currently owned by Code.
+    Redraw,
     /// Exit the interactive Code process.
     Exit,
 }
@@ -353,15 +359,9 @@ enum TurnState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ReadingAnchor {
-    entry: EntryId,
-    source_offset: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ReadingPosition {
-    entry: EntryId,
-    source_offset: usize,
+enum QueueRunState {
+    Running,
+    Paused(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -372,7 +372,7 @@ enum Surface {
     Inspector(OpenInspector),
     Permission,
     Queue { selected: usize },
-    TranscriptSearch { query: String },
+    Recovery { selected: usize },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -419,6 +419,9 @@ enum Choice {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct OpenInspector {
     inspector: Inspector,
+    tracks_transcript: bool,
+    /// Stable retained entry selected by the full-transcript navigator.
+    transcript_entry: Option<EntryId>,
     scroll: usize,
     search: String,
     searching: bool,
@@ -431,6 +434,7 @@ struct OpenInspector {
 struct PendingPrompt {
     prompt: String,
     agent_command: bool,
+    from_queue: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -457,19 +461,18 @@ pub struct CodeState {
     permissions: VecDeque<PendingPermission>,
     permission_selected: Option<usize>,
     permission_return: Option<Surface>,
+    pending_followups: VecDeque<QueuedPrompt>,
     queue: VecDeque<QueuedPrompt>,
+    dispatching: Option<QueuedPrompt>,
+    queue_state: QueueRunState,
+    recovery: VecDeque<QueuedPrompt>,
     selected_command: Option<(String, CommandTarget, CommandOwner)>,
     surface: Surface,
-    follow_live: bool,
-    reading_anchor: Option<ReadingAnchor>,
-    reading_positions: Vec<ReadingPosition>,
-    reading_layout_revision: u64,
-    reading_page: usize,
-    new_activity: bool,
     notice: Option<String>,
     dispatch_after_permissions: bool,
     operations_only: bool,
     operations_root: Option<Inspector>,
+    viewport: Size,
 }
 
 impl Default for CodeState {
@@ -497,19 +500,18 @@ impl CodeState {
             permissions: VecDeque::new(),
             permission_selected: None,
             permission_return: None,
+            pending_followups: VecDeque::new(),
             queue: VecDeque::new(),
+            dispatching: None,
+            queue_state: QueueRunState::Running,
+            recovery: VecDeque::new(),
             selected_command: None,
             surface: Surface::Conversation,
-            follow_live: true,
-            reading_anchor: None,
-            reading_positions: Vec::new(),
-            reading_layout_revision: 0,
-            reading_page: 1,
-            new_activity: false,
             notice: None,
             dispatch_after_permissions: false,
             operations_only: false,
             operations_root: None,
+            viewport: Size::new(80, 24),
         }
     }
 
@@ -638,6 +640,11 @@ impl CodeState {
 
     /// Open a full-content temporary inspector.
     pub fn open_inspector(&mut self, inspector: Inspector) {
+        if !self.permissions.is_empty() {
+            self.notice =
+                Some("Permission needed · F2 to review before opening details".to_string());
+            return;
+        }
         let return_to = self.transient_return_target();
         self.open_inspector_returning_to(inspector, return_to);
     }
@@ -649,6 +656,8 @@ impl CodeState {
     ) {
         self.surface = Surface::Inspector(OpenInspector {
             inspector,
+            tracks_transcript: false,
+            transcript_entry: None,
             scroll: 0,
             search: String::new(),
             searching: false,
@@ -663,8 +672,8 @@ impl CodeState {
     /// composer remains disabled for the entire operations-only surface.
     pub fn operations_root(&mut self, inspector: Inspector) {
         self.operations_only = true;
-        self.operations_root = Some(inspector.clone());
-        self.open_inspector_returning_to(inspector, None);
+        self.operations_root = Some(inspector);
+        self.surface = Surface::Conversation;
     }
 
     /// Toggle operations-only mode when no ACP session exists.
@@ -681,7 +690,7 @@ impl CodeState {
     /// The queue belongs to the prior native session, so the caller must make
     /// an explicit discard decision before changing sessions.
     pub fn reset_session(&mut self) -> bool {
-        if !self.queue.is_empty() {
+        if self.has_queue_work() {
             self.notice =
                 Some("Resolve or discard queued prompts before changing sessions".to_string());
             return false;
@@ -694,47 +703,60 @@ impl CodeState {
         self.permission_return = None;
         self.turn = TurnState::Ready;
         self.pending_prompt = None;
+        self.pending_followups.clear();
+        self.dispatching = None;
+        self.queue_state = QueueRunState::Running;
+        self.recovery.clear();
         self.dispatch_after_permissions = false;
         self.session_active = false;
         self.surface = Surface::Conversation;
-        self.follow_live = true;
-        self.reading_anchor = None;
-        self.reading_positions.clear();
-        self.reading_layout_revision = 0;
-        self.reading_page = 1;
-        self.new_activity = false;
         self.selected_command = None;
         true
     }
 
     /// Explicitly discard all process-local queued prompts.
     pub fn discard_queue(&mut self) {
+        self.pending_followups.clear();
         self.queue.clear();
+        self.dispatching = None;
+        self.queue_state = QueueRunState::Running;
+        self.recovery.clear();
         self.refresh_open_palettes();
     }
 
     /// Number of prompts awaiting a normal turn completion.
     pub fn queue_len(&self) -> usize {
-        self.queue.len()
+        self.pending_followups
+            .len()
+            .saturating_add(self.queue.len())
+            .saturating_add(usize::from(self.dispatching.is_some()))
+            .saturating_add(self.recovery.len())
+    }
+
+    fn queued_preview_len(&self) -> usize {
+        self.pending_followups
+            .len()
+            .saturating_add(self.queue.len())
+    }
+
+    fn has_queue_work(&self) -> bool {
+        self.queue_len() > 0
     }
 
     /// Apply one raw ACP update to the retained journal.
     pub fn apply(&mut self, update: SessionUpdate) {
         self.journal.apply(update);
         self.journal_revision = self.journal_revision.saturating_add(1);
-        if !self.follow_live {
-            self.new_activity = true;
+        if matches!(
+            &self.surface,
+            Surface::Inspector(inspector) if inspector.tracks_transcript
+        ) {
+            let content = self.transcript_content();
+            if let Surface::Inspector(inspector) = &mut self.surface {
+                inspector.inspector.content = content;
+            }
         }
         self.refresh_open_palettes();
-    }
-
-    fn sync_reading_layout(&mut self, revision: u64, positions: &[ReadingPosition], page: usize) {
-        self.reading_page = page.max(1);
-        if self.reading_layout_revision == revision {
-            return;
-        }
-        self.reading_positions = positions.to_vec();
-        self.reading_layout_revision = revision;
     }
 
     /// Queue a permission request by identity.
@@ -788,12 +810,16 @@ impl CodeState {
             CodeAction::TurnStarted => {
                 if let Some(pending) = self.pending_prompt.take() {
                     let prompt = pending.prompt;
+                    if pending.from_queue {
+                        self.dispatching = None;
+                    }
                     self.finish_journal_stream();
                     self.apply(SessionUpdate::UserMessageChunk(ContentChunk::new(
                         ContentBlock::Text(TextContent::new(prompt.clone())),
                     )));
                     self.finish_journal_stream();
                     self.editor.push_history(prompt);
+                    self.queue.extend(self.pending_followups.drain(..));
                     self.turn = TurnState::Working;
                     self.refresh_open_palettes();
                 }
@@ -818,6 +844,10 @@ impl CodeState {
     }
 
     fn event(&mut self, event: &Event) -> Vec<CodeEffect> {
+        if let Event::Resize(width, height) = event {
+            self.viewport = Size::new(*width, *height);
+            return Vec::new();
+        }
         if let Some(key) = pressed(event)
             && key.code == KeyCode::F(2)
             && !self.permissions.is_empty()
@@ -838,13 +868,16 @@ impl CodeState {
             }
             return Vec::new();
         }
+        if crate::editor::is_redraw(event) {
+            return vec![CodeEffect::Redraw];
+        }
         match self.surface {
             Surface::Conversation => self.conversation_event(event),
             Surface::Palette(_) | Surface::Selector(_) => self.choice_event(event),
             Surface::Inspector(_) => self.inspector_event(event),
             Surface::Permission => self.permission_event(event),
             Surface::Queue { .. } => self.queue_event(event),
-            Surface::TranscriptSearch { .. } => self.transcript_search_event(event),
+            Surface::Recovery { .. } => self.recovery_event(event),
         }
     }
 
@@ -857,7 +890,16 @@ impl CodeState {
                 self.open_palette(false, String::new());
                 return Vec::new();
             }
+            if control(key, 'o') {
+                if let Some(root) = self.operations_root.clone() {
+                    self.open_inspector(root);
+                } else {
+                    self.notice = Some("Target status is still loading".to_string());
+                }
+                return Vec::new();
+            }
             if key.code == KeyCode::Esc
+                || control(key, 'c')
                 || (key.code == KeyCode::Char('d') && key.modifiers.contains(KeyModifiers::CONTROL))
             {
                 return vec![CodeEffect::Exit];
@@ -874,8 +916,21 @@ impl CodeState {
             return Vec::new();
         };
 
-        if key.code == KeyCode::F(3) && !self.queue.is_empty() {
-            self.surface = Surface::Queue { selected: 0 };
+        if key.code == KeyCode::Enter && !supported_viewport(self.viewport) {
+            self.notice = Some("Resize to at least 40×16 before submitting".to_string());
+            return Vec::new();
+        }
+
+        if key.code == KeyCode::F(3) && self.has_queue_work() {
+            self.surface = if self.recovery.is_empty() {
+                Surface::Queue { selected: 0 }
+            } else {
+                Surface::Recovery { selected: 0 }
+            };
+            return Vec::new();
+        }
+        if control(key, 'o') {
+            self.inspect_transcript();
             return Vec::new();
         }
         if key.code == KeyCode::F(4) {
@@ -886,38 +941,13 @@ impl CodeState {
             self.open_palette(false, String::new());
             return Vec::new();
         }
-        if control(key, 'f') {
-            self.surface = Surface::TranscriptSearch {
-                query: String::new(),
-            };
-            return Vec::new();
-        }
         if control(key, 'y') {
             return self.copy_anchor();
         }
         if control(key, 'g') && self.turn == TurnState::Ready && self.permissions.is_empty() {
             return vec![CodeEffect::ExternalEditor];
         }
-        if control(key, 'l') {
-            return Vec::new();
-        }
-        if key.code == KeyCode::End && key.modifiers.contains(KeyModifiers::CONTROL) {
-            self.return_to_live();
-            return Vec::new();
-        }
         match key.code {
-            KeyCode::PageUp => {
-                self.read_previous();
-                return Vec::new();
-            }
-            KeyCode::PageDown => {
-                self.read_next();
-                return Vec::new();
-            }
-            KeyCode::Tab if matches!(self.turn, TurnState::Submitting | TurnState::Working) => {
-                self.queue_current();
-                return Vec::new();
-            }
             KeyCode::Esc if self.turn == TurnState::Working => return self.cancel(),
             KeyCode::Esc if self.turn == TurnState::Submitting => {
                 self.notice = Some("Waiting for prompt submission to start".to_string());
@@ -964,7 +994,7 @@ impl CodeState {
                     .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT)
                     && matches!(self.turn, TurnState::Submitting | TurnState::Working) =>
             {
-                self.notice = Some("Tab queues for the next turn; Esc interrupts".to_string());
+                self.queue_current();
                 return Vec::new();
             }
             KeyCode::Esc if self.turn == TurnState::Ready => {
@@ -987,9 +1017,16 @@ impl CodeState {
                 }
                 Vec::new()
             }
+            Edit::Submitted
+                if self.turn == TurnState::Ready
+                    && matches!(self.queue_state, QueueRunState::Paused(_)) =>
+            {
+                self.queue_current();
+                Vec::new()
+            }
             Edit::Submitted if self.turn == TurnState::Ready => self.submit_current(),
             Edit::Submitted => {
-                self.notice = Some("Tab queues for the next turn; Esc interrupts".to_string());
+                self.notice = Some("Wait for the current transition to settle".to_string());
                 Vec::new()
             }
             Edit::OpenExternalEditor => vec![CodeEffect::ExternalEditor],
@@ -1096,7 +1133,7 @@ impl CodeState {
                     self.submit_current()
                 } else {
                     self.notice =
-                        Some("Tab queues this agent command for the next turn".to_string());
+                        Some("Enter queues this agent command for the next turn".to_string());
                     Vec::new()
                 }
             }
@@ -1118,7 +1155,7 @@ impl CodeState {
             | Surface::Inspector(_)
             | Surface::Permission
             | Surface::Queue { .. }
-            | Surface::TranscriptSearch { .. } => None,
+            | Surface::Recovery { .. } => None,
         };
     }
 
@@ -1131,6 +1168,7 @@ impl CodeState {
             CommandTarget::OpenSession => vec![CodeEffect::OpenSession],
             CommandTarget::Settings => vec![CodeEffect::Settings],
             CommandTarget::Report { id } => vec![CodeEffect::Report { id }],
+            CommandTarget::ResumeQueue => self.resume_queue(),
             CommandTarget::AgentPrompt { prompt } => self.begin_prompt(prompt, true),
             CommandTarget::PromptTemplate { prompt } => {
                 self.editor.set_text(prompt);
@@ -1143,11 +1181,17 @@ impl CodeState {
         let Some(key) = pressed(event) else {
             return Vec::new();
         };
-        if control(key, 'l') {
-            return Vec::new();
-        }
         if control(key, 'c') {
             return self.cancel();
+        }
+        if !supported_viewport(self.viewport)
+            && (key.code == KeyCode::Enter || matches!(key.code, KeyCode::Char('1'..='9')))
+        {
+            self.notice = Some(
+                "Approval disabled until every offered choice fits at 40×16 or larger".to_string(),
+            );
+            self.permission_selected = None;
+            return Vec::new();
         }
         if key.code == KeyCode::F(4) {
             self.inspect_permission_context();
@@ -1243,6 +1287,9 @@ impl CodeState {
         let Some(key) = pressed(event) else {
             return Vec::new();
         };
+        if key.code == KeyCode::Char('r') {
+            return self.resume_queue();
+        }
         let Surface::Queue { selected } = &mut self.surface else {
             return Vec::new();
         };
@@ -1251,6 +1298,19 @@ impl CodeState {
             return Vec::new();
         }
         match key.code {
+            KeyCode::Up if key.modifiers.contains(KeyModifiers::ALT) && *selected > 0 => {
+                let previous = selected.saturating_sub(1);
+                self.queue.swap(*selected, previous);
+                *selected = previous;
+            }
+            KeyCode::Down
+                if key.modifiers.contains(KeyModifiers::ALT)
+                    && selected.saturating_add(1) < self.queue.len() =>
+            {
+                let next = selected.saturating_add(1);
+                self.queue.swap(*selected, next);
+                *selected = next;
+            }
             KeyCode::Up => *selected = selected.saturating_sub(1),
             KeyCode::Down => {
                 *selected = selected
@@ -1267,6 +1327,11 @@ impl CodeState {
                 }
             }
             KeyCode::Enter | KeyCode::Char('e') => {
+                if !self.editor.text().is_empty() {
+                    self.notice =
+                        Some("Clear the composer before editing a queued draft".to_string());
+                    return Vec::new();
+                }
                 let index = *selected;
                 if let Some(item) = self.queue.remove(index) {
                     self.editor.set_text(item.prompt);
@@ -1285,34 +1350,63 @@ impl CodeState {
         Vec::new()
     }
 
-    fn transcript_search_event(&mut self, event: &Event) -> Vec<CodeEffect> {
+    fn resume_queue(&mut self) -> Vec<CodeEffect> {
+        if let Some(reason) = self.resume_queue_reason() {
+            self.notice = Some(reason);
+            return Vec::new();
+        }
+        self.queue_state = QueueRunState::Running;
+        self.surface = Surface::Conversation;
+        self.notice = Some("Next-turn queue resumed".to_string());
+        self.refresh_open_palettes();
+        self.dispatch_next()
+    }
+
+    fn recovery_event(&mut self, event: &Event) -> Vec<CodeEffect> {
         let Some(key) = pressed(event) else {
             return Vec::new();
         };
-        let mut updated_query = None;
-        let mut close = false;
-        if let Surface::TranscriptSearch { query } = &mut self.surface {
-            match key.code {
-                KeyCode::Esc | KeyCode::Enter => close = true,
-                KeyCode::Backspace => {
-                    query.pop();
-                    updated_query = Some(query.clone());
-                }
-                KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    query.push(character);
-                    updated_query = Some(query.clone());
-                }
-                _ => {}
-            }
-        }
-        if control(key, 'c') {
-            close = true;
-        }
-        if let Some(query) = updated_query {
-            self.search_transcript(&query);
-        }
-        if close {
+        if key.code == KeyCode::Esc || control(key, 'c') {
             self.surface = Surface::Conversation;
+            return Vec::new();
+        }
+        let Surface::Recovery { selected } = &mut self.surface else {
+            return Vec::new();
+        };
+        match key.code {
+            KeyCode::Up => *selected = selected.saturating_sub(1),
+            KeyCode::Down => {
+                *selected = selected
+                    .saturating_add(1)
+                    .min(self.recovery.len().saturating_sub(1));
+            }
+            KeyCode::Delete | KeyCode::Backspace => {
+                let _ = self.recovery.remove(*selected);
+                if self.recovery.is_empty() {
+                    self.surface = Surface::Conversation;
+                } else {
+                    *selected = (*selected).min(self.recovery.len().saturating_sub(1));
+                }
+            }
+            KeyCode::Enter => {
+                if !self.editor.text().is_empty() {
+                    self.notice =
+                        Some("Clear the composer before restoring a rejected draft".to_string());
+                    return Vec::new();
+                }
+                if let Some(item) = self.recovery.remove(*selected) {
+                    self.editor.set_text(item.prompt);
+                    self.selected_command = item.target.map(|target| {
+                        (
+                            self.editor.text().to_string(),
+                            target,
+                            item.owner.unwrap_or(CommandOwner::Agent),
+                        )
+                    });
+                }
+                self.surface = Surface::Conversation;
+            }
+            _ => {}
         }
         Vec::new()
     }
@@ -1328,6 +1422,8 @@ impl CodeState {
         }
         let mut close = false;
         let mut copy = None;
+        let mut move_entry = None;
+        let mut inspect_entry = false;
         if let Surface::Inspector(inspector) = &mut self.surface {
             if control(key, 'c') {
                 close = true;
@@ -1341,6 +1437,12 @@ impl CodeState {
                 inspector.searching = true;
             } else if control(key, 'y') {
                 copy = Some(inspector.inspector.content.clone());
+            } else if inspector.tracks_transcript && key.code == KeyCode::Char('[') {
+                move_entry = Some(-1);
+            } else if inspector.tracks_transcript && key.code == KeyCode::Char(']') {
+                move_entry = Some(1);
+            } else if inspector.tracks_transcript && key.code == KeyCode::F(4) {
+                inspect_entry = true;
             } else if inspector.searching {
                 match key.code {
                     KeyCode::Enter => inspector.searching = false,
@@ -1369,10 +1471,23 @@ impl CodeState {
                     KeyCode::PageUp => inspector.scroll = inspector.scroll.saturating_sub(8),
                     KeyCode::PageDown => inspector.scroll = inspector.scroll.saturating_add(8),
                     KeyCode::Home => inspector.scroll = 0,
-                    KeyCode::End => inspector.scroll = inspector.inspector.content.lines().count(),
+                    KeyCode::End => {
+                        inspector.scroll = inspector
+                            .inspector
+                            .content
+                            .lines()
+                            .count()
+                            .saturating_sub(1)
+                    }
                     _ => {}
                 }
             }
+        }
+        if let Some(delta) = move_entry {
+            self.move_transcript_entry(delta);
+        }
+        if inspect_entry {
+            self.inspect_selected_transcript_entry();
         }
         if close {
             let (return_to_permission, return_to) = match &self.surface {
@@ -1381,16 +1496,7 @@ impl CodeState {
                 }
                 _ => (false, None),
             };
-            if let Some(root) = self.operations_root.clone() {
-                let closing_root = matches!(
-                    &self.surface,
-                    Surface::Inspector(current) if current.inspector == root
-                );
-                if closing_root {
-                    return vec![CodeEffect::Exit];
-                }
-                self.open_inspector_returning_to(root, None);
-            } else if return_to_permission {
+            if return_to_permission {
                 self.surface = Surface::Permission;
             } else {
                 self.surface = return_to.map_or(Surface::Conversation, |surface| *surface);
@@ -1470,9 +1576,9 @@ impl CodeState {
         self.pending_prompt = Some(PendingPrompt {
             prompt: prompt.clone(),
             agent_command,
+            from_queue: false,
         });
         self.turn = TurnState::Submitting;
-        self.return_to_live();
         self.refresh_open_palettes();
         if agent_command {
             vec![CodeEffect::AgentPrompt { prompt }]
@@ -1486,6 +1592,7 @@ impl CodeState {
         let agent_command = pending
             .as_ref()
             .is_some_and(|pending| pending.agent_command);
+        let from_queue = pending.as_ref().is_some_and(|pending| pending.from_queue);
         let restored = if prompt.is_empty() {
             pending
                 .as_ref()
@@ -1496,23 +1603,24 @@ impl CodeState {
         };
         self.turn = TurnState::Ready;
         self.dispatch_after_permissions = false;
-        if self.editor.text().is_empty() {
-            self.editor.set_text(restored.clone());
-            if agent_command {
-                self.selected_command = Some((
-                    restored.clone(),
-                    CommandTarget::AgentPrompt { prompt: restored },
-                    CommandOwner::Agent,
-                ));
-            }
-        } else if !restored.is_empty() {
-            self.queue.push_front(QueuedPrompt {
+        if from_queue {
+            self.dispatching = None;
+        }
+        if !restored.is_empty() {
+            self.recovery.push_back(QueuedPrompt {
                 prompt: restored.clone(),
                 owner: agent_command.then_some(CommandOwner::Agent),
                 target: agent_command.then_some(CommandTarget::AgentPrompt { prompt: restored }),
             });
         }
-        self.notice = Some(format!("Prompt was not started: {reason}"));
+        self.recovery.extend(self.pending_followups.drain(..));
+        self.queue_state = QueueRunState::Paused(reason.clone());
+        if !self.recovery.is_empty() {
+            self.surface = Surface::Recovery { selected: 0 };
+        }
+        self.notice = Some(format!(
+            "Prompt was not started: {reason}. Queue paused; recover drafts explicitly."
+        ));
         self.refresh_open_palettes();
         Vec::new()
     }
@@ -1538,9 +1646,13 @@ impl CodeState {
                 None => return,
             },
         };
-        self.queue.push_back(queued);
+        if self.turn == TurnState::Submitting {
+            self.pending_followups.push_back(queued);
+        } else {
+            self.queue.push_back(queued);
+        }
         self.editor.clear();
-        self.notice = Some(format!("Queued for the next turn ({})", self.queue.len()));
+        self.notice = Some(format!("Queued for the next turn ({})", self.queue_len()));
     }
 
     fn queueable_prompt(&mut self, prompt: &str) -> Option<QueuedPrompt> {
@@ -1611,27 +1723,34 @@ impl CodeState {
         match outcome {
             TurnOutcome::Completed => {
                 if was_cancelling {
+                    self.pause_queue("turn completed after cancellation request");
                     self.notice = Some(
                         "Turn completed after cancellation request. Queue is paused.".to_string(),
                     );
                     return Vec::new();
                 }
                 self.notice = Some("Turn completed".to_string());
-                if self.permissions.is_empty() {
+                if self.permissions.is_empty() && matches!(self.queue_state, QueueRunState::Running)
+                {
                     return self.dispatch_next();
                 }
-                self.dispatch_after_permissions = !self.queue.is_empty();
+                self.dispatch_after_permissions =
+                    !self.queue.is_empty() && matches!(self.queue_state, QueueRunState::Running);
             }
             TurnOutcome::Stopped(reason) => {
+                self.pause_queue(format!("turn stopped: {reason}"));
                 self.notice = Some(format!("Turn stopped: {reason}. Queue is paused."));
             }
             TurnOutcome::Failed(error) => {
+                self.pause_queue(format!("turn failed: {error}"));
                 self.notice = Some(format!("Turn failed: {error}. Queue is paused."));
             }
             TurnOutcome::Cancelled => {
+                self.pause_queue("turn cancelled");
                 self.notice = Some("Turn cancelled. Queue is paused.".to_string());
             }
             TurnOutcome::Disconnected => {
+                self.pause_queue("disconnected");
                 self.notice = Some("Disconnected. Queue is paused.".to_string());
             }
         }
@@ -1639,26 +1758,53 @@ impl CodeState {
     }
 
     fn dispatch_next(&mut self) -> Vec<CodeEffect> {
+        if !matches!(self.queue_state, QueueRunState::Running) || self.dispatching.is_some() {
+            return Vec::new();
+        }
         let Some(next) = self.queue.front().cloned() else {
             return Vec::new();
         };
         if matches!(next.owner, Some(CommandOwner::Agent))
             && !self.agent_command_available(&next.prompt)
         {
+            self.pause_queue("queued agent command is no longer advertised");
             self.notice =
                 Some("Queued agent command is no longer advertised; queue is paused".to_string());
             return Vec::new();
         }
         let _ = self.queue.pop_front();
-        match next.target {
-            Some(CommandTarget::AgentPrompt { prompt }) => self.begin_prompt(prompt, true),
-            Some(CommandTarget::PromptTemplate { prompt }) => self.begin_prompt(prompt, false),
+        let effect = match &next.target {
+            Some(CommandTarget::AgentPrompt { prompt }) => CodeEffect::AgentPrompt {
+                prompt: prompt.clone(),
+            },
+            Some(CommandTarget::PromptTemplate { prompt }) => CodeEffect::Submit {
+                prompt: prompt.clone(),
+            },
             Some(_) => {
+                self.recovery.push_back(next);
+                self.pause_queue("queued local action is not runnable as a prompt");
                 self.notice = Some("Queued local action is not runnable as a prompt".to_string());
-                Vec::new()
+                return Vec::new();
             }
-            None => self.begin_prompt(next.prompt, false),
-        }
+            None => CodeEffect::Submit {
+                prompt: next.prompt.clone(),
+            },
+        };
+        let agent_command = matches!(&effect, CodeEffect::AgentPrompt { .. });
+        self.pending_prompt = Some(PendingPrompt {
+            prompt: next.prompt.clone(),
+            agent_command,
+            from_queue: true,
+        });
+        self.dispatching = Some(next);
+        self.turn = TurnState::Submitting;
+        self.refresh_open_palettes();
+        vec![effect]
+    }
+
+    fn pause_queue(&mut self, reason: impl Into<String>) {
+        self.queue_state = QueueRunState::Paused(reason.into());
+        self.dispatch_after_permissions = false;
     }
 
     fn cancel(&mut self) -> Vec<CodeEffect> {
@@ -1736,7 +1882,7 @@ impl CodeState {
         return_to: Option<Box<Surface>>,
     ) {
         let choices = self
-            .palette_commands()
+            .palette_commands(slash)
             .into_iter()
             .map(Choice::Command)
             .collect::<Vec<_>>();
@@ -1786,20 +1932,31 @@ impl CodeState {
         }
     }
 
-    fn palette_commands(&self) -> Vec<Command> {
+    fn palette_commands(&self, slash: bool) -> Vec<Command> {
         let mut commands = self
             .commands
             .iter()
             .filter(|command| {
-                !self.operations_only
-                    || !matches!(
-                        &command.target,
-                        CommandTarget::AgentPrompt { .. } | CommandTarget::PromptTemplate { .. }
-                    )
+                (!slash || command.label.starts_with('/'))
+                    && (!self.operations_only
+                        || !matches!(
+                            &command.target,
+                            CommandTarget::AgentPrompt { .. }
+                                | CommandTarget::PromptTemplate { .. }
+                        ))
             })
             .cloned()
             .map(|command| self.command_with_local_availability(command))
             .collect::<Vec<_>>();
+        if !slash && matches!(self.queue_state, QueueRunState::Paused(_)) {
+            let resume = self.command_with_local_availability(Command::new(
+                "Resume queue",
+                "Resume FIFO dispatch after reviewing paused work",
+                CommandOwner::BitRouter,
+                CommandTarget::ResumeQueue,
+            ));
+            commands.insert(0, resume);
+        }
         if !self.operations_only && self.journal.commands_received() {
             commands.extend(self.journal.commands().iter().map(|command| {
                 let label = if command.name.starts_with('/') {
@@ -1814,7 +1971,7 @@ impl CodeState {
                     CommandTarget::AgentPrompt { prompt: label },
                 )
             }));
-        } else if !self.operations_only {
+        } else if !self.operations_only && !slash {
             commands.push(
                 Command::new(
                     "Agent commands",
@@ -1831,14 +1988,19 @@ impl CodeState {
     }
 
     fn refresh_open_palettes(&mut self) {
-        let choices = self
-            .palette_commands()
+        let full = self
+            .palette_commands(false)
             .into_iter()
             .map(Choice::Command)
             .collect::<Vec<_>>();
-        refresh_palette_surface(&mut self.surface, &choices);
+        let slash = self
+            .palette_commands(true)
+            .into_iter()
+            .map(Choice::Command)
+            .collect::<Vec<_>>();
+        refresh_palette_surface(&mut self.surface, &full, &slash);
         if let Some(surface) = &mut self.permission_return {
-            refresh_palette_surface(surface, &choices);
+            refresh_palette_surface(surface, &full, &slash);
         }
     }
 
@@ -1865,6 +2027,7 @@ impl CodeState {
                         )
                     })
             }),
+            CommandTarget::ResumeQueue => self.resume_queue_reason(),
             _ => None,
         };
         if let Some(reason) = unavailable {
@@ -1885,10 +2048,26 @@ impl CodeState {
                 "Finish or cancel the current turn before changing this session".to_string(),
             );
         }
-        if !self.queue.is_empty() {
+        if self.has_queue_work() {
             return Some(
                 "Resolve or discard queued prompts before changing this session".to_string(),
             );
+        }
+        None
+    }
+
+    fn resume_queue_reason(&self) -> Option<String> {
+        if !matches!(self.queue_state, QueueRunState::Paused(_)) {
+            return Some("The next-turn queue is already running".to_string());
+        }
+        if !self.session_active || self.turn != TurnState::Ready {
+            return Some("Reconnect and settle the active turn before resuming".to_string());
+        }
+        if !self.permissions.is_empty() || self.dispatching.is_some() {
+            return Some("Resolve the pending transition before resuming".to_string());
+        }
+        if !self.recovery.is_empty() {
+            return Some("Recover or discard rejected drafts before resuming".to_string());
         }
         None
     }
@@ -1914,77 +2093,13 @@ impl CodeState {
         }
     }
 
-    fn read_previous(&mut self) {
-        if self.reading_positions.is_empty() {
-            return;
-        }
-        let current = self
-            .reading_anchor
-            .as_ref()
-            .and_then(|anchor| self.reading_position(anchor))
-            .unwrap_or(self.reading_positions.len());
-        let target = current.saturating_sub(self.reading_page);
-        if let Some(position) = self.reading_positions.get(target).cloned() {
-            self.follow_live = false;
-            self.reading_anchor = Some(ReadingAnchor {
-                entry: position.entry,
-                source_offset: position.source_offset,
-            });
-        }
-    }
-
-    fn read_next(&mut self) {
-        let Some(anchor) = self.reading_anchor.clone() else {
-            return;
-        };
-        let Some(position) = self.reading_position(&anchor) else {
-            self.return_to_live();
-            return;
-        };
-        if let Some(next) = self
-            .reading_positions
-            .get(position.saturating_add(self.reading_page))
-            .cloned()
-        {
-            self.reading_anchor = Some(ReadingAnchor {
-                entry: next.entry,
-                source_offset: next.source_offset,
-            });
-        } else {
-            self.return_to_live();
-        }
-    }
-
-    fn reading_position(&self, anchor: &ReadingAnchor) -> Option<usize> {
-        self.reading_positions
-            .iter()
-            .position(|position| {
-                position.entry == anchor.entry && position.source_offset >= anchor.source_offset
-            })
-            .or_else(|| {
-                self.reading_positions
-                    .iter()
-                    .rposition(|position| position.entry == anchor.entry)
-            })
-    }
-
-    fn return_to_live(&mut self) {
-        self.follow_live = true;
-        self.reading_anchor = None;
-        self.new_activity = false;
-    }
-
     fn finish_journal_stream(&mut self) {
         self.journal.finish_stream();
         self.journal_revision = self.journal_revision.saturating_add(1);
     }
 
     fn inspect_anchor(&mut self) {
-        let id = self
-            .reading_anchor
-            .as_ref()
-            .map(|anchor| anchor.entry.clone())
-            .or_else(|| self.journal.entries().last().map(|item| item.id));
+        let id = self.journal.entries().last().map(|item| item.id);
         let Some(id) = id else {
             self.notice = Some("There is no transcript entry to inspect".to_string());
             return;
@@ -1994,6 +2109,124 @@ impl CodeState {
             return;
         };
         self.open_inspector(inspector);
+    }
+
+    fn inspect_transcript(&mut self) {
+        let first_entry = self.journal.entries().next().map(|item| item.id);
+        if first_entry.is_none() {
+            self.notice = Some("There is no transcript to inspect".to_string());
+            return;
+        }
+        let content = self.transcript_content();
+        let return_to = self.transient_return_target();
+        self.surface = Surface::Inspector(OpenInspector {
+            inspector: Inspector::new("Full transcript", content),
+            tracks_transcript: true,
+            transcript_entry: first_entry,
+            scroll: 0,
+            search: String::new(),
+            searching: false,
+            return_to,
+            return_to_permission: false,
+        });
+    }
+
+    fn transcript_content(&self) -> String {
+        self.transcript_sections()
+            .into_iter()
+            .map(|(_, section)| section)
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+
+    fn transcript_sections(&self) -> Vec<(EntryId, String)> {
+        self.journal
+            .entries()
+            .map(|item| {
+                let section = match item.entry {
+                    Entry::Message(message) => {
+                        let owner = match message.voice {
+                            Voice::User => "User",
+                            Voice::Agent => "Assistant",
+                            Voice::Thought => "Reasoning",
+                        };
+                        format!("## {owner}\n\n{}", message.text)
+                    }
+                    Entry::Tool(call) => {
+                        let content = match serde_json::to_string_pretty(call) {
+                            Ok(content) => content,
+                            Err(error) => {
+                                format!("Could not serialise retained tool content: {error}")
+                            }
+                        };
+                        format!("## Tool · {}\n\n{content}", call.title)
+                    }
+                    Entry::Plan(plan) => {
+                        let content = match serde_json::to_string_pretty(plan) {
+                            Ok(content) => content,
+                            Err(error) => format!("Could not serialise retained plan: {error}"),
+                        };
+                        format!("## Plan\n\n{content}")
+                    }
+                };
+                (item.id, section)
+            })
+            .collect()
+    }
+
+    fn move_transcript_entry(&mut self, delta: isize) {
+        let current = match &self.surface {
+            Surface::Inspector(inspector) if inspector.tracks_transcript => {
+                inspector.transcript_entry.clone()
+            }
+            _ => return,
+        };
+        let sections = self.transcript_sections();
+        if sections.is_empty() {
+            return;
+        }
+        let current_index = current
+            .as_ref()
+            .and_then(|current| sections.iter().position(|(id, _)| id == current))
+            .unwrap_or_default();
+        let next_index = if delta < 0 {
+            current_index.saturating_sub(delta.unsigned_abs())
+        } else {
+            current_index
+                .saturating_add(delta.unsigned_abs())
+                .min(sections.len().saturating_sub(1))
+        };
+        let line = sections
+            .iter()
+            .take(next_index)
+            .map(|(_, section)| section.lines().count().saturating_add(2))
+            .sum();
+        if let Surface::Inspector(inspector) = &mut self.surface {
+            inspector.transcript_entry = Some(sections[next_index].0.clone());
+            inspector.scroll = line;
+        }
+    }
+
+    fn inspect_selected_transcript_entry(&mut self) {
+        if !self.permissions.is_empty() {
+            self.notice =
+                Some("Permission needed · F2 to review before opening details".to_string());
+            return;
+        }
+        let target = match &self.surface {
+            Surface::Inspector(inspector) if inspector.tracks_transcript => {
+                inspector.transcript_entry.clone()
+            }
+            _ => None,
+        };
+        let Some(target) = target else {
+            return;
+        };
+        let Some(detail) = self.inspector_for(&target) else {
+            return;
+        };
+        let return_to = Some(Box::new(self.surface.clone()));
+        self.open_inspector_returning_to(detail, return_to);
     }
 
     fn inspect_permission_context(&mut self) {
@@ -2011,6 +2244,8 @@ impl CodeState {
         };
         self.surface = Surface::Inspector(OpenInspector {
             inspector: Inspector::new("Permission context", content),
+            tracks_transcript: false,
+            transcript_entry: None,
             scroll: 0,
             search: String::new(),
             searching: false,
@@ -2020,11 +2255,7 @@ impl CodeState {
     }
 
     fn copy_anchor(&self) -> Vec<CodeEffect> {
-        let id = self
-            .reading_anchor
-            .as_ref()
-            .map(|anchor| anchor.entry.clone())
-            .or_else(|| self.journal.entries().last().map(|item| item.id));
+        let id = self.journal.entries().last().map(|item| item.id);
         let Some(id) = id else {
             return Vec::new();
         };
@@ -2060,33 +2291,6 @@ impl CodeState {
             };
             Some(inspector)
         })
-    }
-
-    fn search_transcript(&mut self, query: &str) {
-        if query.is_empty() {
-            return;
-        }
-        let needle = query.to_lowercase();
-        let ids = self
-            .journal
-            .entries()
-            .map(|item| item.id)
-            .collect::<Vec<_>>();
-        for id in ids {
-            let Some(inspector) = self.inspector_for(&id) else {
-                continue;
-            };
-            let haystack = inspector.content.to_lowercase();
-            let Some(offset) = haystack.find(&needle) else {
-                continue;
-            };
-            self.follow_live = false;
-            self.reading_anchor = Some(ReadingAnchor {
-                entry: id,
-                source_offset: inspector.content[..offset].graphemes(true).count(),
-            });
-            return;
-        }
     }
 }
 
@@ -2192,8 +2396,13 @@ impl ChoiceList {
     }
 }
 
-fn refresh_palette_surface(surface: &mut Surface, choices: &[Choice]) {
+fn refresh_palette_surface(surface: &mut Surface, full: &[Choice], slash: &[Choice]) {
     if let Surface::Palette(list) = surface {
+        let choices = match list.kind {
+            ChoiceListKind::Palette { slash: true } => slash,
+            ChoiceListKind::Palette { slash: false } => full,
+            ChoiceListKind::Selector { .. } => return,
+        };
         list.replace_choices(choices.to_vec());
     }
 }
@@ -2250,7 +2459,7 @@ fn surface_returns_to_permission(surface: &Surface) -> bool {
             .return_to
             .as_deref()
             .is_some_and(surface_returns_to_permission),
-        Surface::Conversation | Surface::Queue { .. } | Surface::TranscriptSearch { .. } => false,
+        Surface::Conversation | Surface::Queue { .. } | Surface::Recovery { .. } => false,
     }
 }
 
@@ -2324,12 +2533,15 @@ impl Choice {
     }
 }
 
-/// Full-screen terminal custody for Code state.
+/// Normal-buffer terminal custody for Code state.
 ///
-/// The app can own this type without naming a terminal frame or any renderer
-/// type from the terminal library.
+/// The persistent conversation is painted through [`Writer`], so transcript
+/// rows enter the terminal's native scrollback while the variable-height dock
+/// remains repaintable. A read-only inspector temporarily owns the alternate
+/// screen; the surrounding session keeps raw input and keyboard modes.
 pub struct CodeView {
-    terminal: Terminal<CrosstermBackend<std::io::Stdout>>,
+    writer: Writer<CrosstermBackend<std::io::Stdout>>,
+    detached: Option<Terminal<CrosstermBackend<std::io::Stdout>>>,
     registry: Registry,
     document: DocumentCache,
     finished: bool,
@@ -2337,7 +2549,7 @@ pub struct CodeView {
 }
 
 impl CodeView {
-    /// Enter full-screen raw mode.
+    /// Enter session input modes without replacing the normal terminal buffer.
     pub fn open() -> io::Result<Self> {
         if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
             return Err(io::Error::other(
@@ -2347,22 +2559,22 @@ impl CodeView {
         crate::lifecycle::install_panic_restore();
         crate::lifecycle::enter_raw()?;
         let mut stdout = std::io::stdout();
-        if let Err(error) = crate::lifecycle::enter_alternate_screen()
-            .and_then(|()| crate::lifecycle::enable_session_keys())
-            .and_then(|()| execute!(stdout, Hide))
+        if let Err(error) =
+            crate::lifecycle::enable_session_keys().and_then(|()| execute!(stdout, Hide))
         {
             crate::lifecycle::restore();
             return Err(error);
         }
-        let terminal = match Terminal::new(CrosstermBackend::new(stdout)) {
-            Ok(terminal) => terminal,
+        let writer = match Writer::new(CrosstermBackend::new(stdout)) {
+            Ok(writer) => writer,
             Err(error) => {
                 crate::lifecycle::restore();
                 return Err(error);
             }
         };
         Ok(Self {
-            terminal,
+            writer,
+            detached: None,
             registry: Registry::default(),
             document: DocumentCache::default(),
             finished: false,
@@ -2370,50 +2582,123 @@ impl CodeView {
         })
     }
 
-    /// Draw one full frame from pure Code state.
+    /// Draw either the normal-buffer conversation or an explicit inspector.
     pub fn draw(&mut self, state: &mut CodeState) -> io::Result<()> {
         if self.finished || self.suspended {
             return Ok(());
         }
-        let registry = &self.registry;
-        let document = &mut self.document;
-        self.terminal
-            .draw(|frame| render_frame(frame, state, registry, document))
-            .map(|_| ())
+        state.viewport = if let Some(detached) = self.detached.as_ref() {
+            detached.size()?
+        } else {
+            self.writer.size()
+        };
+        if matches!(state.surface, Surface::Inspector(_)) {
+            return self.draw_detached(state);
+        }
+        self.close_detached()?;
+        self.draw_normal(state)
     }
 
     /// Restore terminal settings before launching an external editor.
     pub fn suspend(&mut self) -> io::Result<()> {
         if !self.finished && !self.suspended {
+            self.close_detached()?;
+            self.writer.finish()?;
             crate::lifecycle::restore();
             self.suspended = true;
         }
         Ok(())
     }
 
-    /// Restore the full-screen surface after an external editor exits.
+    /// Reacquire session input modes after an external editor exits.
     pub fn resume(&mut self) -> io::Result<()> {
         if self.finished || !self.suspended {
             return Ok(());
         }
         crate::lifecycle::enter_raw()?;
-        if let Err(error) = crate::lifecycle::enter_alternate_screen()
-            .and_then(|()| crate::lifecycle::enable_session_keys())
-            .and_then(|()| execute!(self.terminal.backend_mut(), Hide))
+        if let Err(error) =
+            crate::lifecycle::enable_session_keys().and_then(|()| execute!(std::io::stdout(), Hide))
         {
             crate::lifecycle::restore();
             return Err(error);
         }
-        self.terminal.clear()?;
+        self.writer.invalidate();
         self.suspended = false;
         Ok(())
+    }
+
+    /// Forget the cached physical live region without touching scrollback.
+    pub fn invalidate(&mut self) {
+        if let Some(detached) = self.detached.as_mut() {
+            let _ = detached.clear();
+        } else {
+            self.writer.invalidate();
+        }
     }
 
     /// Restore the user's terminal. Calling it repeatedly is harmless.
     pub fn finish(&mut self) -> io::Result<()> {
         if !self.finished {
+            self.close_detached()?;
+            self.writer.finish()?;
             crate::lifecycle::restore();
             self.finished = true;
+        }
+        Ok(())
+    }
+
+    fn draw_normal(&mut self, state: &mut CodeState) -> io::Result<()> {
+        let size = self.writer.size();
+        if !supported_viewport(size) {
+            self.writer.claim_full_height()?;
+        }
+        let transcript = normal_document(state, &self.registry, &mut self.document, size);
+        let dock_height = dock_height(state, size);
+        let mut dock = Terminal::new(TestBackend::new(size.width.max(1), dock_height.max(1)))?;
+        let mut cursor = None;
+        let frame = dock.draw(|frame| {
+            cursor = render_dock(frame, state, size);
+        })?;
+        let footer = buffer_lines(frame.buffer);
+        self.writer.docked_frame(&transcript, &footer)?;
+        let cursor = cursor.map(|position| {
+            Position::new(
+                position.x,
+                size.height.saturating_sub(dock_height) + position.y,
+            )
+        });
+        self.writer.cursor(cursor)
+    }
+
+    fn draw_detached(&mut self, state: &CodeState) -> io::Result<()> {
+        if self.detached.is_none() {
+            self.writer.cursor(None)?;
+            crate::lifecycle::enter_alternate_screen()?;
+            let terminal = Terminal::new(CrosstermBackend::new(std::io::stdout()));
+            match terminal {
+                Ok(terminal) => self.detached = Some(terminal),
+                Err(error) => {
+                    let _ = crate::lifecycle::leave_alternate_screen();
+                    return Err(error);
+                }
+            }
+        }
+        let Some(detached) = self.detached.as_mut() else {
+            return Ok(());
+        };
+        detached
+            .draw(|frame| render_detached_frame(frame, state))
+            .map(|_| ())
+    }
+
+    fn close_detached(&mut self) -> io::Result<()> {
+        if self.detached.take().is_some() {
+            crate::lifecycle::leave_alternate_screen()?;
+            // The alternate buffer may have changed the physical cursor, but
+            // it did not change the writer's retained normal-buffer model.
+            // Invalidating repaints only the owned live region and lets newly
+            // appended journal rows flow through the writer exactly once.
+            self.writer.invalidate();
         }
         Ok(())
     }
@@ -2425,9 +2710,245 @@ impl Drop for CodeView {
     }
 }
 
+fn normal_document(
+    state: &CodeState,
+    registry: &Registry,
+    document: &mut DocumentCache,
+    size: Size,
+) -> Vec<Line<'static>> {
+    if state.operations_only {
+        let mut lines = vec![
+            Line::styled(
+                sanitize(&state.status.title),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Line::default(),
+            Line::styled(
+                "No coding agent is attached to this context.",
+                Style::default().fg(Color::DarkGray),
+            ),
+            Line::default(),
+        ];
+        if let Some(root) = &state.operations_root {
+            lines.extend(root.content.lines().map(|line| Line::from(sanitize(line))));
+        } else {
+            lines.push(Line::styled(
+                "Loading target status…",
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        return lines;
+    }
+    document.refresh(state, size.width.max(1), size.height.max(1), registry);
+    let mut lines = vec![
+        Line::styled(
+            sanitize(&state.status.title),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Line::default(),
+    ];
+    lines.extend(document.all_lines());
+    lines
+}
+
+fn dock_height(state: &CodeState, size: Size) -> u16 {
+    if size.width < 40 || size.height < 16 {
+        return size.height.max(1);
+    }
+    let transient_budget = size.height.saturating_mul(2).saturating_div(5).clamp(5, 12);
+    if matches!(state.surface, Surface::Permission) {
+        // Permission identity, complete choices, and its confirmation hints
+        // outrank ordinary session status. The extra row is the transient
+        // boundary; the content itself keeps the documented dock budget.
+        return transient_budget.saturating_add(1).min(size.height);
+    }
+    if state.operations_only {
+        return if matches!(state.surface, Surface::Conversation) {
+            2_u16.min(size.height).max(1)
+        } else {
+            transient_budget.saturating_add(1).min(size.height)
+        };
+    }
+    let status: u16 = if size.width < 68 { 4 } else { 2 };
+    let hint: u16 = 1;
+    let content = match state.surface {
+        Surface::Conversation => {
+            let queue = if state.queued_preview_len() == 0 {
+                0
+            } else {
+                u16::try_from(state.queued_preview_len().min(2))
+                    .unwrap_or(u16::MAX)
+                    .saturating_add(2)
+            };
+            let notice = u16::from(state.notice.is_some());
+            queue
+                .saturating_add(notice)
+                .saturating_add(composer_height(state, size.width))
+        }
+        Surface::Inspector(_) => 0,
+        _ => transient_budget,
+    };
+    status
+        .saturating_add(content)
+        .saturating_add(hint)
+        .min(size.height)
+        .max(1)
+}
+
+fn render_dock(frame: &mut Frame<'_>, state: &CodeState, terminal_size: Size) -> Option<Position> {
+    let area = frame.area();
+    if !supported_viewport(terminal_size) {
+        let message = state.permissions.front().map_or_else(
+            || {
+                "Resize terminal to at least 40×16. Conversation, draft, queue, and selections are retained. Enter is disabled."
+                    .to_string()
+            },
+            |pending| {
+                format!(
+                    "Resize terminal to at least 40×16. Permission {} · {}\nF2 Review · Esc Deny · Ctrl-C Cancel turn\nApproval is disabled until every offered choice fits.",
+                    safe_one_line(pending.prompt.id()),
+                    safe_one_line(pending.prompt.title())
+                )
+            },
+        );
+        frame.render_widget(
+            Paragraph::new(message)
+                .style(Style::default().fg(Color::Yellow))
+                .wrap(Wrap { trim: true }),
+            area,
+        );
+        return None;
+    }
+    if matches!(state.surface, Surface::Permission) {
+        render_permission(frame, area, state);
+        return None;
+    }
+    if state.operations_only {
+        let [content, hint_area] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
+        match &state.surface {
+            Surface::Conversation => frame.render_widget(
+                Paragraph::new("Ctrl-P opens target actions · Ctrl-O refreshes status")
+                    .style(Style::default().fg(Color::DarkGray)),
+                content,
+            ),
+            Surface::Palette(list) | Surface::Selector(list) => {
+                render_choice_list(frame, content, list)
+            }
+            Surface::Queue { selected } => render_queue_editor(frame, content, state, *selected),
+            Surface::Recovery { selected } => {
+                render_recovery_editor(frame, content, state, *selected)
+            }
+            Surface::Permission | Surface::Inspector(_) => {}
+        }
+        frame.render_widget(
+            Paragraph::new("Ctrl-P Commands · Ctrl-O Status details · Ctrl-C Exit")
+                .style(Style::default().fg(Color::DarkGray)),
+            hint_area,
+        );
+        return None;
+    }
+
+    let status_height = if area.width < 68 { 4 } else { 2 };
+    let [status, content, hint_area] = Layout::vertical([
+        Constraint::Length(status_height.min(area.height.saturating_sub(1))),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .areas(area);
+    render_status(frame, status, state);
+
+    let mut cursor = None;
+    match &state.surface {
+        Surface::Conversation => {
+            if state.operations_only {
+                frame.render_widget(
+                    Paragraph::new("Ctrl-P opens the available target actions.")
+                        .style(Style::default().fg(Color::DarkGray)),
+                    content,
+                );
+            } else {
+                let queue_height = if state.queued_preview_len() == 0 {
+                    0
+                } else {
+                    u16::try_from(state.queued_preview_len().min(2))
+                        .unwrap_or(u16::MAX)
+                        .saturating_add(2)
+                };
+                let notice_height = u16::from(state.notice.is_some());
+                let composer_height = composer_height(state, content.width);
+                let [queue, notice, composer] = Layout::vertical([
+                    Constraint::Length(queue_height),
+                    Constraint::Length(notice_height),
+                    Constraint::Length(composer_height),
+                ])
+                .areas(content);
+                if state.queued_preview_len() > 0 {
+                    render_queue_summary(frame, queue, state);
+                }
+                if let Some(notice_text) = &state.notice {
+                    render_notice(frame, notice, notice_text);
+                }
+                render_composer(frame, composer, state);
+                cursor = composer_cursor_position(composer, state);
+                if let Some(position) = cursor {
+                    frame.set_cursor_position(position);
+                }
+            }
+        }
+        Surface::Palette(list) | Surface::Selector(list) => {
+            render_choice_list(frame, content, list)
+        }
+        Surface::Permission => render_permission(frame, content, state),
+        Surface::Queue { selected } => render_queue_editor(frame, content, state, *selected),
+        Surface::Recovery { selected } => render_recovery_editor(frame, content, state, *selected),
+        Surface::Inspector(_) => {}
+    }
+    frame.render_widget(
+        Paragraph::new(hint(state)).style(Style::default().fg(Color::DarkGray)),
+        hint_area,
+    );
+    cursor
+}
+
+fn supported_viewport(size: Size) -> bool {
+    size.width >= 40 && size.height >= 16
+}
+
+fn render_detached_frame(frame: &mut Frame<'_>, state: &CodeState) {
+    if let Surface::Inspector(inspector) = &state.surface {
+        render_inspector(frame, frame.area(), inspector);
+        if !state.permissions.is_empty() {
+            let notice = Rect::new(frame.area().x, frame.area().y, frame.area().width, 1);
+            frame.render_widget(
+                Paragraph::new(format!(
+                    "Permission needed · F2 to review ({})",
+                    state.permissions.len()
+                ))
+                .style(Style::default().fg(Color::Yellow)),
+                notice,
+            );
+        }
+    }
+}
+
+fn buffer_lines(buffer: &Buffer) -> Vec<Line<'static>> {
+    (buffer.area.top()..buffer.area.bottom())
+        .map(|y| {
+            let mut spans = Vec::new();
+            let mut x = buffer.area.left();
+            while x < buffer.area.right() {
+                let cell = &buffer[(x, y)];
+                spans.push(Span::styled(cell.symbol().to_string(), cell.style()));
+                x = x.saturating_add(u16::try_from(cell.symbol().width()).unwrap_or(1).max(1));
+            }
+            Line::from(spans)
+        })
+        .collect()
+}
+
 #[derive(Clone)]
 struct DocumentRow {
-    source_offset: usize,
     line: Line<'static>,
 }
 
@@ -2438,8 +2959,6 @@ struct DocumentCache {
     source_revision: u64,
     total_rows: usize,
     entries: Vec<CachedDocumentEntry>,
-    positions: Vec<ReadingPosition>,
-    layout_revision: u64,
 }
 
 struct CachedDocumentEntry {
@@ -2455,7 +2974,6 @@ impl DocumentCache {
         if !geometry_changed && self.source_revision == state.journal_revision {
             return;
         }
-        let mut changed = geometry_changed;
         let mut previous = HashMap::with_capacity(self.entries.len());
         if !geometry_changed {
             for entry in std::mem::take(&mut self.entries) {
@@ -2473,66 +2991,30 @@ impl DocumentCache {
                 .filter(|cached| cached.revision == item.revision);
             let mut entry = match cached {
                 Some(entry) => entry,
-                None => {
-                    changed = true;
-                    CachedDocumentEntry {
-                        id: item.id.clone(),
-                        revision: item.revision,
-                        start: 0,
-                        rows: document_rows_for_entry(item.entry, width, height, registry),
-                    }
-                }
+                None => CachedDocumentEntry {
+                    id: item.id.clone(),
+                    revision: item.revision,
+                    start: 0,
+                    rows: document_rows_for_entry(item.entry, width, height, registry),
+                },
             };
-            if entry.revision != item.revision {
-                changed = true;
-            }
             entry.start = start;
             start = start.saturating_add(entry.rows.len());
             entries.push(entry);
-        }
-        if !previous.is_empty() {
-            changed = true;
         }
         self.width = width;
         self.height = height;
         self.source_revision = state.journal_revision;
         self.total_rows = start;
         self.entries = entries;
-        if changed {
-            self.positions = self
-                .entries
-                .iter()
-                .flat_map(|entry| {
-                    entry.rows.iter().map(move |row| ReadingPosition {
-                        entry: entry.id.clone(),
-                        source_offset: row.source_offset,
-                    })
-                })
-                .collect();
-            self.layout_revision = self.layout_revision.saturating_add(1);
-        }
     }
 
-    fn start_for(&self, state: &CodeState, visible: usize) -> usize {
-        if state.follow_live {
-            return self.total_rows.saturating_sub(visible);
-        }
-        let Some(anchor) = &state.reading_anchor else {
-            return self.total_rows.saturating_sub(visible);
-        };
-        self.entries
-            .iter()
-            .find(|entry| entry.id == anchor.entry)
-            .and_then(|entry| {
-                entry
-                    .rows
-                    .iter()
-                    .position(|row| row.source_offset >= anchor.source_offset)
-                    .map(|offset| entry.start.saturating_add(offset))
-            })
-            .unwrap_or_else(|| self.total_rows.saturating_sub(visible))
+    #[cfg(test)]
+    fn start_for(&self, visible: usize) -> usize {
+        self.total_rows.saturating_sub(visible)
     }
 
+    #[cfg(test)]
     fn visible_lines(&self, start: usize, count: usize) -> Vec<Line<'static>> {
         let end = start.saturating_add(count);
         let mut lines = Vec::with_capacity(count);
@@ -2554,8 +3036,16 @@ impl DocumentCache {
         }
         lines
     }
+
+    fn all_lines(&self) -> Vec<Line<'static>> {
+        self.entries
+            .iter()
+            .flat_map(|entry| entry.rows.iter().map(|row| row.line.clone()))
+            .collect()
+    }
 }
 
+#[cfg(test)]
 fn render_frame(
     frame: &mut Frame<'_>,
     state: &mut CodeState,
@@ -2582,11 +3072,11 @@ fn render_frame(
     }
 
     let status_height = if area.width < 68 { 4 } else { 2 };
-    let notice_height = u16::from(state.notice.is_some()) * 2;
-    let queue_height = if state.queue.is_empty() {
+    let notice_height = u16::from(state.notice.is_some());
+    let queue_height = if state.queued_preview_len() == 0 {
         0
     } else {
-        u16::try_from(state.queue.len().min(2))
+        u16::try_from(state.queued_preview_len().min(2))
             .unwrap_or(u16::MAX)
             .saturating_add(2)
     };
@@ -2619,17 +3109,11 @@ fn render_frame(
     );
     render_status(frame, status, state);
     render_transcript(frame, transcript, state, registry, document);
-    if !state.queue.is_empty() {
+    if state.queued_preview_len() > 0 {
         render_queue_summary(frame, queue, state);
     }
     if let Some(notice) = &state.notice {
-        frame.render_widget(
-            Paragraph::new(notice.as_str())
-                .style(Style::default().fg(Color::Yellow))
-                .block(Block::default().borders(Borders::TOP).title(" Notice "))
-                .wrap(Wrap { trim: true }),
-            notice_area,
-        );
+        render_notice(frame, notice_area, notice);
     }
     render_composer(frame, composer, state);
     frame.render_widget(
@@ -2644,6 +3128,7 @@ fn render_frame(
     }
 }
 
+#[cfg(test)]
 fn render_operations_base(frame: &mut Frame<'_>, area: Rect, state: &CodeState) {
     let [header, body, hint_area] = Layout::vertical([
         Constraint::Length(1),
@@ -2669,14 +3154,29 @@ fn render_operations_base(frame: &mut Frame<'_>, area: Rect, state: &CodeState) 
     );
 }
 
+#[cfg(test)]
 fn render_surface(frame: &mut Frame<'_>, state: &CodeState) {
     match &state.surface {
         Surface::Conversation => {}
-        Surface::Palette(list) | Surface::Selector(list) => render_choice_list(frame, list),
-        Surface::Inspector(inspector) => render_inspector(frame, inspector),
-        Surface::Permission => render_permission(frame, state),
-        Surface::Queue { selected } => render_queue_editor(frame, state, *selected),
-        Surface::TranscriptSearch { query } => render_transcript_search(frame, query),
+        Surface::Palette(list) | Surface::Selector(list) => {
+            render_choice_list(frame, centered(frame.area(), 86, 70, 12, 20), list)
+        }
+        Surface::Inspector(inspector) => {
+            render_inspector(frame, centered(frame.area(), 96, 90, 14, 22), inspector)
+        }
+        Surface::Permission => render_permission(frame, frame.area(), state),
+        Surface::Queue { selected } => render_queue_editor(
+            frame,
+            centered(frame.area(), 82, 60, 8, 14),
+            state,
+            *selected,
+        ),
+        Surface::Recovery { selected } => render_recovery_editor(
+            frame,
+            centered(frame.area(), 82, 60, 8, 14),
+            state,
+            *selected,
+        ),
     }
 }
 
@@ -2733,6 +3233,17 @@ fn render_status(frame: &mut Frame<'_>, area: Rect, state: &CodeState) {
     frame.render_widget(Paragraph::new(lines), area);
 }
 
+fn render_notice(frame: &mut Frame<'_>, area: Rect, notice: &str) {
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("! ", Style::default().fg(Color::Yellow)),
+            Span::raw(safe_one_line(notice)),
+        ]))
+        .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
 fn compact_cost(cost: &str, cells: usize) -> String {
     if cost.width() <= cells {
         return cost.to_string();
@@ -2756,6 +3267,7 @@ fn compact_cost(cost: &str, cells: usize) -> String {
     format!("{source}{separator}{}", truncate_cells(figure, remaining))
 }
 
+#[cfg(test)]
 fn render_transcript(
     frame: &mut Frame<'_>,
     area: Rect,
@@ -2765,18 +3277,14 @@ fn render_transcript(
 ) {
     document.refresh(state, area.width.saturating_sub(2), area.height, registry);
     let visible = usize::from(area.height.saturating_sub(2));
-    state.sync_reading_layout(document.layout_revision, &document.positions, visible);
-    let start = document.start_for(state, visible);
+    let start = document.start_for(visible);
     let lines = document.visible_lines(start, visible);
-    let title = if state.follow_live {
-        " Conversation "
-    } else if state.new_activity {
-        " Reading history · new activity "
-    } else {
-        " Reading history "
-    };
     frame.render_widget(
-        Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(title)),
+        Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Conversation "),
+        ),
         area,
     );
 }
@@ -2788,37 +3296,17 @@ fn document_rows_for_entry(
     registry: &Registry,
 ) -> Vec<DocumentRow> {
     let mut rows = Vec::new();
-    let (lines, source_offsets) = match entry {
+    let lines = match entry {
         Entry::Message(message) if message.voice == Voice::Agent => {
-            let lines = render::markdown::source_lines(&message.text);
-            let offsets = source_line_offsets(&message.text, lines.len());
-            (lines, offsets)
+            render::markdown::source_lines(&message.text)
         }
-        Entry::Message(message) => {
-            let lines = render::source_message(message);
-            let offsets = source_line_offsets(&message.text, lines.len());
-            (lines, offsets)
-        }
-        Entry::Tool(call) => {
-            let lines = compact_tool_lines(call, width, height, registry);
-            let offsets = (0..lines.len()).collect();
-            (lines, offsets)
-        }
-        Entry::Plan(plan) => {
-            let lines = render::session::plan(plan);
-            let offsets = (0..lines.len()).collect();
-            (lines, offsets)
-        }
+        Entry::Message(message) => render::source_message(message),
+        Entry::Tool(call) => compact_tool_lines(call, width, height, registry),
+        Entry::Plan(plan) => render::session::plan(plan),
     };
-    for (line_index, line) in lines.into_iter().enumerate() {
-        let mut source_offset = source_offsets.get(line_index).copied().unwrap_or_default();
+    for line in lines {
         for line in wrap(&sanitize_line(&line), width.max(1)) {
-            let source_length = line_graphemes(&line);
-            rows.push(DocumentRow {
-                source_offset,
-                line,
-            });
-            source_offset = source_offset.saturating_add(source_length);
+            rows.push(DocumentRow { line });
         }
     }
     rows
@@ -2856,80 +3344,73 @@ fn compact_tool_lines(
     lines
 }
 
-fn source_line_offsets(text: &str, count: usize) -> Vec<usize> {
-    let mut offsets = Vec::new();
-    let mut offset = 0_usize;
-    for line in text.split('\n') {
-        offsets.push(offset);
-        offset = offset
-            .saturating_add(line.graphemes(true).count())
-            .saturating_add(1);
-    }
-    if offsets.is_empty() {
-        offsets.push(0);
-    }
-    let fallback = offsets.last().copied().unwrap_or_default();
-    while offsets.len() < count {
-        offsets.push(fallback);
-    }
-    offsets.truncate(count);
-    offsets
-}
-
-fn line_graphemes(line: &Line<'_>) -> usize {
-    line.spans
-        .iter()
-        .map(|span| span.content.graphemes(true).count())
-        .sum()
-}
-
 fn render_queue_summary(frame: &mut Frame<'_>, area: Rect, state: &CodeState) {
-    let lines = state
-        .queue
-        .iter()
-        .take(2)
-        .enumerate()
-        .map(|(index, prompt)| {
-            let owner = prompt.owner.map(CommandOwner::label).unwrap_or("prompt");
-            Line::from(format!(
-                "{}: {} [{}]",
-                index.saturating_add(1),
-                one_line(&prompt.prompt),
-                owner
-            ))
-        })
-        .collect::<Vec<_>>();
-    frame.render_widget(
-        Paragraph::new(lines)
-            .block(
-                Block::default()
-                    .borders(Borders::TOP)
-                    .title(" Next turn · F3 edit/remove "),
-            )
-            .wrap(Wrap { trim: true }),
-        area,
+    let total = state.queued_preview_len();
+    let rail = Style::default().fg(Color::DarkGray);
+    let mut lines = vec![Line::from(vec![
+        Span::styled("┋ ", rail),
+        Span::styled("Queued next · F3 edit", rail.add_modifier(Modifier::BOLD)),
+    ])];
+    lines.extend(
+        state
+            .pending_followups
+            .iter()
+            .chain(state.queue.iter())
+            .take(2)
+            .enumerate()
+            .map(|(index, prompt)| {
+                let owner = prompt.owner.map(CommandOwner::label).unwrap_or("prompt");
+                Line::from(vec![
+                    Span::styled("┋ ", rail),
+                    Span::raw(format!(
+                        "{} · {} [{}]",
+                        index.saturating_add(1),
+                        one_line(&prompt.prompt),
+                        owner
+                    )),
+                ])
+            }),
     );
+    if total > 2 {
+        lines.push(Line::from(vec![
+            Span::styled("┋ ", rail),
+            Span::styled(format!("… {} more", total.saturating_sub(2)), rail),
+        ]));
+    }
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
 }
 
 fn composer_height(state: &CodeState, width: u16) -> u16 {
     let layout = composer_layout(
         state.editor.text(),
         state.editor.cursor_byte(),
-        width.saturating_sub(4).max(1),
+        width.saturating_sub(2).max(1),
+        composer_rail(state),
+        composer_rail_style(state),
     );
     let rows = layout.rows.len().clamp(1, 4);
-    u16::try_from(rows).unwrap_or(u16::MAX).saturating_add(2)
+    u16::try_from(rows).unwrap_or(u16::MAX).saturating_add(1)
 }
 
 fn render_composer(frame: &mut Frame<'_>, area: Rect, state: &CodeState) {
-    let inner = Block::default()
-        .borders(Borders::ALL)
-        .title(" Composer ")
-        .inner(area);
+    let rail = composer_rail(state);
+    let [label, inner] = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(area);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(format!("{rail} "), composer_rail_style(state)),
+            Span::styled(
+                composer_title(state),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ])),
+        label,
+    );
     let layout = composer_layout(
         state.editor.text(),
         state.editor.cursor_byte(),
         inner.width.saturating_sub(2).max(1),
+        rail,
+        composer_rail_style(state),
     );
     let start = layout
         .cursor_row
@@ -2941,24 +3422,59 @@ fn render_composer(frame: &mut Frame<'_>, area: Rect, state: &CodeState) {
         .take(usize::from(inner.height))
         .cloned()
         .collect::<Vec<_>>();
-    frame.render_widget(
-        Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(" Composer ")),
-        area,
-    );
+    frame.render_widget(Paragraph::new(lines), inner);
 }
 
+fn composer_title(state: &CodeState) -> &'static str {
+    match state.turn {
+        TurnState::Submitting | TurnState::Working => "Next turn",
+        TurnState::Cancelling => "Next turn — waiting for stop",
+        TurnState::Ready if matches!(state.queue_state, QueueRunState::Paused(_)) => {
+            "Next turn — queue paused"
+        }
+        TurnState::Ready => "Message",
+    }
+}
+
+fn composer_rail(state: &CodeState) -> &'static str {
+    if state.turn == TurnState::Ready && matches!(state.queue_state, QueueRunState::Running) {
+        "┃"
+    } else {
+        "┋"
+    }
+}
+
+fn composer_rail_style(state: &CodeState) -> Style {
+    if composer_rail(state) == "┃" {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    }
+}
+
+#[cfg(test)]
 fn set_composer_cursor(frame: &mut Frame<'_>, area: Rect, state: &CodeState) {
-    let inner = Block::default()
-        .borders(Borders::ALL)
-        .title(" Composer ")
-        .inner(area);
+    if let Some(position) = composer_cursor_position(area, state) {
+        frame.set_cursor_position(position);
+    }
+}
+
+fn composer_cursor_position(area: Rect, state: &CodeState) -> Option<Position> {
+    let inner = Rect::new(
+        area.x,
+        area.y.saturating_add(1),
+        area.width,
+        area.height.saturating_sub(1),
+    );
     if inner.width == 0 || inner.height == 0 {
-        return;
+        return None;
     }
     let layout = composer_layout(
         state.editor.text(),
         state.editor.cursor_byte(),
         inner.width.saturating_sub(2).max(1),
+        composer_rail(state),
+        composer_rail_style(state),
     );
     let start = layout
         .cursor_row
@@ -2972,7 +3488,7 @@ fn set_composer_cursor(frame: &mut Frame<'_>, area: Rect, state: &CodeState) {
         .y
         .saturating_add(y_offset)
         .min(inner.bottom().saturating_sub(1));
-    frame.set_cursor_position(Position::new(x, y));
+    Some(Position::new(x, y))
 }
 
 #[derive(Clone)]
@@ -2982,9 +3498,29 @@ struct ComposerLayout {
     cursor_column: u16,
 }
 
-fn composer_layout(text: &str, cursor: usize, content_width: u16) -> ComposerLayout {
+#[derive(Clone, Copy)]
+struct ComposerFormat {
+    cursor: usize,
+    content_width: u16,
+    rail: &'static str,
+    rail_style: Style,
+}
+
+fn composer_layout(
+    text: &str,
+    cursor: usize,
+    content_width: u16,
+    rail: &'static str,
+    rail_style: Style,
+) -> ComposerLayout {
     let mut rows = Vec::new();
     let mut cursor_position = None;
+    let format = ComposerFormat {
+        cursor,
+        content_width,
+        rail,
+        rail_style,
+    };
     let mut start = 0_usize;
     let bytes = text.as_bytes();
     let mut index = 0_usize;
@@ -3000,8 +3536,7 @@ fn composer_layout(text: &str, cursor: usize, content_width: u16) -> ComposerLay
             &mut cursor_position,
             &text[start..index],
             start,
-            cursor,
-            content_width,
+            &format,
         );
         let mut next = index.saturating_add(1);
         if bytes[index] == b'\r' && bytes.get(next) == Some(&b'\n') {
@@ -3023,8 +3558,7 @@ fn composer_layout(text: &str, cursor: usize, content_width: u16) -> ComposerLay
         &mut cursor_position,
         &text[start..],
         start,
-        cursor,
-        content_width,
+        &format,
     );
     let (cursor_row, cursor_column) = cursor_position.unwrap_or_else(|| {
         let row = rows.len().saturating_sub(1);
@@ -3046,18 +3580,16 @@ fn append_composer_line(
     cursor_position: &mut Option<(usize, u16)>,
     text: &str,
     start: usize,
-    cursor: usize,
-    content_width: u16,
+    format: &ComposerFormat,
 ) {
     let mut content = String::new();
     let mut cells = 0_u16;
-    let width = content_width.max(1);
-    let mut first_row = true;
+    let width = format.content_width.max(1);
     let mut row_start = start;
 
     for (offset, grapheme) in text.grapheme_indices(true) {
         let position = start.saturating_add(offset);
-        if cursor_position.is_none() && cursor == position {
+        if cursor_position.is_none() && format.cursor == position {
             *cursor_position = Some((
                 rows.len(),
                 u16::try_from(2_usize.saturating_add(usize::from(cells))).unwrap_or(u16::MAX),
@@ -3066,31 +3598,33 @@ fn append_composer_line(
         let rendered = sanitize(grapheme);
         let grapheme_cells = u16::try_from(rendered.width()).unwrap_or(u16::MAX);
         if !content.is_empty() && cells.saturating_add(grapheme_cells) > width {
-            rows.push(composer_row(std::mem::take(&mut content), first_row));
-            first_row = false;
+            rows.push(composer_row(
+                std::mem::take(&mut content),
+                format.rail,
+                format.rail_style,
+            ));
             row_start = position;
             cells = 0;
         }
-        if cursor_position.is_none() && cursor == row_start {
+        if cursor_position.is_none() && format.cursor == row_start {
             *cursor_position = Some((rows.len(), 2));
         }
         content.push_str(&rendered);
         cells = cells.saturating_add(grapheme_cells);
     }
     let end = start.saturating_add(text.len());
-    if cursor_position.is_none() && cursor == end {
+    if cursor_position.is_none() && format.cursor == end {
         *cursor_position = Some((
             rows.len(),
             u16::try_from(2_usize.saturating_add(usize::from(cells))).unwrap_or(u16::MAX),
         ));
     }
-    rows.push(composer_row(content, first_row));
+    rows.push(composer_row(content, format.rail, format.rail_style));
 }
 
-fn composer_row(content: String, first: bool) -> Line<'static> {
-    let prefix = if first { "› " } else { "  " };
+fn composer_row(content: String, rail: &'static str, rail_style: Style) -> Line<'static> {
     Line::from(vec![
-        Span::styled(prefix, Style::default().fg(Color::Cyan)),
+        Span::styled(format!("{rail} "), rail_style),
         Span::raw(content),
     ])
 }
@@ -3106,22 +3640,24 @@ fn hint(state: &CodeState) -> String {
     match state.turn {
         TurnState::Submitting | TurnState::Working => {
             if state.permissions.is_empty() {
-                "Tab queue next · Esc interrupt · Ctrl-P commands · F3 queue".to_string()
+                "Enter queue next · Esc interrupt · Ctrl-P commands · F3 queue".to_string()
             } else {
                 format!(
-                    "F2 permission ({}) · Tab queue next · Esc interrupt · Ctrl-P commands",
+                    "F2 permission ({}) · Enter queue next · Esc interrupt · Ctrl-P commands",
                     state.permissions.len()
                 )
             }
         }
         TurnState::Cancelling => "Cancelling · wait for the agent to settle".to_string(),
         TurnState::Ready => {
+            if let QueueRunState::Paused(reason) = &state.queue_state {
+                return format!("Queue paused: {} · F3 review/resume", safe_one_line(reason));
+            }
             if state.permissions.is_empty() {
-                "Ctrl-P commands · F2 permissions · F4 inspect · Ctrl-F search · Ctrl-End live"
-                    .to_string()
+                "Ctrl-P commands · Ctrl-O details · F2 permissions · F3 queue".to_string()
             } else {
                 format!(
-                    "F2 permission ({}) · Ctrl-P commands · F4 inspect · Ctrl-End live",
+                    "F2 permission ({}) · Ctrl-P commands · Ctrl-O details",
                     state.permissions.len()
                 )
             }
@@ -3129,42 +3665,33 @@ fn hint(state: &CodeState) -> String {
     }
 }
 
-fn render_choice_list(frame: &mut Frame<'_>, list: &ChoiceList) {
-    let area = centered(frame.area(), 86, 70, 12, 20);
+fn render_choice_list(frame: &mut Frame<'_>, viewport: Rect, list: &ChoiceList) {
+    let area = viewport;
     frame.render_widget(Clear, area);
     let [heading, query, choices, footer] = Layout::vertical([
-        Constraint::Length(2),
-        Constraint::Length(3),
-        Constraint::Min(4),
-        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
     ])
     .areas(area);
     frame.render_widget(
-        Paragraph::new(Line::styled(
-            safe_one_line(&list.detail),
-            Style::default().fg(Color::DarkGray),
-        ))
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(safe_one_line(&list.title)),
-        ),
+        Block::default()
+            .borders(Borders::TOP)
+            .title(format!(" {} ", safe_one_line(&list.title))),
         heading,
     );
-    let query_title = if list.query.is_empty() {
-        " Search · type to filter "
+    let query_text = if list.query.is_empty() {
+        format!("› Type to filter · {}", safe_one_line(&list.detail))
     } else {
-        " Search "
+        format!("› {}", safe_one_line(&list.query))
     };
     frame.render_widget(
-        Paragraph::new(safe_one_line(&list.query))
-            .block(Block::default().borders(Borders::ALL).title(query_title)),
+        Paragraph::new(query_text).style(Style::default().fg(Color::DarkGray)),
         query,
     );
 
-    let results_block = Block::default().borders(Borders::ALL).title(" Results ");
-    let results = results_block.inner(choices);
-    frame.render_widget(results_block, choices);
+    let results = choices;
     let mut lines = Vec::new();
     let mut selected_start = None;
     let mut selected_end = None;
@@ -3182,16 +3709,14 @@ fn render_choice_list(frame: &mut Frame<'_>, list: &ChoiceList) {
             Style::default()
         };
         let start = lines.len();
-        let label = Line::from(vec![Span::styled(
-            format!("{marker}{}", safe_one_line(choice.label())),
-            style,
-        )]);
+        let label = Line::from(vec![
+            Span::styled(format!("{marker}{}", safe_one_line(choice.label())), style),
+            Span::styled(
+                format!(" · {}", safe_one_line(&choice.detail())),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]);
         lines.extend(wrap(&sanitize_line(&label), results.width.max(1)));
-        let detail = Line::styled(
-            format!("    {}", safe_one_line(&choice.detail())),
-            Style::default().fg(Color::DarkGray),
-        );
-        lines.extend(wrap(&detail, results.width.max(1)));
         if selected {
             selected_start = Some(start);
             selected_end = Some(lines.len());
@@ -3220,14 +3745,14 @@ fn render_choice_list(frame: &mut Frame<'_>, list: &ChoiceList) {
         results,
     );
     frame.render_widget(
-        Paragraph::new("↑/↓ move · Enter select · Esc/Ctrl-C close · digits filter")
+        Paragraph::new("↑/↓ move · Enter select · Esc/Ctrl-C close")
             .style(Style::default().fg(Color::DarkGray)),
         footer,
     );
 }
 
-fn render_inspector(frame: &mut Frame<'_>, inspector: &OpenInspector) {
-    let area = centered(frame.area(), 96, 90, 14, 22);
+fn render_inspector(frame: &mut Frame<'_>, viewport: Rect, inspector: &OpenInspector) {
+    let area = centered(viewport, 100, 100, 14, 8);
     frame.render_widget(Clear, area);
     let title = if inspector.searching {
         format!(
@@ -3264,25 +3789,23 @@ fn render_inspector(frame: &mut Frame<'_>, inspector: &OpenInspector) {
         1,
     );
     frame.render_widget(
-        Paragraph::new("Ctrl-P commands · Ctrl-F search · Ctrl-Y copy · Esc/Ctrl-C close")
-            .style(Style::default().fg(Color::DarkGray)),
+        Paragraph::new(if inspector.tracks_transcript {
+            "[/] entries · F4 inspect · Ctrl-F search · Ctrl-Y copy · Esc/Ctrl-C close"
+        } else {
+            "Ctrl-P commands · Ctrl-F search · Ctrl-Y copy · Esc/Ctrl-C close"
+        })
+        .style(Style::default().fg(Color::DarkGray)),
         footer,
     );
 }
 
-fn render_permission(frame: &mut Frame<'_>, state: &CodeState) {
-    let viewport = frame.area();
-    let area = if viewport.width <= 48 || viewport.height <= 18 {
-        viewport
-    } else {
-        centered(viewport, 86, 66, 10, 16)
-    };
-    frame.render_widget(Clear, area);
+fn render_permission(frame: &mut Frame<'_>, viewport: Rect, state: &CodeState) {
+    let area = viewport;
     let Some(pending) = state.permissions.front() else {
         return;
     };
     let prompt = &pending.prompt;
-    let block = Block::default().borders(Borders::ALL).title(" Permission ");
+    let block = Block::default().borders(Borders::TOP).title(" Permission ");
     let inner = block.inner(area);
     frame.render_widget(block, area);
     if inner.width == 0 || inner.height == 0 {
@@ -3290,17 +3813,17 @@ fn render_permission(frame: &mut Frame<'_>, state: &CodeState) {
     }
     let width = usize::from(inner.width);
     let mut header = vec![Line::styled(
-        truncate_cells(&safe_one_line(prompt.title()), width),
+        truncate_cells(
+            &format!(
+                "{} · request {} · pending {}",
+                safe_one_line(prompt.title()),
+                safe_one_line(prompt.id()),
+                state.permissions.len()
+            ),
+            width,
+        ),
         Style::default().add_modifier(Modifier::BOLD),
     )];
-    header.push(Line::from(truncate_cells(
-        &format!(
-            "request {} · pending {}",
-            safe_one_line(prompt.id()),
-            state.permissions.len()
-        ),
-        width,
-    )));
     if let Some(context) = &pending.context {
         header.push(Line::styled(
             truncate_cells(&safe_one_line(&permission_context_summary(context)), width),
@@ -3324,10 +3847,34 @@ fn render_permission(frame: &mut Frame<'_>, state: &CodeState) {
             Style::default().fg(Color::DarkGray),
         ),
     ];
-    let header_height = u16::try_from(header.len()).unwrap_or(u16::MAX);
     let footer_height = u16::try_from(footer.len()).unwrap_or(u16::MAX);
+    let option_rows = prompt
+        .options()
+        .iter()
+        .enumerate()
+        .map(|(index, option)| {
+            wrap(
+                &Line::from(format!(
+                    "  [{}] {}",
+                    index.saturating_add(1),
+                    safe_one_line(&option.name)
+                )),
+                inner.width.max(1),
+            )
+            .len()
+        })
+        .sum::<usize>();
+    let body_height = inner.height.saturating_sub(footer_height);
+    let reserved_options = u16::try_from(option_rows)
+        .unwrap_or(u16::MAX)
+        .min(body_height.saturating_sub(1));
+    let header_height = u16::try_from(header.len())
+        .unwrap_or(u16::MAX)
+        .min(body_height.saturating_sub(reserved_options))
+        .max(1_u16.min(body_height));
+    header.truncate(usize::from(header_height));
     let [header_area, options_area, footer_area] = Layout::vertical([
-        Constraint::Length(header_height.min(inner.height.saturating_sub(footer_height))),
+        Constraint::Length(header_height),
         Constraint::Min(1),
         Constraint::Length(footer_height.min(inner.height)),
     ])
@@ -3406,8 +3953,8 @@ fn permission_context_summary(context: &ToolCallUpdate) -> String {
     )
 }
 
-fn render_queue_editor(frame: &mut Frame<'_>, state: &CodeState, selected: usize) {
-    let area = centered(frame.area(), 82, 60, 8, 14);
+fn render_queue_editor(frame: &mut Frame<'_>, viewport: Rect, state: &CodeState, selected: usize) {
+    let area = centered(viewport, 100, 100, 8, 5);
     frame.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)
@@ -3445,27 +3992,61 @@ fn render_queue_editor(frame: &mut Frame<'_>, state: &CodeState, selected: usize
         .collect::<Vec<_>>();
     frame.render_widget(Paragraph::new(lines), rows);
     frame.render_widget(
-        Paragraph::new("↑/↓ select · Enter/e edit · Delete remove · Esc close")
+        Paragraph::new("↑/↓ select · Alt-↑/↓ reorder · Enter edit · Delete remove · r resume")
             .style(Style::default().fg(Color::DarkGray))
             .wrap(Wrap { trim: true }),
         footer,
     );
 }
 
-fn render_transcript_search(frame: &mut Frame<'_>, query: &str) {
-    let area = centered(frame.area(), 75, 50, 5, 7);
+fn render_recovery_editor(
+    frame: &mut Frame<'_>,
+    viewport: Rect,
+    state: &CodeState,
+    selected: usize,
+) {
+    let area = centered(viewport, 100, 100, 8, 5);
     frame.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Recover drafts ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let [rows, footer] = Layout::vertical([Constraint::Min(1), Constraint::Length(2)]).areas(inner);
+    let visible = usize::from(rows.height);
+    let start = selected
+        .saturating_sub(visible / 2)
+        .min(state.recovery.len().saturating_sub(visible));
+    let lines = state
+        .recovery
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(visible)
+        .map(|(index, item)| {
+            let marker = if index == selected { "› " } else { "  " };
+            let style = if index == selected {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            Line::from(Span::styled(
+                truncate_cells(
+                    &format!("{marker}{}", safe_one_line(&item.prompt)),
+                    usize::from(rows.width),
+                ),
+                style,
+            ))
+        })
+        .collect::<Vec<_>>();
+    frame.render_widget(Paragraph::new(lines), rows);
     frame.render_widget(
-        Paragraph::new(vec![
-            Line::from("Search transcript"),
-            Line::from(query.to_string()),
-            Line::styled(
-                "Enter keeps match · Esc closes",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ])
-        .block(Block::default().borders(Borders::ALL)),
-        area,
+        Paragraph::new("Enter restore to empty composer · Delete discard · Esc close")
+            .style(Style::default().fg(Color::DarkGray))
+            .wrap(Wrap { trim: true }),
+        footer,
     );
 }
 
@@ -3744,11 +4325,232 @@ mod tests {
     }
 
     #[test]
+    fn submission_acceptance_and_rejection_preserve_p0_p1_and_editable_p2() {
+        let mut accepted = active_state();
+        let _ = accepted.step(paste("P0"));
+        let _ = accepted.step(press(KeyCode::Enter));
+        let _ = accepted.step(paste("P1"));
+        let _ = accepted.step(press(KeyCode::Enter));
+        let _ = accepted.step(paste("P2"));
+        assert_eq!(accepted.pending_followups.len(), 1);
+        let _ = accepted.step(CodeAction::TurnStarted);
+        assert_eq!(accepted.editor().text(), "P2");
+        assert_eq!(
+            accepted.queue.front().map(|item| item.prompt.as_str()),
+            Some("P1")
+        );
+        assert!(accepted.pending_followups.is_empty());
+        let submitted = accepted
+            .journal()
+            .entries()
+            .filter_map(|item| match item.entry {
+                Entry::Message(message) if message.voice == Voice::User => {
+                    Some(message.text.as_str())
+                }
+                Entry::Message(_) | Entry::Tool(_) | Entry::Plan(_) => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(submitted, vec!["P0"]);
+
+        let mut rejected = active_state();
+        let _ = rejected.step(paste("P0"));
+        let _ = rejected.step(press(KeyCode::Enter));
+        let _ = rejected.step(paste("P1"));
+        let _ = rejected.step(press(KeyCode::Enter));
+        let _ = rejected.step(paste("P2"));
+        let _ = rejected.step(CodeAction::SubmissionRejected {
+            prompt: "P0".to_string(),
+            reason: "transport rejected submission".to_string(),
+        });
+        assert_eq!(rejected.editor().text(), "P2");
+        assert_eq!(
+            rejected
+                .recovery
+                .iter()
+                .map(|item| item.prompt.as_str())
+                .collect::<Vec<_>>(),
+            vec!["P0", "P1"]
+        );
+        assert!(matches!(rejected.queue_state, QueueRunState::Paused(_)));
+        assert!(matches!(
+            rejected.surface,
+            Surface::Recovery { selected: 0 }
+        ));
+    }
+
+    #[test]
+    fn automatic_dispatch_never_clears_p2_and_rejection_pauses_exact_item() {
+        let mut state = active_state();
+        start_working(&mut state, "P0");
+        let _ = state.step(paste("P1"));
+        let _ = state.step(press(KeyCode::Enter));
+        let _ = state.step(paste("P2"));
+
+        let effect = state.step(CodeAction::TurnSettled(TurnOutcome::Completed));
+        assert!(matches!(
+            &effect[..],
+            [CodeEffect::Submit { prompt }] if prompt == "P1"
+        ));
+        assert_eq!(state.editor().text(), "P2");
+        assert_eq!(
+            state.dispatching.as_ref().map(|item| item.prompt.as_str()),
+            Some("P1")
+        );
+
+        let _ = state.step(CodeAction::SubmissionRejected {
+            prompt: "P1".to_string(),
+            reason: "agent stopped accepting prompts".to_string(),
+        });
+        assert_eq!(state.editor().text(), "P2");
+        assert_eq!(
+            state.recovery.front().map(|item| item.prompt.as_str()),
+            Some("P1")
+        );
+        assert!(state.dispatching.is_none());
+        assert!(matches!(state.queue_state, QueueRunState::Paused(_)));
+    }
+
+    #[test]
+    fn paused_queue_requires_explicit_resume_and_supports_explicit_reorder() {
+        let mut state = active_state();
+        start_working(&mut state, "active");
+        for prompt in ["first", "second"] {
+            let _ = state.step(paste(prompt));
+            let _ = state.step(press(KeyCode::Enter));
+        }
+        let _ = state.step(CodeAction::TurnSettled(TurnOutcome::Failed(
+            "adapter failed".to_string(),
+        )));
+        assert!(matches!(state.queue_state, QueueRunState::Paused(_)));
+        assert!(state.step(press(KeyCode::F(3))).is_empty());
+        let _ = state.step(CodeAction::Event(Event::Key(KeyEvent::new(
+            KeyCode::Down,
+            KeyModifiers::ALT,
+        ))));
+        assert_eq!(
+            state.queue.front().map(|item| item.prompt.as_str()),
+            Some("second")
+        );
+        let resumed = state.step(press(KeyCode::Char('r')));
+        assert!(matches!(
+            &resumed[..],
+            [CodeEffect::Submit { prompt }] if prompt == "second"
+        ));
+        assert!(matches!(state.queue_state, QueueRunState::Running));
+        assert_eq!(
+            state.queue.front().map(|item| item.prompt.as_str()),
+            Some("first")
+        );
+    }
+
+    #[test]
+    fn paused_queue_resume_is_a_full_palette_action_not_a_slash_alias() {
+        let mut state = active_state();
+        start_working(&mut state, "active");
+        let _ = state.step(paste("queued"));
+        let _ = state.step(press(KeyCode::Enter));
+        let _ = state.step(CodeAction::TurnSettled(TurnOutcome::Failed(
+            "adapter failed".to_string(),
+        )));
+
+        let _ = state.step(ctrl('p'));
+        let full = match &state.surface {
+            Surface::Palette(list) => list,
+            _ => {
+                assert!(matches!(state.surface, Surface::Palette(_)));
+                return;
+            }
+        };
+        assert!(full.choices.iter().any(|choice| {
+            matches!(choice, Choice::Command(command)
+                if command.label == "Resume queue" && command.unavailable.is_none())
+        }));
+        let resumed = state.step(press(KeyCode::Enter));
+        assert!(matches!(
+            &resumed[..],
+            [CodeEffect::Submit { prompt }] if prompt == "queued"
+        ));
+
+        let mut slash = active_state();
+        slash.open_palette(true, String::new());
+        let list = match &slash.surface {
+            Surface::Palette(list) => list,
+            _ => {
+                assert!(matches!(slash.surface, Surface::Palette(_)));
+                return;
+            }
+        };
+        assert!(
+            list.choices
+                .iter()
+                .all(|choice| choice.label().starts_with('/'))
+        );
+        assert!(
+            !list
+                .choices
+                .iter()
+                .any(|choice| choice.label() == "Resume queue")
+        );
+    }
+
+    #[test]
+    fn ctrl_l_requests_a_redraw_without_changing_draft_or_surface() {
+        let mut state = active_state();
+        let draft = "draft 界 👩‍💻";
+        let _ = state.step(paste(draft));
+        let effects = state.step(ctrl('l'));
+        assert_eq!(effects, vec![CodeEffect::Redraw]);
+        assert_eq!(state.editor().text(), draft);
+        assert!(matches!(state.surface, Surface::Conversation));
+
+        let _ = state.step(ctrl('p'));
+        let effects = state.step(ctrl('l'));
+        assert_eq!(effects, vec![CodeEffect::Redraw]);
+        assert!(matches!(state.surface, Surface::Palette(_)));
+        assert_eq!(state.editor().text(), draft);
+    }
+
+    #[test]
+    fn below_minimum_permission_cannot_approve_but_can_deny() -> io::Result<()> {
+        let mut state = active_state();
+        let _ = state.step(CodeAction::Event(Event::Resize(30, 10)));
+        assert!(
+            state
+                .receive_permission(question("small-permission"))
+                .is_empty()
+        );
+        let _ = state.step(press(KeyCode::F(2)));
+        assert!(state.step(press(KeyCode::Char('1'))).is_empty());
+        assert!(state.step(press(KeyCode::Enter)).is_empty());
+        assert!(state.permission_selected.is_none());
+
+        let size = Size::new(30, 10);
+        let mut terminal = Terminal::new(TestBackend::new(30, 10))?;
+        terminal.draw(|frame| {
+            let _ = render_dock(frame, &state, size);
+        })?;
+        let rendered = grid(terminal.backend());
+        assert!(rendered.contains("small-permission"), "{rendered}");
+        assert!(rendered.contains("F2 Review"), "{rendered}");
+        assert!(rendered.contains("Approval is disabled"), "{rendered}");
+
+        let denied = state.step(press(KeyCode::Esc));
+        assert!(matches!(
+            &denied[..],
+            [CodeEffect::ResolvePermission {
+                outcome: RequestPermissionOutcome::Selected(choice),
+                ..
+            }] if choice.option_id.0.as_ref() == "reject-once"
+        ));
+        Ok(())
+    }
+
+    #[test]
     fn completion_waits_for_the_last_permission_before_dispatching_queue() {
         let mut state = active_state();
         start_working(&mut state, "first prompt");
         let _ = state.step(paste("follow up"));
-        let _ = state.step(press(KeyCode::Tab));
+        let _ = state.step(press(KeyCode::Enter));
         assert_eq!(state.queue_len(), 1);
         assert!(
             state
@@ -3772,6 +4574,8 @@ mod tests {
                 CodeEffect::Submit { prompt },
             ] if prompt == "follow up"
         ));
+        assert!(state.dispatching.is_some());
+        let _ = state.step(CodeAction::TurnStarted);
         assert_eq!(state.queue_len(), 0);
     }
 
@@ -3784,7 +4588,7 @@ mod tests {
         });
         start_working(&mut state, "first prompt");
         let _ = state.step(paste("follow up"));
-        let _ = state.step(press(KeyCode::Tab));
+        let _ = state.step(press(KeyCode::Enter));
         assert!(state.receive_permission(question("late-one")).is_empty());
         assert!(state.receive_permission(question("late-two")).is_empty());
         assert!(
@@ -3841,7 +4645,7 @@ mod tests {
         start_working(&mut state, "first prompt");
 
         let _ = state.step(paste("/route fast"));
-        let _ = state.step(press(KeyCode::Tab));
+        let _ = state.step(press(KeyCode::Enter));
         assert_eq!(state.queue_len(), 0);
         assert!(
             state
@@ -3853,7 +4657,7 @@ mod tests {
         let _ = state.step(CodeAction::ExternalEditorFinished(Ok(
             "/review narrow layout".to_string(),
         )));
-        let _ = state.step(press(KeyCode::Tab));
+        let _ = state.step(press(KeyCode::Enter));
         assert_eq!(state.queue_len(), 1);
         let next = state.step(CodeAction::TurnSettled(TurnOutcome::Completed));
         assert!(matches!(
@@ -3870,7 +4674,7 @@ mod tests {
             )]),
         ));
         let _ = agent_state.step(paste("/deploy preview"));
-        let _ = agent_state.step(press(KeyCode::Tab));
+        let _ = agent_state.step(press(KeyCode::Enter));
         assert_eq!(agent_state.queue_len(), 1);
         agent_state.apply(SessionUpdate::AvailableCommandsUpdate(
             AvailableCommandsUpdate::new(Vec::new()),
@@ -4032,12 +4836,15 @@ mod tests {
             prompt: "/route".to_string(),
             reason: "connection still opening".to_string(),
         });
+        assert!(state.editor().text().is_empty());
+        assert!(matches!(state.queue_state, QueueRunState::Paused(_)));
+        assert!(matches!(state.surface, Surface::Recovery { selected: 0 }));
+        assert_eq!(
+            state.recovery.front().map(|item| item.prompt.as_str()),
+            Some("/route")
+        );
+        assert!(state.step(press(KeyCode::Enter)).is_empty());
         assert_eq!(state.editor().text(), "/route");
-        let retry = state.step(press(KeyCode::Enter));
-        assert!(matches!(
-            &retry[..],
-            [CodeEffect::AgentPrompt { prompt }] if prompt == "/route"
-        ));
         Ok(())
     }
 
@@ -4068,31 +4875,14 @@ mod tests {
     }
 
     #[test]
-    fn reading_anchor_and_full_tool_inspection_survive_new_activity() {
+    fn ctrl_o_opens_a_live_full_transcript_and_f4_inspects_the_latest_entry() {
         let mut state = active_state();
-        let long = "one long retained line ".repeat(20);
         state.apply(SessionUpdate::AgentMessageChunk(
-            ContentChunk::new(ContentBlock::Text(TextContent::new(long)))
-                .message_id(MessageId::new("m1")),
+            ContentChunk::new(ContentBlock::Text(TextContent::new(
+                "first retained answer",
+            )))
+            .message_id(MessageId::new("m1")),
         ));
-        let registry = Registry::default();
-        let mut cache = DocumentCache::default();
-        cache.refresh(&state, 16, 10, &registry);
-        state.sync_reading_layout(cache.layout_revision, &cache.positions, 8);
-        let _ = state.step(press(KeyCode::PageUp));
-        let anchor = state.reading_anchor.clone();
-        assert!(anchor.is_some());
-
-        state.apply(SessionUpdate::AgentMessageChunk(
-            ContentChunk::new(ContentBlock::Text(TextContent::new("new live activity")))
-                .message_id(MessageId::new("m2")),
-        ));
-        cache.refresh(&state, 16, 10, &registry);
-        state.sync_reading_layout(cache.layout_revision, &cache.positions, 8);
-        assert_eq!(state.reading_anchor, anchor);
-        assert!(state.new_activity);
-
-        state.return_to_live();
         state.apply(SessionUpdate::ToolCall(
             ToolCall::new(ToolCallId::new("tool-1"), "Read complete output")
                 .status(ToolCallStatus::Completed)
@@ -4100,6 +4890,48 @@ mod tests {
                     TextContent::new("full retained tool output including the final diff hunk"),
                 ))]),
         ));
+        let _ = state.step(ctrl('o'));
+        assert!(matches!(
+            &state.surface,
+            Surface::Inspector(inspector)
+                if inspector.tracks_transcript
+                    && inspector.inspector.content.contains("first retained answer")
+                    && inspector.inspector.content.contains("final diff hunk")
+        ));
+        let _ = state.step(press(KeyCode::Char(']')));
+        let selected_tool = match &state.surface {
+            Surface::Inspector(inspector) => inspector.transcript_entry.clone(),
+            _ => None,
+        };
+        assert!(matches!(selected_tool, Some(EntryId::Tool(_))));
+        let _ = state.step(press(KeyCode::F(4)));
+        assert!(matches!(
+            &state.surface,
+            Surface::Inspector(inspector)
+                if !inspector.tracks_transcript
+                    && inspector.inspector.title.starts_with("Tool ·")
+                    && inspector.inspector.content.contains("final diff hunk")
+        ));
+        let _ = state.step(press(KeyCode::Esc));
+        assert!(matches!(
+            &state.surface,
+            Surface::Inspector(inspector)
+                if inspector.tracks_transcript
+                    && matches!(inspector.transcript_entry, Some(EntryId::Tool(_)))
+        ));
+        state.apply(SessionUpdate::AgentMessageChunk(
+            ContentChunk::new(ContentBlock::Text(TextContent::new(
+                "arrived while detached",
+            )))
+            .message_id(MessageId::new("m2")),
+        ));
+        assert!(matches!(
+            &state.surface,
+            Surface::Inspector(inspector)
+                if inspector.inspector.content.contains("arrived while detached")
+        ));
+
+        let _ = state.step(press(KeyCode::Esc));
         let _ = state.step(press(KeyCode::F(4)));
         let inspector = match &state.surface {
             Surface::Inspector(inspector) => inspector,
@@ -4111,11 +4943,16 @@ mod tests {
                 return;
             }
         };
-        assert!(inspector.inspector.content.contains("final diff hunk"));
+        assert!(
+            inspector
+                .inspector
+                .content
+                .contains("arrived while detached")
+        );
         let copied = state.step(ctrl('y'));
         assert!(matches!(
             &copied[..],
-            [CodeEffect::Copy { text }] if text.contains("final diff hunk")
+            [CodeEffect::Copy { text }] if text.contains("arrived while detached")
         ));
     }
 
@@ -4178,7 +5015,7 @@ mod tests {
         let mut state = active_state();
         start_working(&mut state, "first prompt");
         let _ = state.step(paste("follow up only after normal completion"));
-        let _ = state.step(press(KeyCode::Tab));
+        let _ = state.step(press(KeyCode::Enter));
         assert_eq!(state.queue_len(), 1);
 
         let cancelled = state.step(press(KeyCode::Esc));
@@ -4266,7 +5103,15 @@ mod tests {
             reason: "connection refused".to_string(),
         });
         assert_eq!(rejected.journal().entries().count(), 0);
-        assert_eq!(rejected.editor().text(), "must not appear");
+        assert!(rejected.editor().text().is_empty());
+        assert_eq!(
+            rejected.recovery.front().map(|item| item.prompt.as_str()),
+            Some("must not appear")
+        );
+        assert!(matches!(
+            rejected.surface,
+            Surface::Recovery { selected: 0 }
+        ));
     }
 
     #[test]
@@ -4312,7 +5157,7 @@ mod tests {
     }
 
     #[test]
-    fn disconnect_reparents_an_error_inspector_that_arrived_during_permission_focus() {
+    fn ordinary_inspectors_do_not_cover_a_focused_permission() {
         let mut state = active_state();
         state.open_inspector(Inspector::new("Session details", "retained session data"));
         assert!(
@@ -4325,10 +5170,13 @@ mod tests {
             "Operation failed",
             "report failed while waiting",
         ));
-        assert!(matches!(
-            &state.surface,
-            Surface::Inspector(inspector) if inspector.inspector.title == "Operation failed"
-        ));
+        assert!(matches!(&state.surface, Surface::Permission));
+        assert!(
+            state
+                .notice
+                .as_deref()
+                .is_some_and(|notice| notice.contains("F2 to review"))
+        );
 
         assert!(
             state
@@ -4336,7 +5184,6 @@ mod tests {
                 .is_empty()
         );
         assert!(state.permissions.is_empty());
-        assert!(state.step(press(KeyCode::Esc)).is_empty());
         assert!(matches!(
             &state.surface,
             Surface::Inspector(inspector) if inspector.inspector.title == "Session details"
@@ -4344,7 +5191,7 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_c_closes_transient_surfaces_without_losing_the_draft_or_anchor() {
+    fn ctrl_c_closes_transient_surfaces_without_losing_the_draft() {
         let mut state = active_state();
         for index in 0..8 {
             state.apply(SessionUpdate::AgentMessageChunk(
@@ -4354,14 +5201,6 @@ mod tests {
                 .message_id(MessageId::new(format!("modal-{index}"))),
             ));
         }
-        let registry = Registry::default();
-        let mut cache = DocumentCache::default();
-        cache.refresh(&state, 12, 8, &registry);
-        state.sync_reading_layout(cache.layout_revision, &cache.positions, 6);
-        let _ = state.step(press(KeyCode::PageUp));
-        let anchor = state.reading_anchor.clone();
-        assert!(anchor.is_some());
-
         let _ = state.step(paste("draft with a grapheme ���\nsecond line"));
         let _ = state.step(press(KeyCode::Left));
         let draft = state.editor().text().to_string();
@@ -4378,7 +5217,6 @@ mod tests {
         assert!(matches!(state.surface, Surface::Conversation));
         assert_eq!(state.editor().text(), draft);
         assert_eq!(state.editor().cursor_byte(), cursor);
-        assert_eq!(state.reading_anchor, anchor);
 
         let _ = state.step(ctrl('p'));
         assert!(matches!(state.surface, Surface::Palette(_)));
@@ -4399,11 +5237,6 @@ mod tests {
         assert!(state.step(ctrl('c')).is_empty());
         assert!(matches!(state.surface, Surface::Conversation));
 
-        let _ = state.step(ctrl('f'));
-        assert!(matches!(state.surface, Surface::TranscriptSearch { .. }));
-        assert!(state.step(ctrl('c')).is_empty());
-        assert!(matches!(state.surface, Surface::Conversation));
-
         let context = ToolCallUpdate::new(
             ToolCallId::new("permission-tool"),
             ToolCallUpdateFields::default(),
@@ -4420,7 +5253,6 @@ mod tests {
         assert!(matches!(state.surface, Surface::Permission));
         assert_eq!(state.editor().text(), draft);
         assert_eq!(state.editor().cursor_byte(), cursor);
-        assert_eq!(state.reading_anchor, anchor);
 
         let mut operations = CodeState::default();
         operations.set_operations_only(true);
@@ -4444,12 +5276,16 @@ mod tests {
         };
         assert_eq!(agent_rows, 0);
         assert!(operations.step(ctrl('c')).is_empty());
+        assert!(matches!(&operations.surface, Surface::Conversation));
+        let _ = operations.step(ctrl('o'));
         assert!(matches!(
             &operations.surface,
             Surface::Inspector(inspector) if inspector.inspector.title == "Target status"
         ));
+        assert!(operations.step(ctrl('c')).is_empty());
+        assert!(matches!(&operations.surface, Surface::Conversation));
         assert!(matches!(
-            &operations.step(ctrl('c'))[..],
+            &operations.step(press(KeyCode::Esc))[..],
             [CodeEffect::Exit]
         ));
     }
@@ -4503,22 +5339,6 @@ mod tests {
     #[test]
     fn failed_selector_mutation_restores_its_exact_source_and_success_clears_it() {
         let mut state = active_state();
-        for index in 0..4 {
-            state.apply(SessionUpdate::AgentMessageChunk(
-                ContentChunk::new(ContentBlock::Text(TextContent::new(format!(
-                    "retained row {index}"
-                ))))
-                .message_id(MessageId::new(format!("selector-anchor-{index}"))),
-            ));
-        }
-        let registry = Registry::default();
-        let mut cache = DocumentCache::default();
-        cache.refresh(&state, 12, 8, &registry);
-        state.sync_reading_layout(cache.layout_revision, &cache.positions, 6);
-        let _ = state.step(press(KeyCode::PageUp));
-        let anchor = state.reading_anchor.clone();
-        assert!(anchor.is_some());
-
         let _ = state.step(paste("draft survives a failed selector mutation"));
         let _ = state.step(press(KeyCode::Left));
         let draft = state.editor().text().to_string();
@@ -4571,7 +5391,6 @@ mod tests {
         ));
         assert_eq!(state.editor().text(), draft);
         assert_eq!(state.editor().cursor_byte(), cursor);
-        assert_eq!(state.reading_anchor, anchor);
 
         assert!(state.step(press(KeyCode::Esc)).is_empty());
         assert!(matches!(
@@ -4689,20 +5508,21 @@ mod tests {
         for index in 0..12 {
             let prompt = format!("queued-{index:02} 界界 with a long first line\nsecond line");
             let _ = state.step(paste(&prompt));
-            let _ = state.step(press(KeyCode::Tab));
+            let _ = state.step(press(KeyCode::Enter));
         }
         state.surface = Surface::Queue { selected: 0 };
         for _ in 0..11 {
             let _ = state.step(press(KeyCode::Down));
         }
-        let registry = Registry::default();
-        let mut cache = DocumentCache::default();
-        let mut terminal = Terminal::new(TestBackend::new(40, 16))?;
-        terminal.draw(|frame| render_frame(frame, &mut state, &registry, &mut cache))?;
+        let size = Size::new(40, 16);
+        let mut terminal = Terminal::new(TestBackend::new(40, dock_height(&state, size)))?;
+        terminal.draw(|frame| {
+            let _ = render_dock(frame, &state, size);
+        })?;
         let rendered = grid(terminal.backend());
         assert!(rendered.contains("› queued-11"), "{rendered}");
         assert!(!rendered.contains("queued-00"), "{rendered}");
-        assert!(rendered.contains("Enter/e edit"), "{rendered}");
+        assert!(rendered.contains("r resume"), "{rendered}");
         let _ = state.step(press(KeyCode::Enter));
         assert_eq!(
             state.editor.text(),
@@ -4776,7 +5596,13 @@ mod tests {
             eprintln!("80x24\n{wide}\n\n40x16\n{narrow}\n\nlarge cost\n{large_wide}");
         }
 
-        let layout = composer_layout("ab界cd", "ab界".len(), 3);
+        let layout = composer_layout(
+            "ab界cd",
+            "ab界".len(),
+            3,
+            "┃",
+            Style::default().fg(Color::Cyan),
+        );
         assert!(layout.rows.len() >= 2);
         assert!(layout.cursor_row < layout.rows.len());
         assert!(layout.cursor_column >= 2);
@@ -4947,8 +5773,7 @@ mod tests {
     }
 
     #[test]
-    fn long_streaming_history_draws_a_bounded_tail_and_keeps_the_reading_anchor() -> io::Result<()>
-    {
+    fn long_streaming_history_keeps_a_bounded_primary_tail_and_full_inspector() -> io::Result<()> {
         let mut state = active_state();
         for index in 0..40 {
             state.apply(SessionUpdate::AgentMessageChunk(
@@ -4962,39 +5787,28 @@ mod tests {
         let mut cache = DocumentCache::default();
         let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
         terminal.draw(|frame| render_frame(frame, &mut state, &registry, &mut cache))?;
-        let first_revision = cache.layout_revision;
         let tail = grid(terminal.backend());
         assert!(tail.contains("stream 39 retained transcript row"));
         assert!(!tail.contains("stream 00 retained transcript row"));
 
-        terminal.draw(|frame| render_frame(frame, &mut state, &registry, &mut cache))?;
-        assert_eq!(cache.layout_revision, first_revision);
-        let _ = state.step(press(KeyCode::PageUp));
-        let anchor = state.reading_anchor.clone();
-        assert!(anchor.is_some());
-        terminal.backend_mut().resize(40, 16);
-        terminal.draw(|frame| render_frame(frame, &mut state, &registry, &mut cache))?;
-        assert_eq!(state.reading_anchor, anchor);
-        assert!(grid(terminal.backend()).contains("Reading history"));
+        let _ = state.step(ctrl('o'));
         state.apply(SessionUpdate::AgentMessageChunk(
             ContentChunk::new(ContentBlock::Text(TextContent::new(
                 "stream 40 live update",
             )))
             .message_id(MessageId::new("message-40")),
         ));
-        terminal.draw(|frame| render_frame(frame, &mut state, &registry, &mut cache))?;
-        assert_eq!(state.reading_anchor, anchor);
-        assert!(state.new_activity);
-        let reading = grid(terminal.backend());
-        assert!(reading.contains("Reading history · new activity"));
-        if std::env::var_os("BITROUTER_TUI_RENDER_GRID").is_some() {
-            eprintln!("80x24 long history\n{reading}");
-        }
+        assert!(matches!(
+            &state.surface,
+            Surface::Inspector(inspector)
+                if inspector.inspector.content.contains("stream 00 retained transcript row")
+                    && inspector.inspector.content.contains("stream 40 live update")
+        ));
         Ok(())
     }
 
     #[test]
-    fn reading_location_survives_an_expanded_tool_before_the_anchor() -> io::Result<()> {
+    fn immutable_tool_updates_remain_visible_in_full_transcript_detail() -> io::Result<()> {
         let mut state = active_state();
         state.apply(SessionUpdate::ToolCall(
             ToolCall::new(ToolCallId::new("expanding-tool"), "Initial short output")
@@ -5003,25 +5817,6 @@ mod tests {
                     TextContent::new("short output"),
                 ))]),
         ));
-        let message = (1..=36)
-            .map(|line| format!("anchored message row {line}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        state.apply(SessionUpdate::AgentMessageChunk(
-            ContentChunk::new(ContentBlock::Text(TextContent::new(message)))
-                .message_id(MessageId::new("anchored-message")),
-        ));
-        let registry = Registry::default();
-        let mut cache = DocumentCache::default();
-        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
-        terminal.draw(|frame| render_frame(frame, &mut state, &registry, &mut cache))?;
-        let _ = state.step(press(KeyCode::PageUp));
-        let anchor = state.reading_anchor.clone();
-        assert!(matches!(
-            &anchor,
-            Some(ReadingAnchor { entry: EntryId::Message(id), .. }) if id.0.as_ref() == "anchored-message"
-        ));
-
         let long_output = (1..=24)
             .map(|line| format!("expanded output row {line}"))
             .collect::<Vec<_>>()
@@ -5034,19 +5829,12 @@ mod tests {
             ToolCallId::new("expanding-tool"),
             fields,
         )));
-        terminal.backend_mut().resize(40, 16);
-        terminal.draw(|frame| render_frame(frame, &mut state, &registry, &mut cache))?;
-        assert_eq!(state.reading_anchor, anchor);
-        let start = cache.start_for(&state, 4);
-        let anchored_entry = cache.entries.iter().find(|entry| {
-            let end = entry.start.saturating_add(entry.rows.len());
-            entry.start <= start && start < end
-        });
+        let _ = state.step(ctrl('o'));
         assert!(matches!(
-            anchored_entry,
-            Some(entry) if matches!(&anchor, Some(anchor) if entry.id == anchor.entry)
+            &state.surface,
+            Surface::Inspector(inspector)
+                if inspector.inspector.content.contains("expanded output row 24")
         ));
-        assert!(grid(terminal.backend()).contains("Reading history"));
         Ok(())
     }
 }

--- a/crates/bitrouter-tui/src/lifecycle.rs
+++ b/crates/bitrouter-tui/src/lifecycle.rs
@@ -31,6 +31,23 @@ pub fn enter_alternate_screen() -> io::Result<()> {
     execute!(io::stdout(), crossterm::terminal::EnterAlternateScreen)
 }
 
+/// Leave only the alternate screen owned by a detached view.
+///
+/// Raw mode, bracketed paste, and enhanced keyboard handling belong to the
+/// surrounding session and deliberately remain active. Repeated calls are
+/// harmless, which lets the normal draw path recover after a failed detached
+/// render without accidentally tearing down session input.
+pub fn leave_alternate_screen() -> io::Result<()> {
+    if ALTERNATE_SCREEN.swap(false, Ordering::SeqCst) {
+        execute!(
+            io::stdout(),
+            crossterm::cursor::Show,
+            crossterm::terminal::LeaveAlternateScreen
+        )?;
+    }
+    Ok(())
+}
+
 /// Request disambiguated Enter modifiers on supporting terminals. Older
 /// terminals ignore the sequence; Alt+Enter and Ctrl+J remain available.
 pub fn enable_session_keys() -> io::Result<()> {
@@ -62,9 +79,7 @@ pub fn restore() {
         crossterm::event::DisableBracketedPaste,
         crossterm::cursor::Show
     );
-    if ALTERNATE_SCREEN.swap(false, Ordering::SeqCst) {
-        let _ = execute!(out, crossterm::terminal::LeaveAlternateScreen);
-    }
+    let _ = leave_alternate_screen();
     // XTWINOPS pop: put the user's window title back.
     let _ = write!(out, "\x1b[23;0t");
     let _ = out.flush();

--- a/crates/bitrouter-tui/src/render/mod.rs
+++ b/crates/bitrouter-tui/src/render/mod.rs
@@ -280,7 +280,7 @@ pub fn message(message: &crate::journal::Message, width: u16) -> Vec<Line<'stati
 /// Keep one row per source line for the Code journal's reading anchors.
 pub fn source_message(message: &crate::journal::Message) -> Vec<Line<'static>> {
     let (prefix, style) = match message.voice {
-        crate::journal::Voice::User => ("> ", Style::default().fg(Color::Cyan)),
+        crate::journal::Voice::User => ("┃ ", Style::default().fg(Color::Cyan)),
         crate::journal::Voice::Agent => ("", Style::default()),
         crate::journal::Voice::Thought => ("· ", thought_style()),
     };

--- a/crates/bitrouter-tui/src/writer.rs
+++ b/crates/bitrouter-tui/src/writer.rs
@@ -306,6 +306,29 @@ impl<B: Backend + SyncSink> Writer<B> {
         self.prev.clear();
     }
 
+    /// Make the complete current screen available without deleting history.
+    ///
+    /// The startup anchor protects shell rows above Code's first cursor. A
+    /// below-minimum safety surface cannot be useful in a one-row remainder,
+    /// so it scrolls those protected rows into native history and then owns
+    /// the full shrunken screen. Repeated calls are harmless once the anchor
+    /// reaches zero.
+    pub fn claim_full_height(&mut self) -> io::Result<()> {
+        let size = self.backend.size()?;
+        self.width = size.width.max(1);
+        self.height = size.height.max(1);
+        self.anchor = self.anchor.min(self.height.saturating_sub(1));
+        if self.anchor == 0 {
+            return Ok(());
+        }
+        self.backend.synchronized(true)?;
+        let result = self.scroll(usize::from(self.anchor));
+        self.backend.synchronized(false)?;
+        result?;
+        self.prev.clear();
+        self.backend.flush()
+    }
+
     /// Leave the cursor below the document, and nothing else.
     ///
     /// Every committed row stays exactly where it is — teardown removes
@@ -692,6 +715,19 @@ mod tests {
         let mut writer = writer(20, 6);
         writer.frame(&document(&["one", "two", "three"]))?;
         assert_eq!(screen(&writer)[..3], ["one", "two", "three"]);
+        Ok(())
+    }
+
+    #[test]
+    fn claiming_full_height_scrolls_the_anchor_instead_of_clearing_history() -> io::Result<()> {
+        let mut writer = writer(20, 6);
+        writer.anchor = 4;
+        writer.claim_full_height()?;
+        assert_eq!(writer.anchor, 0);
+        writer.frame(&document(&["safe one", "safe two", "safe three"]))?;
+        assert_eq!(screen(&writer)[..3], ["safe one", "safe two", "safe three"]);
+        writer.claim_full_height()?;
+        assert_eq!(writer.anchor, 0);
         Ok(())
     }
 

--- a/docs/CODE_TUI_UX_SPEC.md
+++ b/docs/CODE_TUI_UX_SPEC.md
@@ -1,590 +1,788 @@
-# Spec: conversation-first Code TUI
+# Spec: scrollback-native conversation TUI
 
-Status: **implemented; local acceptance verification complete**
+Status: **implemented** · Date: 2026-09-09
 
-Tracking: [CODE_TUI_UX_PROGRESS.md](CODE_TUI_UX_PROGRESS.md).
+Baseline: `65891881` (`main`, PR #900 merged after #899 and #901)
 
-Date: 2026-09-08
-
-Source baseline: `b657cb62` (`v1.0.0-alpha.30` release commit)
+Supersedes the rendering decision in PR #900's conversation-first Code spec.
 
 ## 1. Decision and review boundary
 
-`bitrouter code` is a coding conversation. Its persistent interface is the
-transcript, composer, and a compact status area. Remove the seven-view
-navigation: Home, Agents, Conversation, Sessions, Models, Requests, and Route.
-Expose their useful capabilities as temporary pickers, inspectors, and bounded
-actions that return users to the same conversation.
+`bitrouter code` is a coding conversation, not a router dashboard. Its permanent
+surface is a transcript in the terminal's native scrollback, a docked composer,
+and compact session status. It has no global tabs, sidebar, home page, or
+permanent operations panel.
 
-The maintainer accepted the conversation-first direction and the proposed
-always-visible information: **agent, route, activity, and attributed session
-cost**. This document makes that direction concrete for review. The remaining
-choices below define the implementation the maintainer subsequently authorized.
+Router and agent capabilities remain available through a searchable command
+palette, temporary docked pickers, and explicit read-only inspectors. Large
+inspectors use the alternate screen only while the user has deliberately opened
+them. Closing an inspector restores the ordinary scrollback surface, exact
+draft, cursor, and application focus. The terminal—not BitRouter—owns the
+user's native scrollback position.
 
-| Decision | Proposed contract |
-| --- | --- |
-| D1: primary surface | One conversation; no permanent page tabs or sidebar |
-| D2: rendering | Retain full-screen rendering for the first implementation; do not couple this work to an inline-renderer rewrite |
-| D3: discovery | Searchable command palette and slash completion, plus contextual hints |
-| D4: composition | Editable multiline draft, intact paste, history, and drafting during a running turn |
-| D5: follow-ups | Explicit local queue for the next turn; no simulated native mid-turn steering |
-| D6: routing | Session route controls and agent model settings remain separate, clearly labelled operations |
-| D7: sessions | One active native session; capability-led opening; no BitRouter transcript database |
-| D8: operations | On-demand inspectors using existing typed reports; retain remote read-only access without remote ACP |
+While a turn is running, the composer is visibly relabelled **Next turn**.
+Pressing Enter queues that draft for the next turn. This is FIFO queueing, not
+ACP steering, and the UI must never describe it as steering.
 
-Changes to these decisions must remain explicit during implementation review.
+The decisions for review are:
 
-### Review guide
+| ID | Decision | Consequence |
+| --- | --- | --- |
+| D1 | One permanent conversation; remove all dashboard tabs. | Home, catalogs, route, requests, policy, telemetry, and reload stop being peer destinations. |
+| D2 | The primary surface uses native terminal scrollback. | Do not enter the alternate screen at startup; the terminal owns ordinary transcript scrolling. |
+| D3 | Composer, palette, picker, permission, and queue controls share one docked footer. | Temporary interaction adds no permanent chrome and never replaces the conversation. |
+| D4 | Large read-only inspectors may temporarily own the alternate screen. | Full transcript, retained tool output, policy, request, telemetry, and similar reports can support search and paging without polluting scrollback. |
+| D5 | Enter submits the current composer in both idle and working states. | At idle it starts a turn; while working it queues a visibly labelled **Next turn** draft. |
+| D6 | Queued work is explicit FIFO follow-up, not simulated mid-turn steering. | Dispatch only after a normal turn completion. Abnormal outcomes enter `Paused(reason)` and require an explicit **Resume queue**; unresolved permission temporarily blocks dispatch without changing queue order. |
+| D7 | Agent, confirmed route, activity, and attributed session cost are the only default session facts. | Other identities and operational detail move to inspectors. |
+| D8 | Preserve main's typed local/remote administration actions without preserving its page model. | CLI and TUI remain two front ends over the same action ports and reports. |
+| D9 | Preserve main's merged conversation state, editor, ACP lifecycle, permission, cancellation, and restoration contracts. | Replace its full-screen primary renderer rather than discarding its behavior. |
+| D10 | In a coding conversation, `Ctrl-O` opens the full transcript inspector by default. | The inspector also exposes stable navigation to retained tool calls, diffs, and other detail entries; an inline **Inspect** action may open a specific entry directly. An operations-only root opens its current status report instead. |
 
-Start with the old-view mapping in §5.2 and the proposed terminal layout in
-§6. The central choice is to make conversation the permanent destination,
-with controls returning to the same draft and reading position.
+Changes to D1-D10 require explicit design review. Implementation progress and
+validation evidence belong in a separate ledger, not in this spec.
 
-The recommendations that most affect day-to-day use are:
+## 2. Merged baseline and implemented migration
 
-- Keep full-screen rendering for this release while removing permanent tabs.
-- Show agent, confirmed route, activity, and attributed session cost; move
-  catalogs and operational detail into temporary inspectors.
-- Allow drafting during work, with an explicit next-turn queue. Do not claim
-  native mid-turn steering through ACP.
-- Derive agent commands, permissions, settings, and session controls from
-  advertised protocol support; separate them from BitRouter-owned actions.
-- Preserve remote operations as a visibly read-only inspector without a coding
-  composer until remote ACP exists.
+PR #900 is merged. Current main already removes the eleven-page dashboard,
+deletes `crates/bitrouter-tui/src/dashboard.rs`, keeps `apps/bitrouter/src/dashboard.rs`
+as a thin entry point, and integrates #901's typed local/remote operations into
+Code's command palette and inspectors. It also supplies one conversation state,
+multiline editing, searchable commands, explicit FIFO follow-ups, retained
+detail, and careful ACP permission/cancellation behavior.
 
-The delivery sequence and A1–A14 acceptance criteria in §12 define completion.
-The linked implementation ledger records the completed checks, acceptance
-evidence, and limits of native-adapter validation.
+The implementation closes the remaining terminal-ownership and
+working-composer mismatch. `CodeView::open()` keeps the normal buffer, the
+ordinary conversation has no application-controlled reading anchor, and Enter
+queues the visibly labelled **Next turn** draft during work. It reuses the
+writer's variable-height `docked_frame()` primitive, changing the primary
+renderer and queue contract without redoing the merged information
+architecture.
 
-## 2. Problem and source evidence
-
-The current navigation treats different activities as equal destinations:
-conversation is continuous work; selecting a model is a brief decision; reading
-request history is an occasional investigation. The tab bar makes users leave
-the work to operate its controls and mixes native-session and daemon-wide scope.
-
-The source audit also found two independent conversation drivers. They share
-the journal/renderers but have different input, command, permission, and status
-behavior. Removing tabs alone would leave these inconsistencies intact.
-
-| Component at the source baseline | Observed behavior |
-| --- | --- |
-| [baseline `dashboard.rs` renderer](https://github.com/bitrouter/bitrouter/blob/b657cb62/crates/bitrouter-tui/src/dashboard.rs) | Seven permanent tabs; full-screen permission heading says choose 1–9 without rendering the offered option labels; conversation status omits the inline cost/context footer |
-| [baseline `dashboard.rs` driver](https://github.com/bitrouter/bitrouter/blob/b657cb62/apps/bitrouter/src/dashboard.rs) | Incoming updates reset scroll; one pending-permission slot; conversation prompts bypass local action resolution; ordinary typing is ignored while a turn runs |
-| [baseline `editor.rs`](https://github.com/bitrouter/bitrouter/blob/b657cb62/crates/bitrouter-tui/src/editor.rs) | Inline editor has no cursor movement or history and flattens multiline paste |
-| [baseline `machine.rs`](https://github.com/bitrouter/bitrouter/blob/b657cb62/crates/bitrouter-tui/src/machine.rs) | Inline reducer has explicit phases, queued permissions, and local slash resolution that the dashboard does not share |
-| [baseline `view.rs`](https://github.com/bitrouter/bitrouter/blob/b657cb62/crates/bitrouter-tui/src/view.rs) and [`cost.rs`](https://github.com/bitrouter/bitrouter/blob/b657cb62/crates/bitrouter-tui/src/cost.rs) | Existing cost attribution, route, and session metadata presentation to preserve |
-| [baseline `render/mod.rs`](https://github.com/bitrouter/bitrouter/blob/b657cb62/crates/bitrouter-tui/src/render/mod.rs) | Retained structured tools and diffs; mostly generic presentation; expansion deferred |
-| [baseline `acp_cli.rs`](https://github.com/bitrouter/bitrouter/blob/b657cb62/apps/bitrouter/src/acp_cli.rs) | Shared agent resolution, session host, new/load/resume selection, and negotiated capability snapshot |
-
-These are source-level findings, not measured latency or usability results.
-Historical spec status labels are not proof of current implementation.
-
-## 3. Relationship to existing contracts
-
-This design supersedes the permanent Code-shell navigation in
-[`AGENT_INTERFACE_UNIFICATION_SPEC.md`](AGENT_INTERFACE_UNIFICATION_SPEC.md)
-and the dashboard presentation in
-[`REMOTE_CONTROL_MVP_SPEC.md`](REMOTE_CONTROL_MVP_SPEC.md). It preserves their
-public command naming, native-agent ownership, and remote HTTP action boundary.
-
-It preserves the controller topology in
-[`ACP_CONTROLLER_SPEC.md`](ACP_CONTROLLER_SPEC.md), and the shared action/port
-boundary in [`ACTIONS_SPEC.md`](ACTIONS_SPEC.md) and
-[`CLI_TUI_PARITY_SPEC.md`](CLI_TUI_PARITY_SPEC.md). It replaces presentation
-restrictions in [`TUI_RENDERER_SPEC.md`](TUI_RENDERER_SPEC.md) only where needed
-for the composer, inspection, and explicit scroll ownership described here.
-
-Cancellation requires a narrow amendment to
-[`ACP_SAFETY_INVARIANTS.md`](ACP_SAFETY_INVARIANTS.md): rejecting an operation and
-cancelling a turn are distinct outcomes (§9). Do not preserve reject-on-cancel
-solely because existing tests encode it, or weaken deny-on-abandon behavior for
-unrelated cases.
-
-Remote ACP remains deferred under
-[`REMOTE_CLI_TUI_SUPPORT_SPEC.md`](REMOTE_CLI_TUI_SUPPORT_SPEC.md). No transport,
-supervisor, credential, or provider integration change is implied by this UI.
-
-## 4. Scope
-
-The first implementation includes navigation replacement, one shared
-interaction core, the four-field status contract, useful composition, explicit
-follow-up queueing, permission/cancellation correctness, and transcript
-inspection. It preserves existing local and remote operational capabilities.
-
-Non-goals:
-
-- A first-party graphical application, fleet dashboard, or persistent sidebar.
-- A BitRouter-owned durable transcript/session catalog or background supervisor.
-- Cross-agent transfer of context, automatic agent switching, or multi-agent
-  orchestration.
-- Universal Codex/Claude/OpenCode native-feature parity through ACP.
-- A new inline/full-screen preference or a new widget framework.
-- New remote ACP, terminal-tool, filesystem-tool, or authentication capabilities.
-- New billing estimates, routing decisions, or inferred per-request attribution.
-- Native rewind/undo, fork/delete UI, image/audio composition, shell escape
-  execution, or configurable keymap/theme systems in this release.
-
-## 5. Entry, navigation, and restoration
-
-### 5.1 Local entry
-
-- `bitrouter code <agent>` resolves the existing agent identity and opens the
-  requested new/load/resume session directly into the conversation.
-- Bare `bitrouter code` shows the empty conversation with a searchable **Choose
-  agent** picker. It does not launch an arbitrary first agent or introduce a
-  remembered-agent preference. Cancelling the picker leaves the empty composer.
-- A prompt written before connection is retained. Sending it opens the picker;
-  after connection the prompt stays a draft until explicitly submitted.
-- A supplied invalid agent or unsupported lifecycle flag remains an explicit
-  error. Do not silently create a new session when load/resume was requested.
-- Show connection/authentication progress where activity normally appears. A
-  failed connection offers the existing actionable diagnostic and retry/change
-  agent actions; it must not erase the draft or pretend to be connected.
-- Keep terminal authentication disabled unless a supported terminal handoff is
-  implemented separately. Provide the existing external authentication guidance.
-
-### 5.2 Where the old views go
-
-| Old view | Replacement |
-| --- | --- |
-| Home | Empty conversation with project context, prompt, and command hints |
-| Agents | Choose agent picker, scoped to available ACP facets |
-| Conversation | Primary surface |
-| Sessions | Open session picker when listing is supported; enter a native ID when only load/resume is supported |
-| Models | Agent settings picker and a separate routable-model catalog inspector |
-| Requests | Bounded request inspector labelled by its actual scope; detailed history remains available through `bitrouter requests` |
-| Route | Session route picker and read-only route preview/inspection |
-
-Changing agents creates or opens that agent's own session. It never relabels
-the current transcript as belonging to another agent. During a running turn,
-agent/session replacement is unavailable until the turn settles or cancellation
-completes. Preserve the existing session on picker dismissal. If a replacement
-requires shutting down the connection before opening another, retain the old
-view on failure as a clearly disconnected view with its native ID and draft;
-do not imply that the old session is still attached.
-
-### 5.3 Temporary surfaces
-
-There are three surface types: a searchable single-choice picker, a read-only
-inspector, and a permission/question surface. Closing a picker or inspector
-restores draft text, cursor, transcript anchor, and prior focus. Pending updates
-continue to be consumed while these surfaces are open.
-
-Inspectors may occupy the whole terminal for long output. Their title and exit
-hint identify what is being inspected. They are temporary views of the active
-work, without a global page bar. A brief action result may be recorded as a
-BitRouter-labelled transcript event; large reports must not repeatedly flood it.
-
-### 5.4 Remote read-only entry
-
-Existing `bitrouter --context <name> code` remains useful for remote operations.
-Since remote ACP is unavailable, open a labelled **Remote operations** status
-inspector with the same command palette offering supported status, models,
-request history, and route preview actions. No seven-tab dashboard returns.
-
-The remote inspector displays the selected target and read-only scope. It has
-no enabled coding composer, agent launcher, or session route mutation. Closing
-its root inspector exits; closing a nested inspector returns to its root.
-The four session status fields apply only when a local ACP session exists.
-Remote errors never fall back to local data. Existing local `--socket`-only
-operational use follows the same inspector pattern and existing argument guards.
-
-## 6. Persistent layout and status
-
-Illustrative layout; values are examples, not measured results:
+The target combines the merged baseline with the selected interaction model:
 
 ```text
-bitrouter code · ~/work/project
-
-› Fix model-name search in the route picker.
-
-I'll inspect the picker, update selection, and check the behavior.
-✓ Explored 3 files · 2 searches                  [inspect]
-✓ Edited picker.rs · +8 -4                       [inspect]
-◍ Running focused checks
-
-Next turn: Also check narrow terminals.          [edit/remove]
-────────────────────────────────────────────────────────────
-› Keep the current route selected when I reopen the picker.
-────────────────────────────────────────────────────────────
-agent: Codex · route: coding-default
-activity: working 12s · session cost: USD 0.0800 (router)
-Tab queue next · Esc interrupt · Ctrl-P commands
+main @ 65891881   no tabs, CodeState/editor, ACP correctness, typed operations
+main writer       retained journal, live-tail cache, variable-height dock
+fx interaction    low-chrome footer grammar and detached detail viewer
+──────────────────────────────────────────────────────────────────
+implemented       scrollback-native, conversation-first Code TUI
 ```
 
-Do not permanently show session IDs, provider catalogs, daemon PID/listeners,
-all configuration options, or a task-management sidebar.
+This was a renderer and interaction-state migration, not a branch-conflict
+resolution. Product state and presentation remain separate, so neither
+terminal mode owns network, controller, report, or persistence behavior.
 
-### 6.1 The four fields
+### 2.1 Relationship to existing contracts
 
-| Field | Meaning and source |
-| --- | --- |
-| Agent | Resolved selected agent identity; connected state comes from lifecycle, not catalog availability |
-| Route | Confirmed session override or known configured policy; distinguish no override from direct/unbound routing |
-| Activity | Client-observed lifecycle: choosing agent, connecting, ready, working, permission needed, cancelling, or disconnected/failed |
-| Session cost | Cumulative native-session `UsageUpdate.cost`, labelled with known provenance |
+This spec supersedes the permanent Code-shell navigation in
+[`AGENT_INTERFACE_UNIFICATION_SPEC.md`](AGENT_INTERFACE_UNIFICATION_SPEC.md),
+the page presentation in [`REMOTE_ADMINISTRATION_SPEC.md`](REMOTE_ADMINISTRATION_SPEC.md),
+and the merged PR #900 decision to keep a full-screen primary renderer. It does
+not supersede their command naming, ACP lifecycle, native-session ownership,
+remote-transport boundary, or action authorization.
 
-Activity may include a reported current tool title and client-measured elapsed
-time. Without a reported tool, say **Working**. Never invent a percentage,
-completion estimate, or a claim that the agent is thinking. Permission-needed
-and failure states outrank ordinary activity. Completion may leave a concise
-duration/result event while activity returns to ready.
+It preserves the retained journal and normal-buffer ownership established by
+[`TUI_RENDERER_SPEC.md`](TUI_RENDERER_SPEC.md), with two deliberate extensions:
+a variable-height dock and a detached alternate-screen viewer. It preserves
+[`CLI_TUI_PARITY_SPEC.md`](CLI_TUI_PARITY_SPEC.md)'s narrower rule that only
+session-safe actions belong in the conversation surface; daemon-wide actions
+remain explicit BitRouter-owned operations even when the same palette discovers
+them.
 
-Route display must not equate an agent's model setting, a session lease, and
-the actual upstream used by a request. Use **default (no override)** when that
-is the only known fact. Show **direct** only when launch/routing state proves
-it; otherwise use **unreported**. Route details can expose the agent model and
-latest observed upstream separately when those facts are available.
+## 3. Goals and non-goals
 
-Cost reuses the existing provenance contract: `bitrouter.dev/cost = router`
-means router-attributed; an unmarked agent figure is labelled **agent-reported**;
-missing or unknown provenance renders **cost unreported**. An inspector may
-explain the latter. Never substitute host-wide spend, sum router and agent
-figures, convert currencies, or turn missing data into zero. Preserve supplied
-pricing/completeness qualifications when available. Cost may arrive late; ready
-does not imply that metering has finished. Loaded/resumed session cost remains
-session cumulative, not cost since this UI process started.
+### 3.1 Goals
 
-Context usage is available in session details when the agent reports a usable
-used/size pair. It is not a fifth default status item in this proposal.
+1. Make conversation the only persistent destination in `bitrouter code`.
+2. Preserve the user's ordinary terminal history and native scroll controls.
+3. Make every temporary action return to the same draft, application focus, and
+   detached-view location; native scrollback position remains terminal-owned.
+4. Keep frequent interaction in one low-chrome docked footer.
+5. Give large retained content a searchable, pageable, explicitly opened viewer.
+6. Make working-state follow-ups convenient without misrepresenting ACP support.
+7. Preserve capability-led agent settings, native session identity, permission
+   choices, cancellation, and late-update handling.
+8. Preserve local and remote router operations through the same typed actions
+   used by headless CLI commands.
+9. Make source and authority visible whenever model, route, cost, or operation
+   scope could otherwise be confused.
+10. Remain usable with keyboard-only input, narrow terminals, CJK, emoji,
+    multiline paste, resize, suspend/resume, and ordinary shell scrollback.
 
-### 6.2 Terminal sizes
+### 3.2 Non-goals
 
-At 80×24, all four fields must be readable, using two status rows if needed.
-Long agent/route names may be ellipsized with full text in details; preserve
-activity meaning and cost provenance before optional names or hints. At 40×16,
-wrap the status and show bounded transcript/composer areas rather than clipping
-an approval choice. Below the supported layout minimum, show a resize message
-and retain all input/session state. No action is approved by resizing.
+- A first-party graphical app, fleet dashboard, task sidebar, or multi-session
+  workspace.
+- A BitRouter-owned transcript database, replacement session ID, or background
+  ACP supervisor.
+- Remote ACP, remote coding composition, or reconnecting to an already-running
+  controller.
+- Mid-turn steering unless ACP later exposes a negotiated steering capability.
+- Making every CLI leaf a session command.
+- A mouse-first interface, configurable widget framework, or general-purpose
+  terminal UI toolkit.
+- A theme marketplace or user-defined keymap in the first implementation.
+- Emitting unbounded reports or full tool output into ordinary conversation
+  scrollback.
+- Changing router policy, metering, authentication, or action authorization
+  semantics as part of the presentation rewrite.
 
-Use terminal-aware widths, grapheme-safe editing, plain labels in addition to
-colour, and readable light/dark contrast. Keep the terminal's editing cursor
-at the actual composer position. The transcript, composer, and focused surface
-need distinct visual treatment with minimal borders.
+## 4. Surface and terminal ownership
 
-## 7. Composer, commands, and follow-ups
+The UI has three presentation layers. Their terminal ownership is part of the
+product contract.
 
-### 7.1 Editing
+### 4.1 Persistent document: native scrollback
 
-The composer supports left/right and word navigation, Home/End, deletion,
-multiline editing, and Up/Down prompt history at the first/last logical line.
-History is process-local for this release. Bracketed paste preserves line
-breaks and never submits. A large paste may have a collapsed display, but its
-complete contents must be inspectable and sent unchanged.
+The conversation transcript is a vertically rendered document on the terminal's
+normal buffer. The terminal owns scrolling. BitRouter may repaint the live tail
+that it still owns, but it must not pretend that off-screen native scrollback is
+an application-controlled viewport.
 
-Enter sends at idle. Shift-Enter or Alt-Enter inserts a newline where supported; Ctrl-J is
-the documented fallback. Ctrl-G opens `$VISUAL` or `$EDITOR` when configured,
-using a deliberate terminal suspend/restore path. This handoff is available
-only at idle with no pending question in the first release; drafting inside
-the TUI remains available during work. On editor failure or session disconnect
-preserve the recoverable draft and display the error. The same editor rules
-apply in both canonical and retained compatibility entry paths. Blank-input
-detection may inspect trimmed text; ordinary prompt submission must preserve
-the draft's actual whitespace and line breaks.
+The persistent document contains:
 
-### 7.2 Discovery and command ownership
+- submitted user messages;
+- assistant text;
+- retained tool and diff summaries;
+- short BitRouter-labelled action results when recording them aids continuity;
+- completion, interruption, failure, and recovery events.
 
-Ctrl-P opens a searchable command palette. Typing `/` at the start of the
-composer opens slash completion. Rows contain a label, a short description,
-owner (**BitRouter**, **Agent**, or **Prompt template**), and a reason when an
-offered action is unavailable. Arrow keys navigate; Enter accepts; Esc closes.
-Digits are query text in searchable pickers, never immediate selection keys.
+It does not contain picker rows, permission buttons, palette queries, transient
+notices, complete large reports, or every refresh of operational data.
 
-Keep the existing local command spellings and resolution precedence for direct
-typed submissions. Do not invent aliases such as `/model` or `/agent` that
-silently reserve another agent's commands. View-only actions such as **Open
-session** or **Agent settings** can initially be palette entries without new
-slash names. Existing `/route` is a session mutation; `/preview` is read-only.
+Incoming ACP updates patch the retained journal, which remains authoritative
+even after rows have entered native history. The normal-buffer writer tracks a
+monotonic commit cursor: which persistent entries have been emitted, which
+revision of each entry is still inside the owned live tail, and which rows have
+become immutable terminal history. It may patch the owned live tail, but it
+cannot rewrite an older tool row after the terminal has committed it to
+scrollback. The retained full-transcript/tool inspector shows the newest journal
+revision in that case.
 
-When names collide, show both owners. Selecting an Agent row explicitly sends
-that agent command as prompt text, bypassing local name resolution; selecting
-a BitRouter row dispatches its typed local action. The selection must retain
-owner identity until submission. If edited so that the selected command no
-longer matches, clear that identity and resolve again visibly. Prompt templates
-remain prompt expansions. Unknown typed slash text retains the existing agent
-prompt fallback. No UI command is executed by asking the model to perform it.
+BitRouter cannot read or restore the terminal's native scrollback offset. The
+primary contract is therefore that it never clears the normal buffer, replays
+already committed entries, or deliberately forces a viewport jump. Whether a
+terminal follows new output while the user is reading history is controlled by
+that terminal's scroll-on-output setting. `Ctrl-L` invalidates and redraws only
+the owned live region; it does not clear history, replay the conversation, or
+change the draft.
 
-Agent command lists update from `AvailableCommandsUpdate`. A list not yet
-received is different from an empty list. Shared operational actions continue
-through `ACTIONS` and existing ports. Pure UI actions do not become public MCP
-tools merely because they appear in the palette.
+### 4.2 Docked transient surface
 
-### 7.3 While a turn is running
+The footer is the only persistent interactive region. Depending on state it may
+show:
 
-Draft editing stays available. Tab explicitly queues the draft for the next
-turn when no completion popup owns Tab. With a popup open, Tab accepts its
-completion; it must not also queue. Enter during a running turn preserves the
-draft and displays **Tab queues for the next turn; Esc interrupts**. It does
-not claim Codex-style steering or silently interrupt and resubmit.
+- the ordinary composer;
+- the **Next turn** composer and bounded queue preview;
+- command palette or slash completion;
+- a searchable single-choice picker;
+- the oldest pending permission or agent question;
+- a short notice or recoverable error;
+- compact agent, route, activity, and cost status;
+- width-appropriate keyboard hints.
 
-Queued prompts appear above the composer and can be inspected, edited, or
-removed through a focused queue action. FIFO dispatch sends one item only after
-the preceding `session/prompt` has completed normally with `end_turn` and all
-blocking requests are settled. A refusal, limit stop, error, cancellation, or
-disconnect pauses the queue for explicit user action. Never replay uncertain
-submissions after reconnect or move queued work to a different agent/session.
+Palette, picker, permission, and queue controls reuse this space. They do not
+appear as centered cards and do not establish a second navigation hierarchy.
+Opening or closing them must not commit rows to scrollback merely because their
+height changed.
 
-The first queue supports text prompts, prompt templates, and advertised agent
-commands. Revalidate command availability when dispatching. Local UI/settings
-actions execute through their own availability rules; do not add them or shell
-commands to this queue. New-session/agent switching with queued work requires
-the user to resolve or discard that queue explicitly.
+### 4.3 Detached read-only inspector: temporary alternate screen
 
-### 7.4 Keys and modal precedence
+A large inspector may enter the alternate screen only after an explicit user
+action. `Ctrl-O` opens the full transcript inspector; its stable entry navigator
+can jump to retained tool calls, diffs, and other detail. Accepting an inline
+**Inspect** action opens that entry directly. Choosing a large report from the
+command palette may also open the inspector. In the operations-only remote root,
+where no coding transcript exists, `Ctrl-O` opens the current status report.
 
-| Context | Esc | Ctrl-C | Ctrl-D |
+Eligible content includes:
+
+- full transcript;
+- complete retained tool output and diffs;
+- bounded request history;
+- model/provider catalogs when they exceed the dock budget;
+- policy overview and named policy detail;
+- telemetry detail;
+- reload receipts and partial-failure detail;
+- structured permission context.
+
+The inspector owns paging, search, selection within the report, and an explicit
+close control. It is read-only: mutations require returning to the normal
+surface and confirming through a docked action or permission flow.
+
+In the full-transcript inspector, `[` and `]` move through retained entries by
+stable journal identity. `F4` opens the selected entry's complete detail without
+leaving the alternate screen; Escape returns to the same transcript selection
+and scroll position. Ordinary arrows and Page Up/Page Down remain report
+scrolling, while Ctrl-F searches the current inspector.
+
+The session owns raw mode, keyboard enhancement, bracketed paste, signal hooks,
+and the normal-buffer cursor contract for its whole lifetime. A detached
+inspector acquires only alternate-buffer custody plus its own cursor
+visibility/shape; closing an inspector must not run the session-wide terminal
+restore path.
+
+Opening records both the latest journal revision and the normal writer's commit
+cursor, then suspends normal-buffer painting. ACP updates, action completions,
+metering updates, resize events, and permission requests continue to update
+authoritative state in the background. Each new persistent transcript entry is
+added to a pending normal-buffer commit range. Revisions to already committed
+history update the journal but are not emitted again.
+
+On close, in this order:
+
+1. stop inspector painting and leave the alternate buffer, restoring only the
+   cursor state it acquired;
+2. resume the normal buffer with session-owned input modes still active;
+3. emit every persistent entry after the recorded commit cursor in document
+   order, exactly once, even when the backlog exceeds several screens;
+4. apply current revisions to entries that remain in the owned live tail,
+   invalidate its cache, and draw the current dock;
+5. advance the commit cursor atomically so retrying restoration cannot duplicate
+   the backlog;
+6. restore exact draft bytes, grapheme cursor, prior dock focus, and any detached
+   search/navigation state retained for reopening;
+7. show newly arrived permission, failure, or disconnect notices at normal
+   priority without transferring input focus implicitly.
+
+The restore path must handle a backlog larger than three terminal screens, an
+old tool entry receiving a late update, and one or more resizes while detached.
+It never replays the whole journal and never claims to restore the terminal's
+native scrollback offset.
+
+An inspector may navigate within one alternate-screen session, but inspectors
+must not nest alternate buffers. On SIGTSTP the process restores all acquired
+terminal modes before suspension; on SIGCONT it reacquires session modes and
+redraws whichever normal or detached surface is authoritative. SIGINT, SIGTERM,
+panics, ordinary exit, and failed external-editor handoff likewise restore every
+mode the process acquired exactly once.
+
+## 5. Persistent layout and visual grammar
+
+Illustrative 80-column state; values are examples:
+
+```text
+𝒃 bitrouter · project
+
+┃ Keep the selected route when I reopen the picker.
+
+  ● Read 4 files
+  ● Ran cargo nextest run -p bitrouter-tui
+  ● Edited picker.rs · +8 −4                         Inspect
+  • Running focused checks (12s)
+
+┋ Queued next · Also check CJK model names.
+
+┋ Next turn
+┋ Continue typing…
+
+Codex · route coding-default · working 12s · USD 0.0800 router
+Ctrl-P Commands · Ctrl-O Details
+```
+
+Presentation rules:
+
+- Use typography, indentation, weight, and semantic glyphs before borders.
+- Submitted user messages and the idle composer use a strong `┃` rail.
+- The working composer and queued next-turn previews use a dim/dotted `┋` rail;
+  the editable composer also carries a visible **Next turn** label.
+- Tool/activity rows use stable meanings such as `● Read`, `● Ran`, `● Edited`,
+  `■ Cancelled`, and `✓ Recovered`.
+- Do not say **Thinking** unless the agent reports that semantic state. When the
+  client knows only that a turn is active, say **Working**.
+- Ordinary assistant text has no card or bubble.
+- Ordinary notices have no titled box. Use a border only when it expresses a
+  real boundary, such as the start of a temporary picker.
+- Keep the palette and pickers inline below the composer, with `›` for the
+  selected row and aligned annotations where width permits.
+- Use a mostly neutral palette. Reserve semantic color for diffs, destructive or
+  dangerous states, errors, and active selection. Every meaning also has a text
+  or glyph distinction.
+- Put the short workspace folder in the terminal title or welcome line, not the
+  permanent status. Do not permanently show full paths, branch, daemon PID,
+  listener, session ID, provider catalog, or configuration inventory.
+
+Startup welcome is at most two lines and disappears into scrollback. An empty
+conversation is the home surface; there is no separate Home screen.
+
+## 6. Navigation and discovery without tabs
+
+`Ctrl-P` opens the searchable full action inventory. Typing `/` at the beginning
+of a draft opens the slash-capable subset plus agent commands and prompt
+templates. Directly typed commands use the same resolver and precedence as
+their palette counterparts. A palette-only action need not have a slash spelling.
+
+Rows identify their owner:
+
+- **BitRouter** for typed local/remote actions;
+- **Agent** for commands advertised by the active ACP session;
+- **Prompt template** for local user-authored expansion.
+
+Local BitRouter commands shadow same-named agent commands, and discovery must
+make that ownership visible rather than silently selecting one.
+
+The merged palette is the naming baseline. A label is not automatically a slash
+command, and this spec does not authorize new aliases:
+
+| Capability | Current palette label | Current slash entry | Target surface |
 | --- | --- | --- | --- |
-| Picker/inspector | Close and restore | Close and restore | No session exit through a modal |
-| Working composer | Request cancellation | Request cancellation | No action; show exit guidance |
-| Cancelling | Leave cancellation running | Leave cancellation running | No action |
-| Ready composer with draft | Clear completion/selection only | Clear draft | Preserve draft; explain empty-draft exit |
-| Ready empty composer | No action | Exit | Exit |
-| Focused permission | Dismiss using the explicit reject/cancel rule in §9 | Cancel the turn | No approval or session exit |
+| Home | None; the empty conversation is home | None | Persistent conversation |
+| Agent selection | **Choose agent** | None | Docked searchable picker |
+| Native sessions | **Open session** | None | Docked capability-led picker |
+| Agent configuration | **Agent settings** | Agent-advertised commands only | Docked setting picker |
+| Routable catalog | **Routable models** | `/models` | Detached catalog inspector |
+| Host requests | **Host requests** | None | Detached bounded inspector |
+| Session route | Agent/session route control | `/route`, `/route reset` | Docked session-route picker/action |
+| Route preview | **Route preview** | `/preview` | Docked model selector, then detached detail |
+| Providers | **Providers** | None | Detached read-only inspector |
+| Telemetry | **Telemetry** | None | Detached read-only inspector |
+| Policy | **Policy status**, **Policy detail** | None | Detached inspector; named detail starts with a docked selector |
+| Agent catalog | **Agent catalog** | None | Detached read-only inspector |
+| Reload | **Reload state**, **Reload now** | None | Detached state/receipt; mutation starts with docked confirmation |
 
-Process INT/TERM/HUP and input closure still use the shared teardown path.
-Ctrl-L redraws without clearing the conversation or draft. Hints are contextual;
-no key both selects an option and types into the draft, or both closes a modal
-and exits. Tab never cycles global pages.
+Any future `/agent`, `/session`, `/requests`, `/providers`, `/telemetry`,
+`/policy`, or `/reload` alias is a separate public command-inventory decision.
+It must define precedence, update the shared inventory and shipped skill, and
+receive its own compatibility review. `/preview` remains distinct because
+`/route` already owns session-route selection.
 
-## 8. Transcript and inspection
+Closing a palette or picker restores its exact query only when returning from a
+recoverable failure that originated there. Ordinary dismissal restores the
+conversation draft, cursor, and prior application focus. It makes no claim
+about the terminal's native scrollback offset.
 
-Keep the retained journal as the authoritative in-memory projection of ACP
-events. Presentation groups may combine adjacent completed reads/searches but
-must retain their underlying IDs, order, status, and content for inspection.
-Do not merge across user/agent messages or hide a failed/pending tool in a
-completed group. Unknown tool kinds keep a generic visible representation.
+Agent model setting, session route override, routable catalog, and latest
+observed upstream are different facts. The UI must not collapse them into one
+generic **Model** field or imply that changing one changed the others.
 
-Use restrained Markdown rendering for agent messages: paragraphs, lists,
-headings, fenced code, and links. Preserve exact code text when copying. Treat
-terminal control sequences in output as content to sanitize, never commands to
-the terminal. Do not infer structured plans from arbitrary prose.
+## 7. Composer and next-turn queue
 
-Completed routine tools default to a compact summary; failed tools expose a
-bounded useful diagnostic immediately. Full tool output and ACP-provided diffs
-open in an inspector. A truncation indicator must offer a path to the retained
-content; if the upstream itself truncated it, state that the remainder was not
-received. Do not fetch or execute a command to reconstruct missing output.
+### 7.1 Editing contract
 
-Transcript inspection supports search and copying a selected message/tool
-output, with a terminal-appropriate fallback if clipboard integration is
-unavailable. File locations and structured diffs use ACP data when supplied;
-they must not claim to be a complete working-tree Git diff. Terminal-reference
-content remains a labelled reference unless terminal tooling is negotiated and
-implemented; this spec does not turn it on.
+The composer preserves PR #900's editor behavior:
 
-Scrolling away from the live tail enters **reading history**. Incoming events
-update the journal and a new-activity indicator, never reset the scroll anchor.
-An explicit **Return to live** action resumes following. Anchor by retained
-entry and intra-entry offset so wrapping, resize, and tool expansion do not
-arbitrarily change the reading position. A user submission can explicitly
-return the view to live. A permission arriving during inspection raises an
-attention indicator; it does not silently discard the inspection position.
+- grapheme-safe left/right and word movement;
+- Home/End and deletion;
+- multiline editing;
+- process-local prompt history at logical first/last lines;
+- bracketed paste with exact line breaks and no implicit submit;
+- `Shift-Enter` or `Alt-Enter` for newline where supported, with `Ctrl-J` as the
+  documented fallback;
+- deliberate `$VISUAL`/`$EDITOR` handoff at safe idle points;
+- draft and cursor preservation across picker, inspector, failure, resize,
+  suspend/resume, and reconnect preparation.
 
-## 9. Permissions and cancellation
+### 7.2 Enter semantics by state
 
-Render the agent's actual option labels and preserve their exact IDs. Show the
-tool title, kind, and available structured command/diff/location context; retain
-a generic fallback for absent fields. No locally invented **Always allow** or
-permission option may be sent to the agent. Do not interpret ToolKind alone as
-proof that an operation is safe or enforceable by an OS sandbox.
+| State | Composer label | Enter | Escape |
+| --- | --- | --- | --- |
+| No agent selected | **Message** | Open agent picker; retain draft for explicit later submission | Close the picker if open; otherwise leave the draft unchanged |
+| Idle, connected | **Message** | Submit one turn and clear the submitted draft | Close the focused transient surface; otherwise leave the draft unchanged |
+| Submitting | **Next turn** | Move the exact draft to pending follow-ups; queue it only after the original turn is accepted | Request cancellation through the explicit interrupt path; preserve the next-turn draft and pending follow-ups |
+| Working | **Next turn** | Append the exact draft to the FIFO queue and clear the composer | Interrupt the active turn; preserve but do not queue the draft |
+| Cancelling | **Next turn — waiting for stop** | Do not dispatch; retain the draft and explain that cancellation is settling | No second cancellation side effect |
+| Queue paused, connected | **Next turn — queue paused** | Append the exact draft to the end of the paused queue; do not send it | Leave the draft unchanged |
+| Permission/question focused | No composer ownership | Confirm only an explicitly selected option | Deny/cancel according to the protocol-specific contract |
+| Disconnected/failed | **Message — disconnected** | Retain the draft and open recovery choices; never pretend it was submitted | Close recovery surface without losing draft |
 
-Permission requests are queued by identity and resolved exactly once. A second
-request cannot overwrite the visible request. Show pending count where useful.
-Preserve the user's draft throughout the interaction. Newly arrived permission
-UI must not consume buffered composer keystrokes as consent: require explicit
-focus/selection after presentation, with no preselected approval. Numeric keys
-may highlight an option but must not immediately authorize it; Enter confirms
-an explicitly selected option. F2 focuses the oldest pending permission, with
-the same action available in the palette. Show that shortcut in the activity
-hint; it works while reading history or editing a draft and is inert when no
-permission is pending.
+Enter always means “submit the currently labelled composer.” At idle its target
+is the active agent turn. While work is active its target is the visible
+**Next turn** FIFO. This consistency replaces PR #900's `Tab`-to-queue shortcut.
 
-Dismissal while leaving the turn running chooses an offered reject-once option
-when available; it must not silently grant persistent rejection when both
-reject-once and reject-always exist. Otherwise use the protocol's cancelled
-outcome rather than inventing an option. Turn cancellation is separate: resolve
-all pending permissions with `RequestPermissionOutcome::Cancelled`.
+The working composer must not use copy such as **Steer**, **Update current
+turn**, or **Send now**. A future ACP steering capability may introduce a
+separate negotiated action; it must not silently change this queue contract.
 
-On user cancellation:
+### 7.3 Queue behavior
 
-1. Enter **Cancelling** and prevent another prompt or session replacement.
-2. Settle pending permission requests with the cancelled outcome and send
-   `session/cancel` once. Newly arriving permissions for that turn also cancel.
-3. Continue consuming final tool/message updates and observe the original
-   prompt response. Do not drop the future and immediately report ready.
-4. Report the actual result. A completion racing cancellation is not rewritten
-   as successful cancellation; partial effects are not described as rolled back.
-5. If the agent fails to settle within the shared bounded cancellation grace,
-   show failure/disconnected state and use controlled teardown. Do not reuse an
-   uncertain connection or automatically submit queued work.
+- Prompt text has separate ownership buckets: the prompt awaiting submission
+  acceptance, the active in-flight prompt, pending follow-ups entered during
+  submission, queued items, the one queue item being dispatched, recovery
+  drafts, and the currently editable composer draft. Moving text between these
+  buckets is explicit; no transition clears or overwrites a different bucket.
+- Queue items contain exact prompt text and visible origin where relevant.
+- Submitting an idle draft `P0` moves it out of the editor into the submission
+  slot. The user may type `P1`; Enter moves `P1` to pending follow-ups and leaves
+  the editor available for `P2`.
+- If `P0` is accepted, it becomes the in-flight prompt and pending follow-ups
+  enter the FIFO in order. Any unsubmitted `P2` remains in the editor.
+- If `P0` is rejected, `P0` and every pending follow-up move, in order, to an
+  explicit **Recover drafts** surface. The current editor draft remains intact.
+  Nothing is retried, merged, or silently promoted. Restoring one recovery item
+  to the editor requires an explicit choice and cannot overwrite a non-empty
+  editor.
+- Show at most the first two queued previews in the dock; indicate the remaining
+  count and offer an explicit queue editor.
+- The queue editor can inspect, edit, remove, or reorder only through explicit
+  focused actions. Closing it changes nothing.
+- Dispatch one item only after the previous turn completes normally and no
+  permission remains unresolved.
+- Automatic dispatch moves the oldest item into a dedicated dispatch slot. It
+  never reads, clears, replaces, or submits the current editor draft. The item
+  leaves the slot only after acceptance; rejection moves it to recovery and
+  pauses the remaining queue.
+- Cancellation, abnormal stop, submission failure, disconnect, session
+  replacement, or unavailable agent command changes the queue to
+  `Paused(reason)`. Resolving a permission merely unblocks the active turn; it
+  does not pause, resume, or reorder the queue.
+- A paused queue never resumes because time passed, a connection reappeared, a
+  permission resolved, or the user submitted another draft. **Resume queue** is
+  an explicit action and is enabled only for the same connected agent/native
+  session with no unresolved permission or uncertain submission.
+- While paused, Enter appends the labelled **Next turn — queue paused** draft to
+  the end. It cannot overtake older work. To send it first, the user must open
+  the queue editor and explicitly reorder or discard older entries before
+  choosing **Resume queue**.
+- Never replay an uncertain submission after reconnect.
+- Never transfer queued work to a different agent or native session. Changing
+  either requires dispatching, moving items to recovery, or discarding them.
+- BitRouter administration actions cannot be queued as agent prompts.
+- A queued item that resolves to an agent command is revalidated against the
+  currently advertised command inventory immediately before dispatch.
 
-Reuse the existing client timeout/grace machinery rather than introduce a
-second timer policy in a renderer. Journal tool presentation may show a local
-cancellation annotation while preserving the actual protocol status. This is
-not a new wire enum. Terminal restoration and permission cleanup must also hold
-on input closure, shutdown signals, adapter failure, and UI error.
+## 8. Status and provenance
 
-## 10. ACP-led settings, sessions, and routing
+The default session status contains four facts, in priority order:
 
-Build **Agent settings** from initial session configuration/mode data and later
-updates. Apply supported changes through the appropriate standard session
-method; update displayed values only from confirmed results. Use configuration
-categories for placement, not correctness. Missing/unknown categories fall
-back to the agent's labels/order; unknown option types are not actionable.
-No native-agent name grants a capability. The first UI offers settings changes
-at idle even where an agent could accept them during generation.
-
-At the source baseline, the client has new/load/resume methods and a wider
-capability snapshot. A snapshot flag alone is not an implemented client operation. Native
-session listing/config setters needed by a picker require typed client support
-and protocol tests before exposure. Do not add fork/delete or enable unrelated
-unstable schema features to complete this UI. A load-only agent gets native-ID
-entry; a list-capable agent gets pagination/search over its native results.
-
-Load replays native history. Resume continues without replay and must say
-**Earlier history was not replayed** rather than draw an apparently fresh
-conversation. Subscribe/buffer updates before opening so replay is not lost.
-Seed the view from initial session metadata as well as streamed changes. IDs
-and transcript storage remain harness-owned; the renderer stores only the
-current process's projection and drafts.
-
-Session routing uses the existing `_bitrouter/route/*` extension only when its
-version, session scope, and required methods are advertised. Route selection
-and reset are idle-only; confirmed failures leave the old route displayed. Reset
-means drop this session's override, not reset agent settings or daemon config.
-
-The routable-model catalog and route preview use the existing shared report
-ports. Preview is declared/configured resolution, not a promise to reproduce
-all prompt-dependent routing, capability filtering, hooks, or fallbacks. A
-request inspector labels actual observations separately. If only host-wide
-request history is available, label it **Host requests**; do not infer a session
-filter from timing or model names. Session-specific inspection requires proven
-identity correlation in the underlying report.
-
-## 11. Implementation boundaries
-
-| Owner | Responsibility |
+| Field | Source and wording |
 | --- | --- |
-| `crates/bitrouter-tui` | Composer, focus/modal state, permission/queue data, retained journal, presentation, scrolling, and pure interaction transitions |
-| `apps/bitrouter/src/chat` and canonical Code driver | Input and async event orchestration; render effects, never own daemon configuration/storage |
-| `apps/bitrouter/src/actions` | Injected typed operational ports and reports for local/remote scope |
-| `apps/bitrouter/src/acp_cli.rs` | Agent resolution, preparation, authentication boundary, session host, lifecycle capability snapshot |
-| `crates/bitrouter-sdk/src/acp/client.rs` | Typed ACP methods, permission outcomes, cancellation, and protocol lifecycle |
+| Agent | Resolved agent identity and lifecycle; catalog availability is not connection. |
+| Route | Confirmed session override or known default; distinguish no override, direct, and unreported. |
+| Activity | Client-observed lifecycle or reported tool label; no invented percentage or thinking state. |
+| Session cost | Cumulative ACP session cost with router-attributed, agent-reported, unknown, or unreported provenance. |
 
-Use one interaction core and one permission/turn lifecycle for every
-BitRouter-owned interactive conversation path. Retained hidden compatibility
-entries must delegate to it; no independent dashboard-versus-inline command or
-approval semantics remain. A presentation wrapper may differ for terminal/pipe
-output. Keep the existing noninteractive output contract and protocol-pure ACP
-stdout intact. Pure UI queueing and focus do not leak into headless execution.
+Permission-needed, failure, disconnect, and cancellation outrank ordinary
+activity. Context used/size appears in details when the agent reports a usable
+pair; it is not a fifth always-visible field.
 
-Preserve the dependency direction: the TUI crate cannot access app config,
-HTTP, IPC, or metering, and the app does not acquire a ratatui dependency.
-Reuse the existing searchable selection state where practical, without keeping
-duplicate digit-selection semantics. Remove the seven-page enum, page-cycling
-handlers, and unused renderers once their capabilities have replacements.
+Do not equate:
 
-All long effects (connection, reports, settings, session opening) must leave
-input, cancellation, and ACP updates responsive. Bound render work through a
-schedule and dirty state; do not redraw an entire retained history for every
-stream chunk or keep an idle animation timer alive. Optimize from measured
-terminal behavior, not an invented frame-rate target.
+- agent model setting with session route;
+- requested route with actual upstream;
+- host-wide spend with session cost;
+- absence of cost with zero;
+- a cached catalog row with a connected process.
 
-## 12. Delivery sequence and acceptance
+At narrow widths preserve state meaning and provenance before optional names,
+elapsed time, hints, or branding. The status may wrap to two lines at 80×24 and
+below; it must not crowd out a permission choice or one usable composer row.
 
-These are implementation slices of the authorized release.
+## 9. Permission, questions, and interruption
 
-1. **Unify behavior:** consolidate interaction and permission lifecycle, add
-   cancellation completion handling, and preserve canonical/headless boundaries.
-2. **Replace navigation:** conversation entry, command palette, four-field
-   status, transient inspectors, and local/remote operational parity. Remove
-   permanent tabs and page cycling.
-3. **Complete composition:** multiline editing, preserved paste, cursor/history,
-   external editor, and explicit next-turn queue.
-4. **Complete inspection:** stable history reading, searchable full output,
-   structured diff inspection, settings and supported session pickers.
-5. **Validate and document:** real-terminal journeys, minimal-capability agents,
-   supported adapter smoke tests, and source-of-truth documentation updates.
+Permission requests are queued by stable identity and resolved exactly once.
+Arrival raises a prominent **Permission needed · F2 to review** notice but does
+not steal composer, palette, picker, or inspector input ownership. `F2` is the
+only ordinary transition into permission focus. The transition consumes that
+keypress, does not replay buffered input from the prior surface, and clears any
+previous option highlight. The oldest unresolved request then owns the dock. No
+option starts selected; Enter without a post-focus explicit selection has no
+side effect.
 
-| ID | Required observable result |
+While a permission is pending, ordinary report and catalog inspectors cannot be
+opened. The only allowed detached transition is the permission's own structured
+context inspector, which closes back to the same unresolved request.
+
+A pending permission outranks ordinary status, but draft bytes remain intact
+and editing may continue until the user presses `F2`. If a permission arrives
+while a detached inspector is open, the inspector shows a bounded **Permission
+needed · F2 to review** indicator. `F2` closes the inspector and explicitly
+focuses the oldest request. Closing the inspector normally only returns to the
+normal surface and repeats the notice; it never grants permission input
+ownership. The alternate inspector never renders mutation controls over report
+content.
+
+Cancellation and permission rejection remain different outcomes:
+
+- Escape during working requests turn cancellation.
+- Cancelling a turn does not approve, reject, or discard a pending permission
+  unless the ACP teardown contract requires an explicit cancellation response.
+- Closing a permission surface uses the protocol-defined cancellation/deny
+  outcome, not the generic turn-cancel path.
+- Late ACP updates are consumed until the original prompt settles or a bounded
+  failure proves it cannot settle.
+- Queued next-turn work stays paused after abnormal termination.
+
+## 10. Local and remote operations
+
+The implementation preserves #901's typed reports, authorization, target
+resolution, refresh provenance, retained reload receipts, and no-local-fallback
+rules. It removes their permanent dashboard pages.
+
+For a local ACP session, router operations appear in the command palette. Short
+results may add one BitRouter-labelled transcript event; large results open a
+detached inspector. A mutation such as reload requires a docked confirmation
+that states target, authority, and effect before the action starts.
+
+For a named remote context, remote ACP remains unavailable. The root interactive
+surface is therefore **Remote operations**, not a fake conversation:
+
+```text
+𝒃 bitrouter · production
+
+Remote operations · reports read-only · reload explicit
+Last refresh 12s ago · connected
+
+No coding agent is attached to this context.
+
+Ctrl-P Commands · Ctrl-O Status details · Ctrl-C Exit
+```
+
+This root stays on the normal buffer and has no enabled coding composer. Its
+palette exposes only capability-confirmed remote actions. Read actions open
+temporary inspectors. Reload appears only with explicit `control:reload`
+authority and follows the same confirmation and retained-receipt contract as
+the CLI. Remote failures never fall back to local files, sockets, config,
+metering, or agent catalogs.
+
+## 11. State and rendering boundary
+
+The pure interaction state from PR #900 remains the behavioral owner. The exact
+Rust shape may change, but the concepts remain separate:
+
+```rust
+struct CodeState {
+    journal: Journal,
+    editor: Editor,
+    turn: TurnState,
+    dock: DockSurface,
+    submission: Option<PendingSubmission>,
+    queue: QueueState,
+    recovery: VecDeque<RecoveryDraft>,
+    permissions: VecDeque<PendingPermission>,
+    permission_focus: Option<PermissionId>,
+    status: CodeStatus,
+}
+
+struct QueueState {
+    items: VecDeque<QueuedPrompt>,
+    dispatching: Option<QueuedPrompt>,
+    state: RunningOrPaused,
+}
+
+enum DockSurface {
+    Composer,
+    Palette(ChoiceList),
+    Selector(ChoiceList),
+    Permission,
+    QueueEditor,
+}
+
+enum DetachedSurface {
+    FullTranscript,
+    ToolDetail(ToolCallId),
+    Report(Inspector),
+}
+
+struct PrimaryRenderState {
+    committed: NormalBufferCommitCursor,
+    live_tail: LiveTailCache,
+}
+
+struct DetachedViewState {
+    opened_at: JournalRevision,
+    normal_commit_at_open: NormalBufferCommitCursor,
+    search_and_navigation: DetachedNavigation,
+}
+```
+
+This is a contract sketch, not permission to introduce unused abstractions.
+Detached viewer state may live beside the renderer if it contains only paging,
+search, and terminal presentation state. Product state, action authority, ACP
+effects, and reports remain outside the renderer.
+
+`NormalBufferCommitCursor` is application bookkeeping, not a terminal viewport
+or scroll offset. Queue dispatch must use its dedicated prompt slot; current
+main's editor-clearing `begin_prompt()` behavior cannot be reused for automatic
+dispatch unless it is split so an unrelated editor draft is preserved.
+
+The reducer is synchronous and emits plain effects. The application owns ACP
+I/O, target resolution, report fetching, controller lifecycle, clipboard,
+external editor, and async work. The renderer owns terminal modes, layout,
+painting, and cursor placement. Neither renderer may read router config, HTTP,
+IPC, metering storage, or credentials directly.
+
+## 12. Integration with current source
+
+The implementation follows merged main's existing ownership boundaries:
+
+| Source | Keep | Replace or remove |
+| --- | --- | --- |
+| `crates/bitrouter-tui/src/writer.rs` | Differential normal-buffer writer, live-tail cache, terminal restoration, existing variable-height `docked_frame()` | Assumption that the entire Code document is an application viewport |
+| `crates/bitrouter-tui/src/code.rs` | `CodeState`, editor, dock surfaces, retained journal, selectors, permission identities, queue editor | Startup alternate-screen ownership, primary `ReadingAnchor`, Tab-to-queue semantics |
+| `apps/bitrouter/src/chat/code.rs` and wire | Reducer/effect boundary, ACP update consumption, lifecycle, cancellation, capability negotiation | Editor-clearing automatic queue dispatch; implicit focus changes during detached restoration |
+| `apps/bitrouter/src/actions/code.rs` and administration target | Typed local/remote reports, authorization, target isolation, reload scope and receipts | Hand-authored presentation assumptions; action behavior remains unchanged |
+| thin `apps/bitrouter/src/dashboard.rs` entry | Argument/target assembly into the shared Code loop | Nothing; the old page driver and `crates/bitrouter-tui/src/dashboard.rs` are already gone |
+| shared action inventories plus merged palette labels | Existing command IDs, slash names, reports, requirements, ownership and availability | Invented aliases or a second palette registry |
+
+No CLI flag, command, default, harness wiring, or plugin invocation changes are
+authorized by this spec alone. If implementation changes those public surfaces,
+update `skills/bitrouter/` and the agent-plugin manifests in the same change.
+
+## 13. Responsive, input, and accessibility contract
+
+- At 80×24, a submitted user turn, one active-status row, one composer row, and
+  essential hints remain readable without clipping.
+- At 40×16, preserve one usable composer row, the full meaning of a permission
+  choice, and status provenance before optional labels.
+- For terminals at least 40×16, the dock content budget is
+  `clamp(floor(rows × 0.4), 5, 12)` rows, excluding the compact status/hint row.
+  Composer and choice lists scroll inside that budget. Read-only content whose
+  wrapped body exceeds the budget opens detached; full transcript, tool/diff
+  detail, request history, policy detail, and reload receipts are always
+  detached even when currently short.
+- Below 40×16, show a minimal resize surface while retaining journal, draft,
+  queue, permission, and selection state. Resize cannot approve or submit. If a
+  permission is pending, its identity plus **F2 Review · Esc Deny · Ctrl-C
+  Cancel turn** remain available; approval is disabled until the offered choice
+  can be rendered completely.
+- All clipping and wrapping use display width and grapheme boundaries, not byte
+  or scalar counts.
+- Sanitize terminal control bytes from agent, tool, report, file, provider,
+  model, branch, and error text before measuring or painting.
+- Bracketed paste never submits. Newline key fallbacks remain visible at widths
+  where the primary shortcut cannot be represented reliably.
+- Light and dark terminal backgrounds receive readable contrast. Color is never
+  the only indication of owner, status, permission, diff direction, or error.
+- The physical terminal cursor remains at the actual composer position.
+- Primary operation is keyboard-only. Mouse support is outside this release.
+- The supported contract is a VT-compatible terminal with normal/alternate
+  buffers, cursor save/restore, raw input, and bracketed paste. Automated PTY
+  tests use the repository's VT parser; release smoke tests cover macOS Terminal,
+  iTerm2, and WezTerm. Scroll-on-output preferences may differ, so tests assert
+  no clear/replay/forced jump rather than claiming control of terminal history.
+
+## 14. Acceptance criteria
+
+| ID | Required evidence |
 | --- | --- |
-| A1 | Bare local `code` offers agent selection within an empty conversation; explicit agent invocation reaches conversation; neither draws seven tabs |
-| A2 | Every dismissed picker/inspector restores draft, cursor, focus, and reading anchor; active ACP updates are still consumed |
-| A3 | Agent, confirmed route, activity, and attributed session cost remain readable at 80×24 and 40×16; unknown cost never becomes zero |
-| A4 | Cursor editing, multiline Unicode/CJK/grapheme input, paste, history, and external editor preserve intended prompt bytes and terminal state |
-| A5 | Drafting during a turn loses no input; Tab queues explicitly; Enter never claims unsupported steering; queued work runs serially and pauses on abnormal stops |
-| A6 | Reads during streaming stay anchored; return-to-live is explicit; resize and expanded output preserve location |
-| A7 | Two overlapping permissions retain identities and labels; only explicit post-presentation selection authorizes; dismissal, turn cancellation, and teardown have distinct correct outcomes |
-| A8 | Cancellation accepts late updates, observes settlement or bounded failure, prevents overlapping prompts, and never replays uncertain work |
-| A9 | Local/agent command collisions are visible and both owners are reachable; legacy typed precedence and prompt-template behavior remain deterministic |
-| A10 | A minimal ACP agent with no commands, usage, route control, or optional lifecycle/settings still supports an ordinary conversation and honest unavailable states |
-| A11 | Agent settings and route changes display confirmed results; failed mutations retain previous values; load/resume semantics and native IDs remain distinct |
-| A12 | Remote code retains supported read-only operations without agent execution, route mutation, or local-data fallback; scope is visible |
-| A13 | Tool summaries preserve full received output and structured diffs; unknown kinds remain inspectable; no agent text is mistaken for BitRouter evidence |
-| A14 | Canonical and retained compatibility paths share command/permission behavior; stdout contracts and terminal restoration survive exit, editor handoff, signals, and adapter failure |
+| A1 | Starting `bitrouter code` leaves the terminal on the normal buffer and preserves native scrollback. |
+| A2 | The ordinary Code UI contains no global `Page` navigation, tabs, sidebar, or Home screen. |
+| A3 | Submitted user, assistant, tool, diff, and completion entries remain correctly ordered in the retained journal; the owned live tail is patchable, while immutable native history is never falsely rewritten or duplicated. |
+| A4 | Opening and dismissing palette, picker, permission, and queue surfaces restores exact draft bytes, grapheme cursor, and application focus; no test claims control of the terminal's native scroll offset. |
+| A5 | Dock height changes do not commit picker/permission rows to scrollback or replay the transcript. |
+| A6 | Ctrl-P exposes the authoritative full action inventory; leading `/` exposes its slash-capable subset plus live agent commands and prompt templates. Shared actions have identical ownership, availability, resolver precedence, and naming, with no fabricated aliases. |
+| A7 | At idle, Enter submits exactly one prompt. During submission/work, a visible **Next turn** composer makes Enter retain exactly one pending/FIFO follow-up without overwriting a newer editor draft. |
+| A8 | No queue path or copy claims mid-turn steering; automatic dispatch waits for normal completion, never clears the editor, and abnormal outcomes enter `Paused(reason)` until explicit **Resume queue**. |
+| A9 | Queue edit/remove/reorder/resume is explicit, preserves exact prompt text, prevents new drafts overtaking paused work, and cannot transfer items to another agent/session. |
+| A10 | Agent model setting, route override, routable catalog, and observed upstream remain separately labelled. |
+| A11 | Agent, route, activity, and cost render with honest unknown/unreported/provenance states and responsive priority. |
+| A12 | Permission arrival never steals input. F2 explicitly focuses the oldest request with no selected option; only subsequent selection plus Enter confirms, and overlapping requests are retained and resolved once. |
+| A13 | Full transcript and large reports enter the alternate screen only after explicit user action and remain read-only. |
+| A14 | ACP updates, permissions, action results, metering, and resize events continue to update authoritative state while an inspector is open; normal-buffer painting stays suspended. |
+| A15 | Closing after more than three screens of background output commits only new persistent entries, in order and exactly once; late updates to immutable old entries appear in retained detail without replay. |
+| A16 | The session and detached inspector restore only the terminal modes they own; SIGINT, SIGTERM, panic, ordinary exit, resize, SIGTSTP/SIGCONT, and external-editor failure are idempotently covered. |
+| A17 | Local and remote operational commands use #901's typed action ports, authorization, redaction, target isolation, and retained receipts. |
+| A18 | Remote operations show no coding composer and never fall back to local state or imply remote ACP. |
+| A19 | Real-PTY journeys cover 80×24, 40×16, below-minimum safe permission exit, CJK/emoji, exact multiline paste, queueing, permission during inspector, cancellation, disconnect, resize while detached, and alternate-screen restoration. |
+| A20 | Headless text/JSON/quiet behavior and existing ACP/controller safety tests remain unchanged. |
+| A21 | A `P0` submission with pending `P1` and editable `P2` preserves all three exactly on both acceptance and rejection; rejection exposes ordered recovery without implicit retry. |
+| A22 | Automatic dispatch of queued `P1` while editable `P2` exists leaves `P2` byte-for-byte unchanged; dispatch rejection pauses the queue and preserves the item for recovery. |
+| A23 | Buffered arrows, digits, or Enter from a composer/inspector cannot authorize a newly arrived permission; ordinary inspector close returns to a notice, while F2 performs the explicit focus transfer. |
 
-Use reducer and renderer tests for transitions/layout, protocol stubs for ACP
-ordering/capability behavior, and real-PTY journeys for the integrated loop.
-Fixtures must cover normal end, refusal/limit stop, delayed cancellation,
-duplicate/overlapping permissions, load replay, missing usage, unknown metadata,
-and absent optional capabilities. Use bounded condition waits and deterministic
-semantic assertions; arbitrary sleeps and AI-approved screenshot changes are
-not acceptance oracles. Tests use isolated directories and no live credentials.
+## 15. Delivery sequence
 
-Real-PTY checks include `stty` restoration and a usable shell after exit. A
-visual review checks compact/wide layouts and long streaming output, but does
-not replace protocol/behavior assertions. Native adapter smoke checks record
-adapter versions and actually advertised capabilities; do not derive an
-adapter feature matrix from the native CLI documentation alone.
+1. **Make the primary renderer normal-buffer-native:** retain the merged reducer
+   and `docked_frame()`, remove startup alternate-screen ownership, and give the
+   writer an explicit normal-buffer commit cursor/live-tail boundary.
+2. **Define detached catch-up:** suspend normal-buffer painting while detached,
+   record journal/commit revisions, then implement ordered exactly-once backlog
+   commit and late-update behavior across resize and restoration.
+3. **Implement the complete Next turn state machine:** replace Tab queueing,
+   separate submission/in-flight/editor/pending/queue/dispatch/recovery text,
+   add `Paused(reason)` and explicit **Resume queue**, and preserve ordering.
+4. **Split terminal custody:** keep raw/input modes session-owned and make the
+   inspector own only alternate-buffer/cursor presentation. Add idempotent
+   SIGTSTP/SIGCONT, signal, panic, and external-editor transitions.
+5. **Hold the permission focus boundary:** retain notice-only arrival, F2-only
+   focus transfer, empty initial selection, and no buffered-key replay across
+   normal/detached surfaces.
+6. **Finish inspector and visual grammar:** make Ctrl-O open the full transcript
+   with stable detail navigation; apply rails, semantic activity markers,
+   neutral hierarchy, compact status, dock limits, and width-degrading hints.
+7. **Validate end to end:** add the P0/P1/P2, paused-ordering, multi-screen
+   detached backlog, immutable late-update, resize, permission-key isolation,
+   and terminal-custody tests before all-feature and real-PTY validation.
 
-Before source submission run the required all-features tests, clippy, and fmt
-checks from [`AGENTS.md`](../AGENTS.md), plus relevant ACP/CLI output and
-dependency-boundary guards. The original documentation proposal needed link and diff validation;
-the implementation must pass the full source gates above.
+The no-tabs information architecture and typed #901 operations are baseline,
+not delivery work. Each step must leave one terminal owner and one interaction
+reducer. Do not keep full-screen and scrollback Code implementations as
+selectable modes merely to reduce migration difficulty.
 
-## 13. Documentation and compatibility work when implemented
+## 16. Rejected alternatives and the case against this design
 
-Update [`CLI.md`](CLI.md), [`DEVELOPMENT.md`](DEVELOPMENT.md), affected design
-spec status notes, and [`skills/bitrouter/`](../skills/bitrouter/SKILL.md) in
-lockstep with the changed entry behavior, keys, and session wiring. Keep the
-shippable skill under its documented size limit and use references for detail.
-Check `.claude-plugin/`, `.codex-plugin/`, and `.agents/plugins/marketplace.json`
-only for affected invocation changes; this spec does not rename `mcp serve`.
+### 16.1 Rejected: full-screen conversation as the primary UI
 
-Public naming (`code`, `run`, native launchers, `acp serve`) stays as-is. Retain
-existing hidden CLI aliases without proliferating more. Document the intentional
-interactive key changes and removal of page navigation. Product-site prose is
-owned by `bitrouter-docs`; do not put contributor-only spec material in the
-shippable skill or hand-maintain generated catalog tables.
+This is the merged main renderer inherited from PR #900. It gives complete
+viewport control and makes overlays straightforward, but discards native
+terminal history, makes a
+conversation feel like an application dashboard, and couples ordinary reading
+to BitRouter's scrolling model. The user selected native scrollback instead.
 
-## 14. Research basis
+### 16.2 Rejected: retain dashboard tabs and improve their styling
 
-Official documentation checked on 2026-09-08. These sources motivate the
-interaction design; they do not promise the same functionality through ACP.
+Tabs preserve discoverability, especially for remote administration, but encode
+the wrong information architecture. Conversation, selecting an agent, and
+reading policy are not equal-duration destinations. Eleven permanent tabs also
+consume scarce width and force session-scoped and daemon-wide concepts into one
+navigation layer.
 
-- [Codex CLI commands](https://learn.chatgpt.com/docs/developer-commands?surface=cli):
-  model/session pickers, slash discovery, configurable status fields, and
-  distinct queued versus steering input. Adopt the focused interaction pattern;
-  do not copy native steering semantics into a generic ACP prompt loop.
-- [Claude Code commands](https://code.claude.com/docs/en/commands) and
-  [interactive mode](https://code.claude.com/docs/en/interactive-mode): controls
-  are invoked within a session; transcript inspection preserves editing state.
-- [Claude Code fullscreen rendering](https://code.claude.com/docs/en/fullscreen):
-  alternate-screen rendering is compatible with a conversation-led product.
-- [OpenCode TUI](https://opencode.ai/docs/tui/) and
-  [keybindings](https://opencode.ai/docs/keybinds/): command discovery, transient
-  selection, detail inspection, and optional sidebar access. The optional
-  sidebar is not a requirement for BitRouter's first version.
-- [ACP prompt lifecycle](https://agentclientprotocol.com/protocol/v1/prompt-turn)
-  and [tool calls](https://agentclientprotocol.com/protocol/v1/tool-calls):
-  update ordering, permission choices, cancellation outcomes, and structured
-  tool evidence.
-- [ACP configuration options](https://agentclientprotocol.com/protocol/v1/session-config-options),
-  [slash commands](https://agentclientprotocol.com/protocol/v1/slash-commands),
-  and [session setup](https://agentclientprotocol.com/protocol/v1/session-setup):
-  dynamic client controls and native lifecycle boundaries.
+### 16.3 Rejected: prohibit alternate screen everywhere
 
-The recommendation is a design inference from these patterns and the source
-audit. This proposal intentionally changes information hierarchy before
-attempting to match every visual or native feature of another coding agent.
+This preserves one terminal mode but leaves no clean home for large searchable
+reports or full retained output. Dumping them into scrollback permanently
+pollutes conversation; forcing an external pager fragments state and restoration.
+An explicitly opened, read-only, temporary alternate-screen viewer keeps the
+primary experience shell-native without denying deep inspection.
+
+### 16.4 Rejected: Tab queues the next turn
+
+It is explicit but conflicts with completion/focus expectations and makes Enter
+mean “submit” only in one lifecycle state. Relabelling the working composer
+**Next turn** lets Enter retain one visible meaning: submit to the named target.
+
+### 16.5 Rejected: imitate fx steering copy over a local queue
+
+The current ACP surface does not advertise true mid-turn steering. A local FIFO
+changes when work runs, not what the active model sees. Calling it steering
+would be a protocol and UX falsehood.
+
+### 16.6 Rejected: emit every inspector into conversation scrollback
+
+This makes details durable but mixes conversation history with repeatedly
+refreshed host-wide state, policy catalogs, and request tables. It also makes
+closing impossible: scrollback cannot retract what has already been emitted.
+
+### 16.7 The case against the selected design
+
+The selected design is harder to implement than retaining the current merged
+full-screen renderer:
+
+- a variable-height dock over native scrollback needs precise live-region and
+  cursor ownership;
+- background updates during an alternate-screen inspector require an
+  authoritative journal, a normal-buffer commit cursor, and reliable
+  exactly-once restoration;
+- removing tabs reduces passive discoverability and puts more pressure on the
+  palette, slash completion, welcome copy, and contextual hints;
+- Enter changes destination between **Message** and **Next turn**, so the state
+  label must be unmistakable;
+- a mostly neutral visual system can under-signal risk unless permission,
+  fallback, unpriced cost, partial reload, and disconnection retain explicit
+  textual distinctions;
+- terminal custody, queue text ownership, and permission focus must be explicit
+  across more transitions than the full-screen implementation needs.
+
+These costs are accepted because they concentrate complexity in state and
+rendering correctness while leaving the daily product surface simpler and more
+honest.
+
+## 17. References
+
+- [PR #900: conversation-first Code TUI](https://github.com/bitrouter/bitrouter/pull/900)
+- [PR #901: remote router administration](https://github.com/bitrouter/bitrouter/pull/901)
+- [`TUI_RENDERER_SPEC.md`](TUI_RENDERER_SPEC.md)
+- [`AGENT_INTERFACE_UNIFICATION_SPEC.md`](AGENT_INTERFACE_UNIFICATION_SPEC.md)
+- [`CLI_TUI_PARITY_SPEC.md`](CLI_TUI_PARITY_SPEC.md)
+- [`REMOTE_ADMINISTRATION_SPEC.md`](REMOTE_ADMINISTRATION_SPEC.md)
+- [fx](https://github.com/vercel-labs/fx)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,11 @@ workspace architecture guide, and design specs. It is *not* published anywhere.
   `acp serve` bridge; retires visible `spawn`, keeps sessions harness-owned,
   and reduces MCP CLI to stdio serving plus one diagnostic while direct remote
   MCP moves into the daemon.
+- [`CODE_TUI_UX_SPEC.md`](CODE_TUI_UX_SPEC.md) — **implemented.** Builds on
+  merged #900/#901 with a scrollback-native Code surface: no dashboard tabs,
+  one docked transient footer, explicit Enter-to-queue **Next turn** composition
+  with paused recovery, and temporary alternate-screen inspectors for large
+  read-only detail.
 - [`REMOTE_CONTROL_MVP_SPEC.md`](REMOTE_CONTROL_MVP_SPEC.md) — **implemented.**
   Read-only remote status/models/route/requests and operations inspectors over an
   authenticated, loopback-only HTTP control listener; ACP stays local.


### PR DESCRIPTION
## Summary

- keep the primary Code TUI in the terminal normal buffer so conversation history remains native scrollback
- replace dashboard tabs with temporary alternate-screen inspectors and stable retained-entry navigation
- make working-time input an explicit `Next turn` FIFO queue, including paused recovery, editing, and reordering
- harden permission focus, suspend/resume custody, compact terminals, operations-only mode, and PTY coverage
- mark `CODE_TUI_UX_SPEC.md` implemented and align the internal docs index

## Validation

- `cargo nextest run --all-features` (3279 passed, 12 skipped)
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
