### PR TITLE
feat(config): add provider header policies

### DIFF
--- a/apps/bitrouter/src/cloud/mod.rs
+++ b/apps/bitrouter/src/cloud/mod.rs
@@ -273,6 +273,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/apps/bitrouter/src/continuation.rs
+++ b/apps/bitrouter/src/continuation.rs
@@ -2758,6 +2758,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/apps/bitrouter/src/reload.rs
+++ b/apps/bitrouter/src/reload.rs
@@ -1793,6 +1793,7 @@ policies:
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         };
         let prompt = prompt();
         let ctx = PipelineContext::new(PipelineRequest::new(

--- a/apps/bitrouter/src/workflow_state/response_observer.rs
+++ b/apps/bitrouter/src/workflow_state/response_observer.rs
@@ -2256,6 +2256,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: AuthScheme::XApiKey,
+            headers: Vec::new(),
         }
     }
 }

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -1292,6 +1292,7 @@ async fn e2e_responses_id_encodes_bitrouter_request_id_header() {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: AuthScheme::Bearer,
+            headers: Vec::new(),
         }],
     );
 

--- a/apps/bitrouter/tests/policy_eval_control_plane.rs
+++ b/apps/bitrouter/tests/policy_eval_control_plane.rs
@@ -330,6 +330,7 @@ async fn policy_eval_control_plane_records_observed_action_without_quality_rewar
                 api_key_override: None,
                 api_base_override: None,
                 auth_scheme: AuthScheme::XApiKey,
+                headers: Vec::new(),
             },
             HopOutcome::Generated(&execution),
         )

--- a/crates/bitrouter-guardrails/src/tests.rs
+++ b/crates/bitrouter-guardrails/src/tests.rs
@@ -102,6 +102,7 @@ fn target() -> RoutingTarget {
         api_key_override: None,
         api_base_override: None,
         auth_scheme: Default::default(),
+        headers: Vec::new(),
     }
 }
 

--- a/crates/bitrouter-providers/src/anthropic/mod.rs
+++ b/crates/bitrouter-providers/src/anthropic/mod.rs
@@ -166,6 +166,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/crates/bitrouter-providers/src/antigravity/mod.rs
+++ b/crates/bitrouter-providers/src/antigravity/mod.rs
@@ -415,6 +415,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
             chat_token_limit_field: None,
             chat_supports_store: None,
             chat_supports_stream_options: None,

--- a/crates/bitrouter-providers/src/antigravity/protocol.rs
+++ b/crates/bitrouter-providers/src/antigravity/protocol.rs
@@ -191,6 +191,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
             chat_token_limit_field: None,
             chat_supports_store: None,
             chat_supports_stream_options: None,

--- a/crates/bitrouter-providers/src/claude_code.rs
+++ b/crates/bitrouter-providers/src/claude_code.rs
@@ -640,6 +640,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/crates/bitrouter-providers/src/codex/mod.rs
+++ b/crates/bitrouter-providers/src/codex/mod.rs
@@ -720,6 +720,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/crates/bitrouter-providers/src/copilot/mod.rs
+++ b/crates/bitrouter-providers/src/copilot/mod.rs
@@ -270,6 +270,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/crates/bitrouter-providers/src/hosted/applier.rs
+++ b/crates/bitrouter-providers/src/hosted/applier.rs
@@ -211,6 +211,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/crates/bitrouter-providers/src/supergrok/mod.rs
+++ b/crates/bitrouter-providers/src/supergrok/mod.rs
@@ -318,6 +318,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -18,7 +18,7 @@
 //! # let _ = routing; Ok(()) }
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -27,7 +27,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::error::{BitrouterError, Result};
 use crate::language_model::HttpTimeouts;
 use crate::language_model::routing::SortOrder;
-use crate::language_model::types::{ApiProtocol, ModelCompatibility, ProtocolList};
+use crate::language_model::types::{
+    ApiProtocol, ModelCompatibility, OutboundHeaderRule, ProtocolList,
+};
 
 pub mod pattern;
 pub mod presets;
@@ -1094,6 +1096,11 @@ pub struct ProviderConfig {
     pub api_base: String,
     /// Upstream API key (often a `${VAR}` reference).
     pub api_key: String,
+    /// Additional headers applied to every inference request for this
+    /// provider. A string is shorthand for a static default. The expanded
+    /// form can opt into forwarding the same inbound header, which overrides
+    /// the default for that request.
+    pub headers: BTreeMap<String, ProviderHeaderConfig>,
     /// Glob-prefix `api_protocol` pattern list — each pattern maps to an
     /// ordered set of supported wire protocols (the head is the preferred
     /// default). Precedence: per-model override > longest matching pattern >
@@ -1120,9 +1127,9 @@ pub struct ProviderConfig {
     /// Free-form tags, used by `RoutingPrefs.require_tags` filtering.
     pub tags: Vec<String>,
     /// Inherit defaults from another provider in this config (acceptance F20 /
-    /// v0 `derives`). The named provider's `api_protocol`, `rate_limits`,
-    /// `models`, `tags` and `auto_discover` flow into *this* provider's empty
-    /// fields; explicit fields here win. Resolved by
+    /// v0 `derives`). The named provider's `headers`, `api_protocol`,
+    /// `rate_limits`, `models`, `tags` and `auto_discover` flow into *this*
+    /// provider's empty fields; explicit fields here win. Resolved by
     /// [`resolve_derivations`] after the config is parsed.
     pub derives: Option<String>,
     /// Multiple credentials for this one provider — e.g. two
@@ -1148,6 +1155,46 @@ pub struct ProviderConfig {
     /// resolved global [`UpstreamConfig::timeouts`]; unset fields inherit it.
     /// Not inherited via [`derives`](Self::derives).
     pub timeouts: TimeoutConfig,
+}
+
+/// One provider header entry in `bitrouter.yaml`.
+///
+/// A scalar string is shorthand for a static default with passthrough
+/// disabled. The mapping form supports an optional `default` and an explicit
+/// inbound `passthrough` switch.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum ProviderHeaderConfig {
+    /// Static value; equivalent to `{ default: value, passthrough: false }`.
+    Static(String),
+    /// Expanded default/passthrough policy.
+    Policy(ProviderHeaderPolicy),
+}
+
+impl ProviderHeaderConfig {
+    fn default_value(&self) -> Option<&str> {
+        match self {
+            Self::Static(value) => Some(value),
+            Self::Policy(policy) => policy.default.as_deref(),
+        }
+    }
+
+    fn passthrough(&self) -> bool {
+        match self {
+            Self::Static(_) => false,
+            Self::Policy(policy) => policy.passthrough,
+        }
+    }
+}
+
+/// Expanded provider header behavior.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct ProviderHeaderPolicy {
+    /// Static value used when no allowed inbound value is present.
+    pub default: Option<String>,
+    /// Allow the inbound request's value(s) to override the static default.
+    pub passthrough: bool,
 }
 
 /// One credential within a multi-account provider. An account varies
@@ -1214,6 +1261,7 @@ impl std::fmt::Debug for ProviderConfig {
                     "<redacted>"
                 },
             )
+            .field("headers", &self.headers.keys().collect::<Vec<_>>())
             .field("api_protocol", &self.api_protocol)
             .field("protocol_endpoints", &self.protocol_endpoints)
             .field("rate_limits", &self.rate_limits)
@@ -1235,6 +1283,7 @@ impl Default for ProviderConfig {
         Self {
             api_base: String::new(),
             api_key: String::new(),
+            headers: BTreeMap::new(),
             api_protocol: PatternMap::new(),
             protocol_endpoints: HashMap::new(),
             rate_limits: PatternMap::new(),
@@ -1253,6 +1302,22 @@ impl Default for ProviderConfig {
 }
 
 impl ProviderConfig {
+    fn outbound_headers(&self) -> Result<Vec<OutboundHeaderRule>> {
+        let mut names = HashSet::new();
+        let mut rules = Vec::with_capacity(self.headers.len());
+        for (name, config) in &self.headers {
+            let rule = OutboundHeaderRule::new(name, config.default_value(), config.passthrough())?;
+            if !names.insert(rule.name().clone()) {
+                return Err(BitrouterError::bad_request(format!(
+                    "duplicate provider header '{}'",
+                    rule.name().as_str()
+                )));
+            }
+            rules.push(rule);
+        }
+        Ok(rules)
+    }
+
     /// Resolve either the registry's canonical model id or its provider-native
     /// dispatch id to the same metadata entry. Explicit `provider:model`
     /// routes commonly use the native id, but must retain the registry's
@@ -1679,6 +1744,9 @@ where
     // Validated post-`resolve_derivations` so an inherited `api_base` is
     // checked against the *effective* value.
     for (id, provider) in &config.providers {
+        provider.outbound_headers().map_err(|error| {
+            BitrouterError::bad_request(format!("provider '{id}' has invalid headers: {error}"))
+        })?;
         for model in &provider.models {
             if let Some(reasoning_effort) = &model.reasoning_effort {
                 if !model
@@ -1904,6 +1972,9 @@ fn resolve_one_derivation(
     // intrinsic to the child (you almost always want different endpoints).
     if child.api_protocol.is_empty() {
         child.api_protocol = parent.api_protocol.clone();
+    }
+    if child.headers.is_empty() {
+        child.headers = parent.headers.clone();
     }
     if child.protocol_endpoints.is_empty() {
         child.protocol_endpoints = parent.protocol_endpoints.clone();

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -193,7 +193,7 @@ fn build_targets(
     provider: &crate::config::ProviderConfig,
     model_id: &str,
     inbound: Option<&ApiProtocol>,
-) -> Vec<RoutingTarget> {
+) -> Result<Vec<RoutingTarget>> {
     // Protocol-native routing: prefer the inbound protocol when this upstream
     // supports it (a faithful same-protocol round-trip), else the provider's
     // configured default head.
@@ -226,12 +226,13 @@ fn build_targets(
     let reasoning_effort = provider
         .model_config(model_id)
         .and_then(|model| model.reasoning_effort.clone());
+    let headers = provider.outbound_headers()?;
 
     if provider.accounts.is_empty() {
         let api_base = protocol_base
             .map(str::to_string)
             .unwrap_or_else(|| provider.api_base.clone());
-        return vec![RoutingTarget {
+        return Ok(vec![RoutingTarget {
             provider_name: provider_id.to_string(),
             service_id: service_id.to_string(),
             api_base,
@@ -245,7 +246,8 @@ fn build_targets(
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
-        }];
+            headers,
+        }]);
     }
 
     let n = provider.accounts.len();
@@ -253,7 +255,7 @@ fn build_targets(
         crate::config::AccountStrategy::Failover => 0,
         crate::config::AccountStrategy::Balance => balance_offset(provider_id, n),
     };
-    (0..n)
+    Ok((0..n)
         .map(|i| {
             let idx = (i + offset) % n;
             let account = &provider.accounts[idx];
@@ -286,9 +288,10 @@ fn build_targets(
                 api_key_override: None,
                 api_base_override: None,
                 auth_scheme: Default::default(),
+                headers: headers.clone(),
             }
         })
-        .collect()
+        .collect())
 }
 
 /// Pick the wire protocol for a target: the inbound protocol when the upstream
@@ -396,7 +399,7 @@ fn resolve_virtual_model(
                 provider,
                 &endpoint.service_id,
                 prefs.inbound_protocol.as_ref(),
-            ),
+            )?,
         ));
     }
 
@@ -450,12 +453,12 @@ fn resolve_clean_route_chain(
         && let Some(provider) = config.providers.get(provider_id)
         && provider.active
     {
-        return Ok(build_targets(
+        return build_targets(
             provider_id,
             provider,
             model_id,
             prefs.inbound_protocol.as_ref(),
-        ));
+        );
     }
 
     // ---- Strategy 2: explicit virtual model ----
@@ -503,7 +506,7 @@ fn resolve_clean_route_chain(
                     provider,
                     clean,
                     prefs.inbound_protocol.as_ref(),
-                ),
+                )?,
             ));
         }
     }

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -4,6 +4,118 @@ use super::*;
 use crate::language_model::types::{ApiProtocol, ReasoningEffort};
 
 #[test]
+fn provider_headers_accept_static_and_passthrough_forms() -> crate::Result<()> {
+    let config = parse_with(
+        r#"
+inherit_defaults: false
+providers:
+  opencode-go:
+    api_base: https://opencode.ai/zen/go/v1
+    api_key: test
+    headers:
+      x-opencode-session:
+        default: claude-code
+        passthrough: true
+      user-agent: my-agent/1.0
+      x-rejected:
+        passthrough: false
+"#,
+        |_| None,
+    )?;
+
+    let chain = routing_table::resolve_route_chain(
+        &config,
+        "opencode-go:test-model",
+        &crate::language_model::RoutingPrefs::default(),
+    )?;
+    let target = chain
+        .first()
+        .ok_or_else(|| BitrouterError::internal("provider route was empty"))?;
+    let session = target
+        .headers
+        .iter()
+        .find(|rule| rule.name() == "x-opencode-session")
+        .ok_or_else(|| BitrouterError::internal("session header rule was not routed"))?;
+    assert!(session.passthrough());
+    assert_eq!(
+        session.default().and_then(|value| value.to_str().ok()),
+        Some("claude-code")
+    );
+    let user_agent = target
+        .headers
+        .iter()
+        .find(|rule| rule.name() == "user-agent")
+        .ok_or_else(|| BitrouterError::internal("user-agent rule was not routed"))?;
+    assert!(!user_agent.passthrough());
+    assert_eq!(
+        user_agent.default().and_then(|value| value.to_str().ok()),
+        Some("my-agent/1.0")
+    );
+    let rejected = target
+        .headers
+        .iter()
+        .find(|rule| rule.name() == "x-rejected")
+        .ok_or_else(|| BitrouterError::internal("reject rule was not routed"))?;
+    assert!(!rejected.passthrough());
+    assert!(rejected.default().is_none());
+    Ok(())
+}
+
+#[test]
+fn provider_headers_are_inherited_when_child_declares_none() -> crate::Result<()> {
+    let config = parse_with(
+        r#"
+inherit_defaults: false
+providers:
+  parent:
+    api_base: https://parent.example/v1
+    headers:
+      x-provider-version: v1
+  child:
+    derives: parent
+    api_base: https://child.example/v1
+"#,
+        |_| None,
+    )?;
+    assert_eq!(
+        config.providers["child"].headers,
+        config.providers["parent"].headers
+    );
+    Ok(())
+}
+
+#[test]
+fn provider_headers_reject_invalid_reserved_and_duplicate_names() {
+    for (headers, expected) in [
+        ("'bad header': value", "invalid provider header name"),
+        (
+            "x-test: \"line\\nbreak\"",
+            "invalid value for provider header 'x-test'",
+        ),
+        (
+            "authorization: value",
+            "provider header 'authorization' is reserved",
+        ),
+        (
+            "User-Agent: first\n      user-agent: second",
+            "duplicate provider header 'user-agent'",
+        ),
+        (
+            "x-test:\n        default: value\n        typo: true",
+            "did not match any variant",
+        ),
+    ] {
+        let yaml = format!(
+            "inherit_defaults: false\nproviders:\n  test:\n    api_base: https://api.example/v1\n    headers:\n      {headers}\n"
+        );
+        let error = parse_with(&yaml, |_| None)
+            .err()
+            .unwrap_or_else(|| BitrouterError::internal("invalid provider header was accepted"));
+        assert!(error.to_string().contains(expected), "got: {error}");
+    }
+}
+
+#[test]
 fn policy_table_accepts_scalar_and_model_effort_targets() -> crate::Result<()> {
     let config = parse_with(
         r#"

--- a/crates/bitrouter-sdk/src/language_model/auth.rs
+++ b/crates/bitrouter-sdk/src/language_model/auth.rs
@@ -549,6 +549,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -1880,10 +1880,10 @@ mod beta_forward_tests {
 
     fn ctx_with_beta(beta: Option<&str>) -> PipelineContext {
         let mut headers = http::HeaderMap::new();
-        if let Some(b) = beta {
-            if let Ok(value) = http::HeaderValue::from_str(b) {
-                headers.insert("anthropic-beta", value);
-            }
+        if let Some(b) = beta
+            && let Ok(value) = http::HeaderValue::from_str(b)
+        {
+            headers.insert("anthropic-beta", value);
         }
         ctx_with_headers(headers)
     }

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -921,6 +921,7 @@ impl HttpExecutor {
             .apply_auth(request, input.target, input.transport)
             .await?;
         let (mut request, mut credential_authority) = applied.into_parts();
+        apply_provider_headers(&mut request, input.target, input.ctx);
         merge_outbound_trace_headers(&mut request, input.trace_headers);
         inject_outbound_request_id(&mut request, input.ctx)?;
         credential_authority =
@@ -1142,6 +1143,41 @@ impl HttpExecutor {
             upstream_duration_ms: Some(elapsed),
             server_tool_calls: Vec::new(),
         })
+    }
+}
+
+/// Apply the selected provider's header rules after authentication. This lets
+/// explicit provider compatibility headers replace transport defaults while
+/// reserved authentication, framing, tracing, and request-id fields remain
+/// outside this mechanism. The rules themselves were validated when the route
+/// was built.
+///
+/// HTTP field semantics: <https://www.rfc-editor.org/rfc/rfc9110.html#section-5>
+fn apply_provider_headers(
+    request: &mut reqwest::Request,
+    target: &RoutingTarget,
+    ctx: &PipelineContext,
+) {
+    for rule in &target.headers {
+        let name = rule.name();
+        request.headers_mut().remove(name);
+        if rule.passthrough() {
+            let inbound = ctx
+                .headers()
+                .get_all(name)
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            if !inbound.is_empty() {
+                for value in inbound {
+                    request.headers_mut().append(name.clone(), value);
+                }
+                continue;
+            }
+        }
+        if let Some(value) = rule.default() {
+            request.headers_mut().insert(name.clone(), value.clone());
+        }
     }
 }
 
@@ -1813,14 +1849,10 @@ mod error_classification_tests {
 mod beta_forward_tests {
     use super::*;
     use crate::caller::CallerContext;
-    use crate::language_model::types::Prompt;
+    use crate::language_model::types::{OutboundHeaderRule, Prompt};
     use crate::language_model::{Message, PipelineRequest, Role};
 
-    fn ctx_with_beta(beta: Option<&str>) -> PipelineContext {
-        let mut headers = http::HeaderMap::new();
-        if let Some(b) = beta {
-            headers.insert("anthropic-beta", http::HeaderValue::from_str(b).unwrap());
-        }
+    fn ctx_with_headers(headers: http::HeaderMap) -> PipelineContext {
         let prompt = Prompt {
             model: "claude".into(),
             system: None,
@@ -1846,6 +1878,16 @@ mod beta_forward_tests {
         })
     }
 
+    fn ctx_with_beta(beta: Option<&str>) -> PipelineContext {
+        let mut headers = http::HeaderMap::new();
+        if let Some(b) = beta {
+            if let Ok(value) = http::HeaderValue::from_str(b) {
+                headers.insert("anthropic-beta", value);
+            }
+        }
+        ctx_with_headers(headers)
+    }
+
     fn target(proto: ApiProtocol) -> RoutingTarget {
         RoutingTarget {
             provider_name: "anthropic".into(),
@@ -1861,6 +1903,7 @@ mod beta_forward_tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 
@@ -1945,6 +1988,111 @@ mod beta_forward_tests {
             Some("t")
         );
     }
+
+    #[test]
+    fn provider_headers_apply_passthrough_default_and_rejection() -> crate::Result<()> {
+        let mut inbound = http::HeaderMap::new();
+        inbound.append(
+            "x-opencode-session",
+            http::HeaderValue::from_static("request-session-a"),
+        );
+        inbound.append(
+            "x-opencode-session",
+            http::HeaderValue::from_static("request-session-b"),
+        );
+        inbound.insert(
+            "user-agent",
+            http::HeaderValue::from_static("untrusted-agent"),
+        );
+        inbound.insert("x-rejected", http::HeaderValue::from_static("untrusted"));
+        let ctx = ctx_with_headers(inbound);
+        let mut target = target(ApiProtocol::ChatCompletions);
+        target.headers = vec![
+            OutboundHeaderRule::new("x-opencode-session", Some("static-session"), true)?,
+            OutboundHeaderRule::new("user-agent", Some("my-agent/1.0"), false)?,
+            OutboundHeaderRule::new("x-rejected", None::<&str>, false)?,
+            OutboundHeaderRule::new("x-static-only", Some("static"), true)?,
+        ];
+        let mut request = fresh_request();
+        request
+            .headers_mut()
+            .insert("x-rejected", http::HeaderValue::from_static("transport"));
+
+        apply_provider_headers(&mut request, &target, &ctx);
+
+        let sessions = request
+            .headers()
+            .get_all("x-opencode-session")
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .collect::<Vec<_>>();
+        assert_eq!(sessions, vec!["request-session-a", "request-session-b"]);
+        assert_eq!(request.headers()["user-agent"], "my-agent/1.0");
+        assert_eq!(request.headers()["x-static-only"], "static");
+        assert!(request.headers().get("x-rejected").is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn authenticated_request_applies_provider_headers() -> crate::Result<()> {
+        let mut inbound = http::HeaderMap::new();
+        inbound.insert(
+            "x-opencode-session",
+            http::HeaderValue::from_static("request-session"),
+        );
+        let ctx = ctx_with_headers(inbound);
+        let mut target = target(ApiProtocol::ChatCompletions);
+        target.api_key = "provider-secret".to_string();
+        target.headers = vec![OutboundHeaderRule::new(
+            "x-opencode-session",
+            Some("static-session"),
+            true,
+        )?];
+        let executor = HttpExecutor::with_defaults()?;
+        let (_, transport) = executor
+            .dispatch
+            .lookup(&target.api_protocol)
+            .ok_or_else(|| BitrouterError::internal("chat transport was not registered"))?;
+        let (client, timeouts) = executor.client_for(&target);
+        let body = serde_json::json!({"model": "claude-haiku"});
+        let request = executor
+            .build_authenticated_request(&RequestBuildInput {
+                client: &client,
+                timeouts: &timeouts,
+                url: "https://api.example/v1/chat/completions",
+                body: &body,
+                target: &target,
+                transport,
+                ctx: &ctx,
+                trace_headers: None,
+            })
+            .await?;
+
+        assert_eq!(
+            request.headers()[reqwest::header::AUTHORIZATION],
+            "Bearer provider-secret"
+        );
+        assert_eq!(request.headers()["x-opencode-session"], "request-session");
+        assert_eq!(request.headers()["x-bitrouter-request-id"], "t");
+        Ok(())
+    }
+
+    #[test]
+    fn provider_headers_cannot_take_over_auth_or_internal_fields() {
+        for name in [
+            "authorization",
+            "x-api-key",
+            "x-goog-api-key",
+            "content-length",
+            "traceparent",
+            "x-bitrouter-request-id",
+        ] {
+            let error = OutboundHeaderRule::new(name, Some("value"), true)
+                .err()
+                .unwrap_or_else(|| BitrouterError::internal("reserved provider header accepted"));
+            assert!(error.to_string().contains("is reserved"), "got: {error}");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1971,6 +2119,7 @@ mod provider_continuation_tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 
@@ -2225,6 +2374,7 @@ mod client_selection_tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 
@@ -2347,6 +2497,7 @@ mod client_selection_tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         };
         let prompt = Prompt {
             model: "m".into(),
@@ -2471,6 +2622,7 @@ mod openai_codex_stream_bridge_tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         };
         let prompt = Prompt {
             model: "gpt-5.6-terra".into(),

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -1414,6 +1414,7 @@ mod policy_effort_target_tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -1283,6 +1283,7 @@ fn target_token_limit_override_wins_over_inbound_spelling() {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         };
         let rendered = adapter.render_request_for_target(&prompt, &target).unwrap();
         assert_eq!(rendered[outbound_field], 99);
@@ -1316,6 +1317,7 @@ fn chat_target_omits_explicitly_unsupported_optional_fields() {
         api_key_override: None,
         api_base_override: None,
         auth_scheme: Default::default(),
+        headers: Vec::new(),
     };
 
     let rendered = chat.render_request_for_target(&prompt, &target).unwrap();
@@ -1347,6 +1349,7 @@ fn chat_target_does_not_silently_drop_store_true() {
         api_key_override: None,
         api_base_override: None,
         auth_scheme: Default::default(),
+        headers: Vec::new(),
     };
 
     let error = chat
@@ -1412,6 +1415,7 @@ fn chat_target_emits_one_token_alias_despite_cross_protocol_extra_pollution() {
                 api_key_override: None,
                 api_base_override: None,
                 auth_scheme: Default::default(),
+                headers: Vec::new(),
             };
             let rendered = adapter_for(ApiProtocol::ChatCompletions)
                 .render_request_for_target(&prompt, &target)
@@ -2408,6 +2412,7 @@ fn messages_no_beta_header_is_emitted() {
         api_key_override: None,
         api_base_override: None,
         auth_scheme: Default::default(),
+        headers: Vec::new(),
     };
     let req = futures::executor::block_on(transport.authorise(req, &target)).unwrap();
     assert!(
@@ -2439,6 +2444,7 @@ fn messages_auth_scheme_selects_one_credential_header() {
         api_key_override: None,
         api_base_override: None,
         auth_scheme: AuthScheme::XApiKey,
+        headers: Vec::new(),
     };
 
     // Default (x-api-key) scheme → `x-api-key` only.

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -32,6 +32,7 @@ fn target(provider: &str) -> RoutingTarget {
         api_key_override: None,
         api_base_override: None,
         auth_scheme: Default::default(),
+        headers: Vec::new(),
     }
 }
 
@@ -2818,6 +2819,7 @@ async fn executor_rejects_response_format_on_unsupported_outbound() {
         api_key_override: None,
         api_base_override: None,
         auth_scheme: Default::default(),
+        headers: Vec::new(),
     };
     let prompt = Prompt {
         model: "m".into(),
@@ -3197,6 +3199,7 @@ fn auth_retry_target(api_base: String) -> RoutingTarget {
         api_key_override: None,
         api_base_override: None,
         auth_scheme: Default::default(),
+        headers: Vec::new(),
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -2192,6 +2192,104 @@ pub enum AuthScheme {
     Bearer,
 }
 
+/// One provider-configured outbound HTTP header policy.
+///
+/// The routing layer resolves the provider's YAML entry into this validated
+/// wire representation. [`crate::language_model::HttpExecutor`] applies it to
+/// every request for the target: an explicitly allowed inbound value wins over
+/// [`Self::default`], while a rule without either suppresses that header.
+#[derive(Clone, PartialEq, Eq)]
+pub struct OutboundHeaderRule {
+    name: http::HeaderName,
+    default: Option<http::HeaderValue>,
+    passthrough: bool,
+}
+
+impl OutboundHeaderRule {
+    /// Validate and construct an outbound header rule.
+    pub fn new(
+        name: impl AsRef<str>,
+        default: Option<&str>,
+        passthrough: bool,
+    ) -> crate::Result<Self> {
+        let raw_name = name.as_ref();
+        let name = http::HeaderName::from_bytes(raw_name.as_bytes()).map_err(|error| {
+            crate::BitrouterError::bad_request(format!(
+                "invalid provider header name '{raw_name}': {error}"
+            ))
+        })?;
+        if is_reserved_provider_header(&name) {
+            return Err(crate::BitrouterError::bad_request(format!(
+                "provider header '{}' is reserved",
+                name.as_str()
+            )));
+        }
+        let default = default
+            .map(|value| {
+                http::HeaderValue::from_str(value).map_err(|error| {
+                    crate::BitrouterError::bad_request(format!(
+                        "invalid value for provider header '{}': {error}",
+                        name.as_str()
+                    ))
+                })
+            })
+            .transpose()?;
+        Ok(Self {
+            name,
+            default,
+            passthrough,
+        })
+    }
+
+    /// The canonical, case-insensitive HTTP field name.
+    pub fn name(&self) -> &http::HeaderName {
+        &self.name
+    }
+
+    /// The configured static fallback value, if any.
+    pub fn default(&self) -> Option<&http::HeaderValue> {
+        self.default.as_ref()
+    }
+
+    /// Whether the same inbound request header may override the default.
+    pub fn passthrough(&self) -> bool {
+        self.passthrough
+    }
+}
+
+impl std::fmt::Debug for OutboundHeaderRule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OutboundHeaderRule")
+            .field("name", &self.name)
+            .field("has_default", &self.default.is_some())
+            .field("passthrough", &self.passthrough)
+            .finish()
+    }
+}
+
+fn is_reserved_provider_header(name: &http::HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "authorization"
+            | "proxy-authorization"
+            | "x-api-key"
+            | "x-goog-api-key"
+            | "host"
+            | "content-length"
+            | "content-type"
+            | "transfer-encoding"
+            | "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "trailer"
+            | "te"
+            | "upgrade"
+            | "traceparent"
+            | "tracestate"
+            | "x-bitrouter-request-id"
+    )
+}
+
 /// One hop in a fallback chain: a concrete provider + model + connection info.
 ///
 /// The `Debug` impl redacts `api_key` and `api_key_override` (v0 audit S9):
@@ -2237,6 +2335,9 @@ pub struct RoutingTarget {
     /// transport (`x-api-key` vs `Authorization: Bearer`); others ignore it.
     /// Defaults to [`AuthScheme::XApiKey`].
     pub auth_scheme: AuthScheme,
+    /// Validated static/default and inbound-passthrough header policies for
+    /// every request to this provider.
+    pub headers: Vec<OutboundHeaderRule>,
 }
 
 impl std::fmt::Debug for RoutingTarget {
@@ -2261,6 +2362,7 @@ impl std::fmt::Debug for RoutingTarget {
             )
             .field("api_base_override", &self.api_base_override)
             .field("auth_scheme", &self.auth_scheme)
+            .field("headers", &self.headers)
             .finish()
     }
 }

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -1284,6 +1284,7 @@ mod tests {
                 api_key_override: None,
                 api_base_override: None,
                 auth_scheme: AuthScheme::XApiKey,
+                headers: Vec::new(),
             }],
         );
         let mut builder = PipelineBuilder::new();
@@ -1326,6 +1327,7 @@ mod tests {
                 api_key_override: None,
                 api_base_override: None,
                 auth_scheme: AuthScheme::XApiKey,
+                headers: Vec::new(),
             }],
         );
         let observed = Arc::new(std::sync::Mutex::new(None));

--- a/crates/bitrouter-telemetry/src/otel/exporter.rs
+++ b/crates/bitrouter-telemetry/src/otel/exporter.rs
@@ -1396,6 +1396,7 @@ mod hop_tests {
             api_key_override: None,
             api_base_override: None,
             auth_scheme: Default::default(),
+            headers: Vec::new(),
         }
     }
 

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -1191,11 +1191,18 @@
         },
         "derives": {
           "default": null,
-          "description": "Inherit defaults from another provider in this config (acceptance F20 /\nv0 `derives`). The named provider's `api_protocol`, `rate_limits`,\n`models`, `tags` and `auto_discover` flow into *this* provider's empty\nfields; explicit fields here win. Resolved by\n[`resolve_derivations`] after the config is parsed.",
+          "description": "Inherit defaults from another provider in this config (acceptance F20 /\nv0 `derives`). The named provider's `headers`, `api_protocol`,\n`rate_limits`, `models`, `tags` and `auto_discover` flow into *this*\nprovider's empty fields; explicit fields here win. Resolved by\n[`resolve_derivations`] after the config is parsed.",
           "type": [
             "string",
             "null"
           ]
+        },
+        "headers": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ProviderHeaderConfig"
+          },
+          "description": "Additional headers applied to every inference request for this\nprovider. A string is shorthand for a static default. The expanded\nform can opt into forwarding the same inbound header, which overrides\nthe default for that request.",
+          "type": "object"
         },
         "models": {
           "description": "Declared model entries. Empty + `auto_discover` triggers discovery.",
@@ -1236,6 +1243,39 @@
         "timeouts": {
           "$ref": "#/$defs/TimeoutConfig",
           "description": "Per-provider upstream timeout overrides. Each set field layers over the\nresolved global [`UpstreamConfig::timeouts`]; unset fields inherit it.\nNot inherited via [`derives`](Self::derives)."
+        }
+      },
+      "type": "object"
+    },
+    "ProviderHeaderConfig": {
+      "anyOf": [
+        {
+          "description": "Static value; equivalent to `{ default: value, passthrough: false }`.",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/ProviderHeaderPolicy",
+          "description": "Expanded default/passthrough policy."
+        }
+      ],
+      "description": "One provider header entry in `bitrouter.yaml`.\n\nA scalar string is shorthand for a static default with passthrough\ndisabled. The mapping form supports an optional `default` and an explicit\ninbound `passthrough` switch."
+    },
+    "ProviderHeaderPolicy": {
+      "additionalProperties": false,
+      "description": "Expanded provider header behavior.",
+      "properties": {
+        "default": {
+          "default": null,
+          "description": "Static value used when no allowed inbound value is present.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "passthrough": {
+          "default": false,
+          "description": "Allow the inbound request's value(s) to override the static default.",
+          "type": "boolean"
         }
       },
       "type": "object"


### PR DESCRIPTION
## Summary

- add provider-level header policies with static shorthand and expanded default/passthrough behavior
- validate header names and values, preserve multi-value passthrough, and protect runtime-managed headers
- carry policies through routing to every authenticated inference request
- add config and executor coverage and regenerate the config schema

## Test plan

- NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost cargo nextest run --all-features
- cargo clippy --all-features
- cargo fmt -- --check
- cargo run -p dist-helper -- check

Closes #909